### PR TITLE
Add metadata updater for Android

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/an_update_metadata_source_action.rb
@@ -1,0 +1,173 @@
+require 'fastlane/action'
+require_relative '../helper/an_metadata_update_helper.rb'
+
+module Fastlane
+  module Actions
+    class AnUpdateMetadataSourceAction < Action
+      def self.run(params)
+        # fastlane will take care of reading in the parameter and fetching the environment variable:
+        UI.message "Parameter .po file path: #{params[:po_file_path]}"
+        UI.message "Release version: #{params[:release_version]}"
+
+        # Init
+        create_block_parsers(params[:release_version], params[:source_files])
+
+        # Do
+        check_source_files(params[:source_files])
+        temp_po_name = create_temp_po(params)
+        swap_po(params[:po_file_path], temp_po_name)
+
+        UI.message "File #{params[:po_file_path]} updated!"
+      end
+
+      # Verifies that all the source files are available  
+      # to this action
+      def self.check_source_files(source_files)
+        source_files.values.each do | file_path |
+          UI.user_error!("Couldn't find file at path '#{file_path}'") unless File.exist?(file_path)
+        end
+      end
+
+      # Creates a temp po file merging
+      # new data for known tags
+      # and the data already in the original
+      # .po fo the others.
+      def self.create_temp_po(params)
+        orig = params[:po_file_path]
+        target = self.create_target_file_path(orig)
+
+        # Clear if older exists
+        File.delete(target) if File.exists? target 
+
+        # Create the new one
+        begin
+          File.open(target, "a") do |fw|
+            File.open(orig, "r").each do |fr|
+              write_target_block(fw, fr)
+            end 
+          end
+        rescue 
+          File.delete(target) if File.exists? target 
+          raise 
+        end 
+
+        target 
+      end
+
+      # Deletes the old po and moves the temp one
+      # to the final location
+      def self.swap_po(orig_file_path, temp_file_path)
+        File.delete(orig_file_path) if File.exists? orig_file_path
+        File.rename(temp_file_path, orig_file_path)
+      end
+
+      # Generates the temp file path 
+      def self.create_target_file_path(orig_file_path)
+        "#{File.dirname(orig_file_path)}/#{File.basename(orig_file_path, ".*")}.tmp"
+      end
+
+      # Creates the block instances
+      def self.create_block_parsers(release_version, block_files)
+        @blocks = Array.new
+
+        # Inits default handler
+        @blocks.push (Fastlane::Helper::UnknownMetadataBlock.new)
+
+        # Init special handlers
+        block_files.each do | key, file_path |
+          if (key == :release_note) 
+            @blocks.push (Fastlane::Helper::ReleaseNoteMetadataBlock.new(key, file_path, release_version))
+          else
+            @blocks.push (Fastlane::Helper::StandardMetadataBlock.new(key, file_path))
+          end
+        end
+
+        # Sets the default 
+        @current_block = @blocks[0]
+      end
+
+      # Manages tags depending on the type
+      def self.write_target_block(fw, line)
+        if (is_block_id(line))
+          key = line.split(' ')[1].tr('\"', '')
+          @blocks.each do | block |
+            @current_block = block if block.is_handler_for(key)
+          end
+        end
+
+        if (is_comment(line))
+          @current_block = @blocks.first
+        end
+
+        @current_block.handle_line(fw, line)
+      end
+
+      def self.is_block_id(line)
+        line.start_with?('msgctxt')
+      end
+
+      def self.is_comment(line)
+        line.start_with?('#')
+      end
+
+
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Updates a .po file with new data from .txt files"
+      end
+
+      def self.details
+        "You can use this action to update the .po file that contains the string to load to GlotPress for localization."
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :po_file_path,
+                                       env_name: "FL_UPDATE_METADATA_SOURCE_PO_FILE_PATH", 
+                                       description: "The path of the .po file to update", 
+                                       is_string: true,
+                                       verify_block: proc do |value|
+                                          UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value and not value.empty?)
+                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :release_version,
+                                       env_name: "FL_UPDATE_METADATA_SOURCE_RELEASE_VERSION",
+                                       description: "The release version of the app (to use to mark the release notes)",
+                                       verify_block: proc do |value|
+                                        UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value and not value.empty?) 
+                                      end),
+          FastlaneCore::ConfigItem.new(key: :source_files,
+                                        env_name: "FL_UPDATE_METADATA_SOURCE_SOURCE_FILES",
+                                        description: "The hash with the path to the source files and the key to use to include their content",
+                                        is_string: false,
+                                        verify_block: proc do |value|
+                                          UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value and not value.empty?)
+                                       end)
+        ]
+      end
+
+      def self.output
+          
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        [:android].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -1,0 +1,138 @@
+module Fastlane
+  module Helper
+    
+    # Basic line handler
+    class MetadataBlock
+      attr_reader :block_key
+
+      def initialize(block_key)
+        @block_key = block_key
+      end
+
+      def handle_line(fw, line)
+        fw.puts(line) # Standard line handling: just copy
+      end
+
+      def is_handler_for(key)
+        true
+      end
+    end
+
+    class UnknownMetadataBlock < MetadataBlock     
+      attr_reader :content_file_path
+
+      def initialize()
+        super(nil)
+      end
+    end
+
+    class StandardMetadataBlock < MetadataBlock     
+      attr_reader :content_file_path
+
+      def initialize(block_key, content_file_path)
+        super(block_key)
+        @content_file_path = content_file_path
+      end
+
+      def is_handler_for(key)
+        key == @block_key.to_s
+      end
+
+      def handle_line(fw, line)
+        # put the new content on block start 
+        # and skip all the other content
+        if line.start_with?('msgctxt')
+          generate_block(fw)
+        end
+      end
+
+      def generate_block(fw)
+        # init
+        fw.puts("msgctxt \"#{@block_key}\"")
+        line_count = File.foreach(@content_file_path).inject(0) {|c, line| c+1}
+
+        if (line_count <= 1)
+          # Single line output
+          fw.puts("msgid \"#{File.open(@content_file_path, "r").read}\"")
+        else
+          # Multiple line output
+          fw.puts("msgid \"\"")
+
+          # insert content
+          File.open(@content_file_path, "r").each do | line |
+            fw.puts("\"#{line.strip}\\n\"")
+          end
+        end
+
+        # close
+        fw.puts("msgstr \"\"")
+        fw.puts("")
+      end
+    end
+
+    class ReleaseNoteMetadataBlock < StandardMetadataBlock     
+      attr_reader :new_key, :keep_key, :rel_note_key, :release_version
+
+      def initialize(block_key, content_file_path, release_version)
+        super(block_key, content_file_path)
+        @rel_note_key = "release_note"
+        @release_version = release_version
+        generate_keys(release_version)
+      end
+
+      def generate_keys(release_version)
+        values = release_version.split('.')
+        version_major = Integer(values[0])
+        version_minor = Integer(values[1])
+        @new_key = "#{@rel_note_key}_#{version_major.to_s.rjust(2, '0')}#{version_minor}"
+
+        version_major = version_major - 1 if version_minor == 0
+        version_minor = version_minor == 0 ? 9 : version_minor - 1
+
+        @keep_key = "#{@rel_note_key}_#{version_major.to_s.rjust(2, '0')}#{version_minor}"
+      end
+
+      def is_handler_for(key)
+        values = key.split('_')
+        key.start_with?(@rel_note_key) && values.length == 3 && (Integer(values[2].sub(/^00/, "")) != nil rescue false)
+      end
+
+      def handle_line(fw, line)
+        # put content on block start or if copying the latest one
+        # and skip all the other content
+        if line.start_with?('msgctxt')
+          key = extract_key(line)
+          @is_copying = (key == @keep_key)
+          if (@is_copying)
+            generate_block(fw)
+          end
+        end
+        
+        if (@is_copying)
+          fw.puts(line)
+        end
+      end
+
+      def generate_block(fw)
+        # init
+        fw.puts("msgctxt \"#{@new_key}\"")
+        fw.puts("msgid \"\"")
+        fw.puts("\"#{@release_version}:\\n\"")
+
+        # insert content
+        File.open(@content_file_path, "r").each do | line |
+          fw.puts("\"#{line.strip}\\n\"")
+        end
+
+        # close
+        fw.puts("msgstr \"\"")
+        fw.puts("")
+      end
+
+      def extract_key(line)
+        line.split(' ')[1].tr('\"', '')
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This PR adds an action to update the metadata strings in a .po file for the Android apps. 
It can be tested as a part of: https://github.com/wordpress-mobile/WordPress-Android/pull/9078