### PR TITLE
Fix error 404 not found

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/get_prs_list_action.rb
@@ -26,8 +26,12 @@ module Fastlane
         client = Fastlane::Helper::GhhelperHelper.GHClient()
         File.open(report_path, "w") do | file |
           pr_list.each do | pr_number |
-            data = client.pull_request(repository, pr_number.to_i)
-            file.puts("##{data[:number]}: #{data[:title]} @#{data[:user][:login]} #{data[:html_url]}")
+            begin
+              data = client.pull_request(repository, pr_number.to_i)
+              file.puts("##{data[:number]}: #{data[:title]} @#{data[:user][:login]} #{data[:html_url]}")
+            rescue
+              UI.message("Could not find a PR with number #{pr_number.to_i}. Usually this is due to a bad reference in a commit message, but you probably want to check.")
+            end
           end 
         end 
       end


### PR DESCRIPTION
This PR handles the `404 - Not Found` error in the `get_prs_list_action`.

The error is related to the way the action works: it scans the git log and parses the _merge_ messages in order to create the list of merged PRs, then it queries GitHub for every PR in order to get the data. If a commit message contains the same string used by GitHub for a PR merge, but it references something different, the query fails. 

The specific case we found was a corner one: 
- in a branched repository, a bunch of PRs have been merged into a _master_ branch. GH merge messages have been commited to that branch.
- at the end of the work, a PR has been opened to merge the _master_ branch from the branched repository into the main repository.
This way, all the merge messages related to the branched repository were added to git log. 
The script found these messages and looked for PRs that didn't exist in the main repo.

This PR adds a simple handling for the error, catching the exception and warning the user to verify the failed PR number. It's a quick and dirty fix, but I think it's enough at this point, considering that we want to change the way this work in the future to let it  pull the PR list from GitHub using the assigned milestone as a filter.  