### PR TITLE
Add Configuration Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Wpmreleasetoolkit
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,helper,actions/configure}/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
@@ -1,0 +1,94 @@
+require 'fastlane/action'
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+require 'json'
+
+require_relative '../../helper/filesystem_helper'
+require_relative '../../helper/configure_helper'
+
+module Fastlane
+  module Actions
+    class ConfigureAddFilesToCopyAction < Action
+      def self.run(params = {})
+
+        continue = true
+
+        while(continue)
+
+          confirmation = "Do you want to specify a file that should be copied from the secrets repository into your project?"
+
+          if Fastlane::Helper::ConfigureHelper.has_files
+            confirmation = "Do you want to specify additional files that should be copied from the secrets repository into your project?"
+          end
+
+          if UI.confirm(confirmation)
+            add_file
+          else
+            continue = false
+          end
+        end
+      end
+
+      ### Walks the user through adding a file to the project's `/.configure `file.
+      ###
+      def self.add_file
+
+        invalid_file = true
+
+        while invalid_file
+          UI.header "Please provide the location of the source file relative to the secrets repository"
+          UI.message "Example: google-services.json"
+
+          source = UI.input("Source File Path:")
+          sourcePath = absolute_secret_store_path(source) # Transform the relative path into an absolute path.
+
+          # Don't allow the developer to accidentally specify an invalid file, otherwise validation will never succeed.
+          if File.file?(sourcePath)
+            invalid_file = false
+          else
+            UI.error "There is no file at #{sourcePath}."
+          end
+        end
+
+        UI.header "Please provide the destination of the file relative to the project root"
+        UI.message "Example: WordPress/google-services.json"
+
+        destination = UI.input("Destination File Path:") # Leave the destination as a relative path, as no validation is required.
+
+        Fastlane::Helper::ConfigureHelper.add_file(source: source, destination: destination)
+      end
+
+      def self.secret_store_dir
+          Fastlane::Helper::FilesystemHelper.secret_store_dir
+      end
+
+      def self.absolute_secret_store_path(relative_path)
+          Fastlane::Helper::FilesystemHelper.absolute_secret_store_path(relative_path)
+      end
+
+      def self.description
+          "Interactively add files to the `files_to_copy` list in .configure."
+      end
+
+      def self.authors
+          ["Jeremy Massel"]
+      end
+
+      def self.return_value
+          # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+          "Interactively add files to the `files_to_copy` list in .configure."
+      end
+
+      def self.available_options
+          []
+      end
+
+      def self.is_supported?(platform)
+          true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -1,0 +1,97 @@
+require 'fastlane/action'
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+
+require_relative '../../helper/filesystem_helper'
+require_relative '../../helper/configure_helper'
+
+module Fastlane
+  module Actions
+    class ConfigureApplyAction < Action
+      def self.run(params = {})
+        files_to_copy.each { |x|
+
+            source = absolute_secret_store_path(x["file"])
+            destination = absolute_project_path(x["destination"])
+
+            if(params[:force])
+                copy(source, destination)
+            else
+                copy_with_confirmation(source, destination)
+            end
+        }
+
+        UI.success "Applied configuration"
+      end
+
+      ### Check with the user whether we should overwrite the file, if it exists
+      ###
+      def self.copy_with_confirmation(source, destination)
+
+        unless File.file?(destination)
+            self.copy(source, destination)
+            return  # Don't continue if we were able to copy the file without conflict
+        end
+
+        if UI.confirm("Are sure you want to overwrite #{destination}?")
+            self.copy(source, destination)
+        else
+            UI.message "Skipping #{destination}"
+        end
+      end
+
+      ### Copy the file at `source` to `destination`, overwriting it if it already exists
+      ###
+      def self.copy(source, destination)
+
+        pn = Pathname.new(destination)
+
+        FileUtils.mkdir_p(pn.dirname)   # Create the destination directory if it doesn't exist
+        FileUtils.cp(source, destination)
+      end
+
+      def self.repository_path
+        Fastlane::Helper::FilesystemHelper.secret_store_dir
+      end
+
+      def self.files_to_copy
+        Fastlane::Helper::ConfigureHelper.files_to_copy
+      end
+
+      def self.absolute_project_path(relative_path)
+        Fastlane::Helper::FilesystemHelper.absolute_project_path(relative_path)
+      end
+
+      def self.absolute_secret_store_path(relative_path)
+        Fastlane::Helper::FilesystemHelper.absolute_secret_store_path(relative_path)
+      end
+
+      def self.description
+        "Copy files specified in `.config` from the secrets repository to the project. Specify force:true to avoid confirmation"
+      end
+
+      def self.authors
+        ["Jeremy Massel"]
+      end
+
+      def self.details
+        "Copy files specified in `.config` from the secrets repository to the project. Specify force:true to avoid confirmation"
+      end
+
+      def self.available_options
+        [
+            FastlaneCore::ConfigItem.new(key: :force,
+                             env_name: "FORCE_OVERWRITE",
+                             description: "Overwrite copied files without confirmation",
+                             optional: true,
+                             default_value: false,
+                             is_string: false),
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -1,0 +1,94 @@
+require 'fastlane/action'
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+
+module Fastlane
+  module Actions
+    class ConfigureDownloadAction < Action
+      def self.run(params = {})
+
+        UI.message "Running Configure Download"
+
+        # If the `~/.mobile-secrets` repository doesn't exist
+        unless File.directory?("#{Dir.home}/.mobile-secrets")
+
+          choice = UI.select("No local secret store exists. Please choose an option: ", [
+              "Install the sample data (default)",
+              "Install from a git repository"
+          ])
+
+          # If they enter anything other than "2", just do the default action
+          case choice
+              when "2" then install_from_git_repository 
+              else install_sample_data
+          end
+        else
+          update_repository # If the repo already exists, just update it
+        end
+      end
+
+      # Install the sample repository
+      def self.install_sample_data
+
+        UI.message "Installing from sample data"
+
+        clone_repository("https://github.com/jkmassel/mobile-secrets-repository")
+
+        UI.success "Sample Data Setup Complete"
+      end
+
+      # Attempt to install a user-provided git repository
+      def self.install_from_git_repository
+
+        UI.message "Installing from a git repository"
+
+        ### Prompt the user for the git repo URL
+        repo_url = UI.input("Git Repository URL:  ")
+
+        clone_repository(repo_url)
+
+        UI.success "Downloaded Data from Git Repository"
+      end
+     
+      # Clone the git repository to `~/.mobile-secrets`
+      def self.clone_repository(url)
+
+        if sh("git clone #{url} ~/.mobile-secrets")
+            UI.success "Succesfully downloaded git repository"
+        else
+            UI.error "Unable to download git repository"
+        end
+      end
+      
+      # Ensure the git repository at `~/.mobile-secrets` is up to date
+      def self.update_repository
+        sh("cd ~/.mobile-secrets && git pull")
+      end
+
+      def self.description
+        "Interactively download and set up the mobile secrets respository."
+      end
+
+      def self.authors
+        ["Jeremy Massel"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        "Walks the developer through setting up a `.configure` file in their project on first run.\
+        On subsequent runs, updates the repository to the latest version."
+      end
+
+      def self.available_options
+        []
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -11,52 +11,9 @@ module Fastlane
 
         # If the `~/.mobile-secrets` repository doesn't exist
         unless File.directory?("#{Dir.home}/.mobile-secrets")
-
-          choice = UI.select("No local secret store exists. Please choose an option: ", [
-              "Install the sample data (default)",
-              "Install from a git repository"
-          ])
-
-          # If they enter anything other than "2", just do the default action
-          case choice
-              when "2" then install_from_git_repository 
-              else install_sample_data
-          end
+            UI.user_error!("The local secrets store does not exist. Please clone it to ~/.mobile-secrets before continuing.")
         else
           update_repository # If the repo already exists, just update it
-        end
-      end
-
-      # Install the sample repository
-      def self.install_sample_data
-
-        UI.message "Installing from sample data"
-
-        clone_repository("https://github.com/jkmassel/mobile-secrets-repository")
-
-        UI.success "Sample Data Setup Complete"
-      end
-
-      # Attempt to install a user-provided git repository
-      def self.install_from_git_repository
-
-        UI.message "Installing from a git repository"
-
-        ### Prompt the user for the git repo URL
-        repo_url = UI.input("Git Repository URL:  ")
-
-        clone_repository(repo_url)
-
-        UI.success "Downloaded Data from Git Repository"
-      end
-     
-      # Clone the git repository to `~/.mobile-secrets`
-      def self.clone_repository(url)
-
-        if sh("git clone #{url} ~/.mobile-secrets")
-            UI.success "Succesfully downloaded git repository"
-        else
-            UI.error "Unable to download git repository"
         end
       end
       
@@ -66,7 +23,7 @@ module Fastlane
       end
 
       def self.description
-        "Interactively download and set up the mobile secrets respository."
+        "Updates the mobile secrets."
       end
 
       def self.authors
@@ -78,8 +35,7 @@ module Fastlane
       end
 
       def self.details
-        "Walks the developer through setting up a `.configure` file in their project on first run.\
-        On subsequent runs, updates the repository to the latest version."
+        "Pulls down the latest remote changes to the ~/.mobile-secrets repository."
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
@@ -1,0 +1,71 @@
+require 'fastlane/action'
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+require 'git'
+
+require_relative '../../helper/filesystem_helper'
+require_relative '../../helper/configure_helper'
+
+module Fastlane
+  module Actions
+    class ConfigureSetupAction < Action
+
+      def self.run(params = {})
+
+        # Check to see if the local secret storage is set up at ~/.mobile-secrets.
+        unless File.directory?(repository_path)
+          ConfigureDownloadAction::run # If not, set up the repository
+        end
+
+        # Checks to see if .configure exists. If so, exit – there’s no need to continue as everything is set up.
+        if configuration_file_exists
+          UI.success "Configure file exists – exiting."
+          return
+        end
+
+        # Write out the `.configure` file.
+        Fastlane::Helper::ConfigureHelper.update_configure_file_from_repository
+
+        # Walk the user through adding files to copy to the `.configure` file.
+        ConfigureAddFilesToCopyAction::run
+
+        # Copy the files we just walked the user through setting up.
+        ConfigureApplyAction::run
+
+        UI.success "Created .configure file"
+      end
+
+      def self.configuration_file_exists
+        Fastlane::Helper::ConfigureHelper.configuration_path_exists
+      end
+
+      def self.repository_path
+        Fastlane::Helper::FilesystemHelper.secret_store_dir
+      end
+
+      def self.description
+        "Interactively walks the user through setting up the mobile secrets repository and `.configure` file."
+      end
+
+      def self.authors
+        ["Jeremy Massel"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        "Interactively walks the user through setting up the mobile secrets repository and `.configure` file."
+      end
+
+      def self.available_options
+        []
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
@@ -14,7 +14,7 @@ module Fastlane
 
         # Check to see if the local secret storage is set up at ~/.mobile-secrets.
         unless File.directory?(repository_path)
-          ConfigureDownloadAction::run # If not, set up the repository
+            UI.user_error!("The local secrets store does not exist. Please clone it to ~/.mobile-secrets before continuing.")
         end
 
         # Checks to see if .configure exists. If so, exit – there’s no need to continue as everything is set up.
@@ -44,7 +44,7 @@ module Fastlane
       end
 
       def self.description
-        "Interactively walks the user through setting up the mobile secrets repository and `.configure` file."
+        "Set up the .configure file"
       end
 
       def self.authors
@@ -56,7 +56,7 @@ module Fastlane
       end
 
       def self.details
-        "Interactively walks the user through setting up the mobile secrets repository and `.configure` file."
+            "Interactively walks the user through setting up the `.configure` file. Assumes the ~/.mobile-secrets directory exists"
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -1,0 +1,119 @@
+require 'fastlane/action'
+require 'fastlane_core/ui/ui'
+
+require_relative '../../helper/filesystem_helper'
+require_relative '../../helper/configure_helper'
+
+module Fastlane
+  module Actions
+    class ConfigureUpdateAction < Action
+
+      def self.run(params = {})
+      
+        prompt_to_switch_branches
+
+        if repo_is_ahead_of_remote
+          UI.user_error!("The local secrets store has changes that the remote repository doesn't.\
+            Please fix this issue before continuing")
+        end
+
+        if repo_is_behind_remote
+          prompt_to_update_to_most_recent_version
+        end
+
+        if configure_file_is_behind_repo
+          prompt_to_update_configure_file_to_most_recent_hash
+        end
+
+        UI.success "Configuration Secrets are up to date – don't forget to commit your changes to `.configure`."
+      end
+
+      def self.prompt_to_switch_branches
+
+        if UI.confirm("The current branch is `#{current_branch}`. Would you like to switch branches?")
+          new_branch = UI.select("Select the branch you'd like to switch to: ", get_branches)
+          checkout_branch(new_branch)
+          update_configure_file
+        end
+      end
+
+      def self.prompt_to_update_to_most_recent_version
+        if UI.confirm("The current branch is #{repo_commits_behind_remote} commit(s) behind. Would you like to update it?")
+          update_branch
+          update_configure_file
+        end
+      end
+
+      def self.prompt_to_update_configure_file_to_most_recent_hash
+        if UI.confirm("The `.configure` file is #{configure_file_commits_behind_repo} commit hash(es) behind the repo. Would you like to update it?")
+          update_configure_file
+        end
+      end
+
+      def self.current_branch
+        Fastlane::Helper::ConfigureHelper.repo_branch_name
+      end
+
+      def self.update_configure_file
+        Fastlane::Helper::ConfigureHelper.update_configure_file_from_repository
+      end
+
+      def self.repo_is_ahead_of_remote
+        Fastlane::Helper::ConfigureHelper.repo_is_ahead_of_remote
+      end
+
+      def self.repo_commits_behind_remote
+        Fastlane::Helper::ConfigureHelper.repo_commits_behind_remote
+      end
+
+      def self.repo_is_behind_remote
+        Fastlane::Helper::ConfigureHelper.repo_is_behind_remote
+      end
+
+      def self.configure_file_is_behind_repo
+        Fastlane::Helper::ConfigureHelper.configure_file_is_behind_local
+      end
+
+      def self.configure_file_commits_behind_repo
+        Fastlane::Helper::ConfigureHelper.configure_file_commits_behind_repo
+      end
+
+      def self.get_branches
+        branches = sh("cd #{absolute_secret_store_path} && git branch -r")
+        branches.split("\n")
+          .map { |s| s.strip!.split("/")[1] }
+          .reject { |s| s.include? "HEAD" }
+      end
+
+      ### Switch to the given branch, but don't ensure that it's up-to-date – that's for another step
+      def self.checkout_branch(branch_name)
+        sh("cd '#{absolute_secret_store_path}' && git checkout '#{branch_name}'")
+      end
+
+      ### Ensure that the local secrets respository is up to date
+      def self.update_branch
+        sh("cd '#{absolute_secret_store_path}' && git pull")
+      end
+
+      def self.absolute_secret_store_path
+        Fastlane::Helper::FilesystemHelper.secret_store_dir
+      end
+
+      def self.description
+        "Ensure that the local secrets repository is up to date."
+      end
+
+      def self.authors
+        ["Jeremy Massel"]
+      end
+
+      def self.details
+        "Ensure that the local secrets repository is up to date, and lets you test alternative branches."
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -1,0 +1,109 @@
+require 'fastlane/action'
+require 'fastlane_core/ui/ui'
+
+require_relative '../../helper/filesystem_helper'
+require_relative '../../helper/configure_helper'
+
+module Fastlane
+  module Actions
+    class ConfigureValidateAction < Action
+
+      def self.run(params = {})
+        # Update the repository to get the latest version of the configuration secrets – that's
+        # how we'll know if we're behind in subsequent validations
+        ConfigureDownloadAction::run
+
+        validate_that_branches_match
+
+        validate_that_hashes_match
+
+        validate_that_secrets_repo_is_clean
+
+        validate_that_all_copied_files_match
+
+        UI.success "Configuration is valid"
+      end
+
+      ###
+      #         VALIDATION RULES
+      ###
+
+      ### Validate that the branch specified in .configure matches the branch
+      ### checked out in ~/.mobile-secrets.
+      def self.validate_that_branches_match
+
+        repo_branch_name = Fastlane::Helper::ConfigureHelper.repo_branch_name
+        file_branch_name = Fastlane::Helper::ConfigureHelper.configure_file_branch_name
+
+        unless repo_branch_name == file_branch_name
+
+          UI.user_error!([
+            "The branch specified in `.configure` is not the currently checked out branch in the secrets repository.",
+            "To fix this issue, switch back to the `#{file_branch_name}` branch in the mobile secrets repository.",
+          ].join("\n"))
+        end
+      end
+
+      ### Validate that the commit hash in the .configure file matches the
+      ### latest commit hash in ~/.mobile-secrets.
+      def self.validate_that_hashes_match
+        repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
+        file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
+
+        unless repo_hash == file_hash
+            UI.user_error!("The `.configure` file is out of date. Please update it before continuing.")
+        end
+      end
+
+      ### Validate that the secrets repo doesn't have any local changes
+      def self.validate_that_secrets_repo_is_clean
+        unless Fastlane::Helper::ConfigureHelper.repo_has_changes
+            UI.user_error!("The secrets repository has uncommitted changes. Please commit or discard them before continuing.")
+        end
+      end
+
+      def self.validate_that_all_copied_files_match
+        Fastlane::Helper::ConfigureHelper.files_to_copy.each{ |x|
+
+            source = absolute_secret_store_path(x["file"])
+            destination = absolute_project_path(x["destination"])
+
+            sourceHash = file_hash(source)
+            destinationHash = file_hash(destination)
+
+            unless sourceHash == destinationHash
+                UI.user_error!("`#{x["destination"]} doesn't match the file in the secrets repository (#{x["file"]}) – unable to continue")
+            end
+        }
+      end
+
+      def self.absolute_project_path(relative_path)
+        Fastlane::Helper::FilesystemHelper.absolute_project_path(relative_path)
+      end
+
+      def self.absolute_secret_store_path(relative_path)
+        Fastlane::Helper::FilesystemHelper.absolute_secret_store_path(relative_path)
+      end
+
+      def self.file_hash(absolute_path)
+        Fastlane::Helper::FilesystemHelper.file_hash(absolute_path)
+      end
+
+      def self.description
+        "Ensure that the configuration is valid"
+      end
+
+      def self.authors
+        ["Jeremy Massel"]
+      end
+
+      def self.details
+        "Ensure that the configuration is valid"
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -1,0 +1,220 @@
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+require 'json'
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
+
+  module Helper
+    class ConfigureHelper
+
+      ### Returns the contents of the project's `.configure` file.
+      ### If the file doesn't exist, it'll return an empty sample hash
+      ### that can later be saved to `.configure`.
+      def self.configuration
+
+        if self.configuration_path_exists
+          file = File.read(FilesystemHelper::configure_file)
+          return data_hash = JSON.parse(file)
+        else
+          configuration = Hash.new
+          configuration["branch"] = ""
+          configuration["pinned_hash"] = ""
+          configuration["files_to_copy"] = []
+          return configuration
+        end
+      end
+
+      ### Returns whether or not the `.configure` file exists in the project.
+      def self.configuration_path_exists
+        File.file?(FilesystemHelper::configure_file)
+      end
+
+      ### A global helper to save the current configure hash to `.configure`.
+      def self.update_configuration(hash)
+
+        if hash["files_to_copy"] == nil
+            hash["files_to_copy"] = []
+        end
+
+        File.open(FilesystemHelper::configure_file, 'w') { |file|
+            file.write(JSON.pretty_generate(hash))
+        }
+      end
+
+      ###
+      #       CONFIGURE FILE METHODS
+      ###
+
+      ### Reads current branch name and commit hash `~/.mobile-secrets` and writes them
+      ### to the project's `.configure` file.
+      def self.update_configure_file_from_repository
+        update_configure_file_branch_name(repo_branch_name)
+        update_configure_file_commit_hash(repo_commit_hash)
+      end
+
+      ### Returns the `branch` field of the project's `.configure` file.
+      def self.configure_file_branch_name
+        configuration["branch"]
+      end
+
+      ### Writes the provided new branch name to the `branch` field of the project's `.configure` file.
+      def self.update_configure_file_branch_name(new_branch_name)
+        new_configuration = configuration
+        new_configuration["branch"] = new_branch_name
+        update_configuration(new_configuration)
+      end
+
+      ### Returns the `pinned_hash` field of the project's `.configure` file.
+      def self.configure_file_commit_hash
+        configuration["pinned_hash"].to_s
+      end
+
+      ### Writes the provided new commit hash to the `pinned_hash` field of the project's `.configure` file.
+      def self.update_configure_file_commit_hash(new_hash)
+        new_configuration = configuration
+        new_configuration["pinned_hash"] = new_hash
+        update_configuration(new_configuration)
+      end
+
+      ###
+      #       SECRETS REPO METHODS
+      ###
+
+      ### Returns the currently checked out branch for the `~/.mobile-secrets` repository.
+      def self.repo_branch_name
+        result = `cd #{repository_path} && git branch`
+
+        result.each_line
+            .select { |s| s.strip.start_with?('*') }
+            .map{ |s| s.sub('*', '').strip }
+            .first
+      end
+
+      ### Returns the most recent commit hash in the `~/.mobile-secrets` repository.
+      def self.repo_commit_hash
+        hash = `cd #{repository_path} && git rev-parse --verify HEAD`
+        hash.strip
+      end
+
+      ### Returns an absolute path to the `~/.mobile-secrets` repository.
+      def self.repository_path
+        FilesystemHelper.secret_store_dir
+      end
+
+      ### Returns whether the ~/.mobile-secrets` repository is clean or dirty.
+      def self.repo_has_changes
+        result = `cd #{repository_path} && git status --porcelain`
+        result.empty?
+      end
+
+      ### Returns whether or not the `.configure` file has a pinned hash that's older than the most recent
+      ### ~/.mobile-secrets` commit hash.
+      def self.configure_file_is_behind_local
+      	configure_file_commits_behind_repo > 0
+      end
+
+      def self.configure_file_commits_behind_repo
+     	# Get a sily number of revisions to ensure we don't miss any
+      	result = `cd #{repository_path} && git --no-pager log -10000 --pretty=format:"%H" && echo`
+      	hashes = result.each_line.map{ |s| s.strip }.reverse
+
+      	index_of_configure_hash = hashes.find_index(configure_file_commit_hash)
+      	index_of_repo_commit_hash = hashes.find_index(repo_commit_hash)
+
+      	if index_of_configure_hash >= index_of_repo_commit_hash
+      		return 0
+      	end
+
+      	index_of_repo_commit_hash - index_of_configure_hash
+      end
+
+      ### Determine whether ~/.mobile-secrets` repository is behind its remote counterpart.
+      ### (ie – the remote repo has changes that the local repo doesn't)
+      def self.repo_is_behind_remote
+        repo_commits_behind_remote > 0
+      end
+
+      ### Determine how far behind the remote repo the ~/.mobile-secrets` repository is.
+      def self.repo_commits_behind_remote
+        matches = repo_status.match(/behind \d+/)
+
+        if matches == nil
+            return 0
+        end
+
+        parse_distance(matches[0])
+      end
+
+      ### Determine whether ~/.mobile-secrets` repository is ahead of its remote counterpart.
+      ### (ie – the local repo has changes that the remote repo doesn't)
+      def self.repo_is_ahead_of_remote
+        repo_commits_ahead_of_remote > 0
+      end
+
+      ### Determine how far ahead of the remote repo the ~/.mobile-secrets` repository is.
+      def self.repo_commits_ahead_of_remote
+        matches = repo_status.match(/ahead \d+/)
+
+        if matches == nil
+            return 0
+        end
+
+        parse_distance(matches[0])
+      end
+
+      ### A helper function to extract the distance from the provided string.
+      ### (ie – this function will recieve "behind 2" or "ahead 6" and return 2 or 6, respectively.
+      def self.parse_distance(match)
+        distance = match.to_s.scan(/\d+/).first
+
+        if distance == nil
+            return 0
+        end
+
+        distance.to_i
+      end
+
+      ### A helper function to determine how far apart the local and remote repos are.
+      def self.repo_status
+        `cd #{repository_path} && git fetch && git status --porcelain -b`
+      end
+
+      ###
+      #       FILES
+      ###
+
+      ### Returns whether or not the `files_to_copy` hash in `.configure` is empty.
+      def self.has_files
+        !files_to_copy.empty?
+      end
+
+      ### Returns the list of files to copy from `.configure`.
+      def self.files_to_copy
+        self.configuration["files_to_copy"]
+      end
+
+      # Adds a file to the `.configure` file's `files_to_copy` hash.
+      # The hash for this method must contain the `source` and `destination` keys
+      def self.add_file(params)
+
+        unless(params[:source])
+            UI.user_error!("You must pass a `source` to `add_file`")
+        end
+
+        unless(params[:destination])
+            UI.user_error!("You must pass a `destination` to `add_file`")
+        end
+
+        new_file = {
+            file: params[:source],
+            destination: params[:destination],
+        }
+
+        data_hash = self.configuration
+        data_hash["files_to_copy"].push(new_file)
+        update_configuration(data_hash)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -1,0 +1,67 @@
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+require 'digest'
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
+
+  module Helper
+    class FilesystemHelper
+
+        ### Traverse the file system to find the root project directory.
+        ### For the purposes of this function, we're assuming the root project
+        ### directory is the one with the `.git` file in it. 
+        def self.project_path
+
+            continue = true
+            dir = Pathname.new(Dir.pwd)
+
+            while continue
+                child_filenames = dir.children.map!{ |x| File.basename(x) }
+
+                if child_filenames.include? ".git"
+                    continue = false
+                else
+                    dir = dir.parent
+                end
+
+                if dir.root?
+                    UI.user_error!("Unable to determine the project root directory – #{Dir.pwd} doesn't appear to reside within a git repository.")
+                end
+            end
+
+            dir
+        end
+
+        ### Returns the path to the project's `.configure` file.
+        def self.configure_file
+            Pathname.new(project_path) + ".configure"
+        end
+
+        ### Returns the path to the `~/.mobile-secrets` directory.
+        def self.secret_store_dir
+            return "#{Dir.home}/.mobile-secrets"
+        end
+
+        ### Transforms a relative path within the secret store to an absolute path on disk.
+        def self.absolute_secret_store_path(relative_path)
+            File.join(secret_store_dir, relative_path)
+        end
+
+        ### Transforms a relative path within the project to an absolute path on disk.
+        def self.absolute_project_path(relative_path)
+            File.join(project_path, relative_path)
+        end
+
+        ### Returns the `sha1` hash of a file, given the absolute path.
+        def self.file_hash(absolute_path)
+
+            unless File.file?(absolute_path)
+                UI.user_error!("Unable to hash #{absolute_path} – the file does not exist")
+            end
+
+            Digest::SHA1.file absolute_path
+        end
+    end
+  end
+end


### PR DESCRIPTION
Adds a set of fastlane actions to allow dealing with configuration secrets.

**To Test:**

#### fastlane run configure_setup
1. Add the Release Toolkit to a project's `Pluginfile`, then update your dependencies.
2. Run `bundle exec fastlane run configure_setup` (works from anywhere in the project that calling `fastlane` works). You'll be prompted to either install the sample data, or install from another git repository you have access to. For testing purposes, it's probably easiest to use the sample data.
3. Next, you'll be prompted to add any files you wish to be copied from the secrets repository to your project. Type `y` for yes, then feel free to just us the examples provided. For the source, you have to enter a valid file path, but for the destination, you can use any path, so enter a path that won't overwrite an existing file, just to be safe.
4. You'll keep being asked if you want to add files until you say `n`, so do that now. 
5. The tool will now apply the configuration to the project. If any files will be overwritten, you'll be prompted whether to not to continue.

#### fastlane run configure_validate /  fastlane run configure_update

Run `bundle exec fastlane run configure_validate` anywhere in the project directory that calling `fastlane` works. The configuration should be valid, as the setup tool will not allow you to create an invalid configuration. To test invalid configurations, try the following:

1. The sample data repository contains two additional branches – track either of the non-`master` branches, and switch to it. You should receive an error that the current branch doesn't match the one specified in `.configure`. This prevents us from accidentally building with invalid credentials.

To fix this issue, run `bundle exec fastlane run configure_update`, and when it asks if you want to switch branches, say yes and choose the `master` branch, then try validating again.

2. Change the commit hash in `.configure` to an old commit hash. You should receive an error that the `.configure` file is out of date. This prevents us from missing updates to the secrets repository. 

To fix this issue, run `bundle exec fastlane run configure_update`, and when it asks if you want to switch branches, say no, but when it asks if you want to update the `.configure` file to the latest commit hash, say yes, then try validating again.

3. Make a change in `~/.mobile-secrets` (as a for-instance, you could duplicate a file or folder). You should receive an error saying that the secrets repository has uncommitted changes.

To fix this issue, it's easiest to just delete the file or folder you just made, but if you were to commit your changes, you'd receive the error from step 2, saying that your `.configure` file is out of date.

4. Change a value in one of the files copied from the secrets repo (the change must be done within the project – if you do it within the secrets repo, you'll get the error from step 3). You should receive an error saying that the file doesn't match the file in the secrets repository.  If you were to delete the file entirely, there would be a separate error saying that the file does not exist.

To fix this issue, just undo your change, and the project should validate.

#### fastlane run configure_add_files_to_copy

Running this action will interactively walk you through adding a source / destination pair to the `.configure` file – it's actually invoked as part of the setup action, but can be run separately.

#### fastlane run configure_download

Running this action will update the local secrets repo with changes from the remote.

#### fastlane run configure_apply

Running this action will copy any files that are specified in `.configure` from the repo to the project. By default, this action will ask for confirmation before overwriting any existing files. Running `fastlane run configure_apply force:true` will not ask for confirmation.

Let me know if you have any questions or concerns, and thanks for reading this far!

