### PR TITLE
Add per-file validation

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -26,6 +26,9 @@ module Fastlane
         end
 
         UI.success "Configuration Secrets are up to date – don't forget to commit your changes to `.configure`."
+
+        # Apply the changes that are now in the .configure file
+        ConfigureApplyAction::run
       end
 
       def self.prompt_to_switch_branches

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -58,11 +58,16 @@ module Fastlane
 
         changed_files = Fastlane::Helper::ConfigureHelper.files_changed_between(file_hash, repo_hash)
         dependencies = Fastlane::Helper::ConfigureHelper.file_dependencies
+        new_files = Fastlane::Helper::ConfigureHelper.new_files_in(changed_files)
 
         changed_dependencies = changed_files & dependencies #calculate array intersection
 
         unless changed_dependencies.empty?
             UI.user_error!("The following files are out of date. Please run `bundle exec fastlane run configure_update` before continuing:\n\n#{changed_dependencies.to_s}")
+        end
+
+        unless new_files.empty?
+            UI.user_error!("The following files are in the secrets repository, but aren't available for your project. Please run `bundle exec fastlane run configure_update` before continuing:\n\n#{new_files}")
         end
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -21,6 +21,8 @@ module Fastlane
           configuration["branch"] = ""
           configuration["pinned_hash"] = ""
           configuration["files_to_copy"] = []
+          configuration["file_dependencies"] = []
+
           return configuration
         end
       end
@@ -35,6 +37,10 @@ module Fastlane
 
         if hash["files_to_copy"] == nil
             hash["files_to_copy"] = []
+        end
+
+        if hash["file_dependencies"] == nil
+            hash["file_dependencies"] = []
         end
 
         File.open(FilesystemHelper::configure_file, 'w') { |file|
@@ -129,6 +135,12 @@ module Fastlane
       	index_of_repo_commit_hash - index_of_configure_hash
       end
 
+      ### Get a list of files changed in the secrets repo between to commits
+      def self.files_changed_between(commit_hash_1, commit_hash_2)
+        result = `cd #{repository_path} && git diff --name-only #{commit_hash_1}...#{commit_hash_2}`
+        result.each_line.map{ |s| s.strip }
+      end
+
       ### Determine whether ~/.mobile-secrets` repository is behind its remote counterpart.
       ### (ie – the remote repo has changes that the local repo doesn't)
       def self.repo_is_behind_remote
@@ -192,6 +204,14 @@ module Fastlane
       ### Returns the list of files to copy from `.configure`.
       def self.files_to_copy
         self.configuration["files_to_copy"]
+      end
+
+      ### Returns the list of files that this project uses from `.configure`.
+      def self.file_dependencies
+        file_dependencies = self.configuration["file_dependencies"]
+        file_dependencies ||= []
+
+        self.files_to_copy.map { |o| o["file"] } + file_dependencies
       end
 
       # Adds a file to the `.configure` file's `files_to_copy` hash.


### PR DESCRIPTION
This PR adds support for validating individual files, rather than the whole repo. It's backwards-compatible with older `.configure` files, too – so this shouldn't really break anything.

**How to test:**

On an Android project, update the `.configure` file, setting the `pinned_hash` to a commit hash from the secrets repo – pick one from way back, so that there will have been changes that affect the files in the project. If you run `bundle exec fastlane run configure_validate`, you'll get an error listing which files have changed, and prompting you on how to fix the issue. Following the instructions will resolve the problem for you.

Next, pick a commit hash that isn't the most recent, but that's new enough that there are no new changes to files used by this project. The validation will pass.

~iOS `.configure` files will need a manual update to add the `file_dependencies` array, which will be used to keep track of which files are used for those repositories. I'll add those to the projects in order to enable testing them, and will reference the PRs for those changes below. Once these are merged, I'll update this PR with direction on how to test iOS 🙂~

Now that the `.configure` files have been updated, you can test these in the same way you did Android – that'll show you how it responds to changes to already-existing files. To test how files that exist in the repo, but don't yet exist in the project work, I'd suggest testing with WPiOS and pinning a commit prior to the recent screenshot credentials change.