### PR TITLE
Add a missing dependency to nokogiri

### DIFF
--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
   spec.add_dependency 'diffy'
-
+  spec.add_dependency 'nokogiri'
+  
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('rspec')


### PR DESCRIPTION
This PR adds a missing reference to Nokogiri. The library is used to parse XML files in the android_localise action. The action has been there for a while, but the fact that we used to rely on system ruby dependencies probably hid the issue.

