### PR TITLE
Fix/en us locale issue

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/gp_downloadmetadata_action.rb
@@ -18,7 +18,7 @@ module Fastlane
         downloader = Fastlane::Helper::MetadataDownloader.new(params[:download_path], params[:target_files])
 
         params[:locales].each do | loc |
-          puts "Downloading language: #{loc[0]}"
+          puts "Downloading language: #{loc[1]}"
           complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations?filters[status]=current&format=json"
           downloader.download(loc[1], complete_url, loc[1] == params[:source_locale])
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/gp_downloadmetadata_action.rb
@@ -8,8 +8,9 @@ module Fastlane
         # fastlane will take care of reading in the parameter and fetching the environment variable:
         UI.message "Project URL: #{params[:project_url]}"
         UI.message "Locales: #{params[:locales].inspect}"
+        UI.message "Source locale: #{params[:source_locale].nil? ? '-' : params[:source_locale]}"
         UI.message "Path: #{params[:download_path]}"
-
+        
         # Check download path
         Dir.mkdir(params[:download_path]) unless File.exists?(params[:download_path])
 
@@ -19,7 +20,7 @@ module Fastlane
         params[:locales].each do | loc |
           puts "Downloading language: #{loc[0]}"
           complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations?filters[status]=current&format=json"
-          downloader.download(loc[1], complete_url)
+          downloader.download(loc[1], complete_url, loc[1] == params[:source_locale])
         end
       end
 
@@ -51,7 +52,11 @@ module Fastlane
                                           env_name: "FL_DOWNLOAD_METADATA_LOCALES",
                                           description: "The hash with the GLotPress locale and the project locale association",
                                           is_string: false),
-            FastlaneCore::ConfigItem.new(key: :download_path,
+          FastlaneCore::ConfigItem.new(key: :source_locale,
+                                          env_name: "FL_DOWNLOAD_METADATA_SOURCE_LOCALE",
+                                          description: "The source locale code",
+                                          optional: true),
+          FastlaneCore::ConfigItem.new(key: :download_path,
                                           env_name: "FL_DOWNLOAD_METADATA_DOWNLOAD_PATH",
                                           description: "The path of the target files",
                                           is_string: true)


### PR DESCRIPTION
This PR is required to fix https://github.com/wordpress-mobile/WordPress-iOS/issues/10752.
The issue is related to the fact that GlotPress doesn't allow to download the original string set as a _translation_, so we need a different way to get it back.

The PR adds:
- A new `source_locale` optional parameter for the _downloadmetadata_ action used to define the locale of the source strings.
- Some changes to the metadata_download helper in order to pick the right key when downloading the source language.
  