### PR TITLE
Add missing git gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.1.7)
       diffy
+      git
       nokogiri
       octokit
 
@@ -76,6 +77,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     gh_inspector (1.1.3)
+    git (1.5.0)
     google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diffy'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'octokit'
+  spec.add_dependency 'git'
   
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')


### PR DESCRIPTION
It turns out the `git` gem was also missing from the Gemspec. Adding it here.