### PR TITLE
Reorder configuration checks

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -9,6 +9,10 @@ module Fastlane
     class ConfigureValidateAction < Action
 
       def self.run(params = {})
+
+        # Start by ensuring that we've set up the project for configuration
+        validate_that_configure_file_exists
+
         # Update the repository to get the latest version of the configuration secrets – that's
         # how we'll know if we're behind in subsequent validations
         ConfigureDownloadAction::run
@@ -75,6 +79,12 @@ module Fastlane
                 UI.user_error!("`#{x["destination"]} doesn't match the file in the secrets repository (#{x["file"]}) – unable to continue")
             end
         }
+      end
+
+      def self.validate_that_configure_file_exists
+        unless Fastlane::Helper::ConfigureHelper.configuration_path_exists
+            UI.user_error!("Couldn't find `.configure` file. Please set up this project for `configure` by running `bundle exec fastlane run configure_setup`")
+        end
       end
 
       def self.absolute_project_path(relative_path)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -13,6 +13,10 @@ module Fastlane
         # Start by ensuring that we've set up the project for configuration
         validate_that_configure_file_exists
 
+        # Check that the secrets repo is locally clean _before_ downloading the latest version,
+        # otherwise, the error messaging isn't as helpful.
+        validate_that_secrets_repo_is_clean
+
         # Update the repository to get the latest version of the configuration secrets – that's
         # how we'll know if we're behind in subsequent validations
         ConfigureDownloadAction::run
@@ -20,8 +24,6 @@ module Fastlane
         validate_that_branches_match
 
         validate_that_hashes_match
-
-        validate_that_secrets_repo_is_clean
 
         validate_that_all_copied_files_match
 


### PR DESCRIPTION
Better handle local configuration changes

If someone changes the config locally (by modifying an existing file), the error messaging may not be helpful. This changes improves that.

The old test case only handled new files or folders – this now handles both types of change better.

Depends on #7 