### PR TITLE
Add missing octokit dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,10 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.1.2)
+    fastlane-plugin-wpmreleasetoolkit (0.1.7)
+      diffy
+      nokogiri
+      octokit
 
 GEM
   remote: https://rubygems.org/
@@ -21,6 +24,7 @@ GEM
     declarative (0.0.10)
     declarative-option (0.1.0)
     diff-lcs (1.3)
+    diffy (3.3.0)
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -99,11 +103,16 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mini_magick (4.5.1)
+    mini_portile2 (2.4.0)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     os (1.0.0)
     parallel (1.12.1)
     parser (2.5.3.0)
@@ -149,6 +158,9 @@ GEM
       rubocop (>= 0.49.1)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -204,4 +216,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
   spec.add_dependency 'diffy'
   spec.add_dependency 'nokogiri'
+  spec.add_dependency 'octokit'
   
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')


### PR DESCRIPTION
`octokit` is used in https://github.com/wordpress-mobile/release-toolkit/blob/develop/lib/fastlane/plugin/wpmreleasetoolkit/helper/ghhelper_helper.rb but not declared as a dependency. This adds it to the gemspec.