### PR TITLE
Add lanes for iOS releases

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Wpmreleasetoolkit
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper,actions/configure}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,helper,actions/configure,actions/ios,helper/ios}/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -1,0 +1,95 @@
+module Fastlane
+  module Actions
+    class IosBetabuildPrechecksAction < Action
+      def self.run(params)
+        UI.message "Skip confirm: #{params[:skip_confirm]}"
+        UI.message "Work on version: #{params[:base_version]}" unless params[:base_version].nil?
+        
+        require_relative '../../helper/ios/ios_version_helper.rb'
+        require_relative '../../helper/ios/ios_git_helper.rb'
+
+        # Checkout develop and update
+        Fastlane::Helpers::IosGitHelper::git_checkout_and_pull("develop")
+
+        # Check versions
+        build_version = Fastlane::Helpers::IosVersionHelper::get_build_version
+        message = "The following current version has been detected: #{build_version}\n"
+        
+        # Check branch
+        app_version = Fastlane::Helpers::IosVersionHelper::get_public_version
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helpers::IosGitHelper::git_checkout_and_pull_release_branch_for(app_version))
+        
+        # Check user overwrite
+        build_version = get_user_build_version(params[:base_version], message) unless params[:base_version].nil?
+        next_version = Fastlane::Helpers::IosVersionHelper::calc_next_build_version(build_version)
+
+        # Verify
+        message << "Updating branch to version: #{next_version}.\n"
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
+        # Return the current version
+        build_version
+      end
+
+      def self.get_user_build_version(version, message)
+        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helpers::IosGitHelper::git_checkout_and_pull_release_branch_for(version)
+        build_version = Fastlane::Helpers::IosVersionHelper::get_build_version
+        message << "Looking at branch release/#{version} as requested by user. Detected version: #{build_version}.\n"
+        build_version
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before preparing for a new test build"
+      end
+
+      def self.details
+        "Updates the relevant release branch, checks the app version and ensure the branch is clean"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :base_version,
+                                       env_name: "FL_IOS_BETABUILD_PRECHECKS_BASE_VERSION", 
+                                       description: "The version to work on", # a short description of this parameter
+                                       is_string: true,
+                                       optional: true), # true: verifies the input is a string, false: every kind of value),
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                        env_name: "FL_IOS_BETABUILD_PRECHECKS_SKIPCONFIRM",
+                                        description: "Skips confirmation",
+                                        is_string: false, # true: verifies the input is a string, false: every kind of value
+                                        default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -1,0 +1,72 @@
+module Fastlane
+  module Actions
+    class IosBuildPrechecksAction < Action
+      def self.run(params)
+        require_relative '../../helper/ios/ios_version_helper.rb'
+
+        message = ""
+        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_internal_version()} and uploading to HockeyApp\n" unless !params[:internal]
+        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
+
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before the build"
+      end
+
+      def self.details
+        "Runs some prechecks before the build"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                       env_name: "FL_IOS_BUILD_PRECHECKS_SKIP_CONFIRM", 
+                                       description: "True to avoid the system ask for confirmation", 
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :internal,
+                                       env_name: "FL_IOS_BUILD_PRECHECKS_INTERNAL_BUILD",
+                                       description: "True if this is for an internal build",
+                                       is_string: false, 
+                                       default_value: false), 
+            FastlaneCore::ConfigItem.new(key: :external,
+                                        env_name: "FL_IOS_BUILD_PRECHECKS_EXTERNAL_BUILD",
+                                        description: "True if this is for a public build",
+                                        is_string: false, 
+                                        default_value: false), 
+        ]
+      end
+
+      def self.output
+
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -1,0 +1,74 @@
+module Fastlane
+  module Actions
+    class IosBuildPreflightAction < Action
+      def self.run(params)
+
+        # Validate mobile configuration secrets
+        other_action.configure_validate
+
+        Action.sh("cd .. && rm -rf ~/Library/Developer/Xcode/DerivedData")
+
+        # Verify that ImageMagick exists on this machine and can be called from the command-line.
+        # Internal Builds use it to generate the App Icon as part of the build process
+        begin
+            Action.sh("which convert")
+        rescue
+            UI.user_error!("Couldn't find ImageMagick. Please install it by running `brew install imagemagick`")
+            raise
+        end
+
+        # Verify that Ghostscript exists on this machine and can be called from the command-line.
+        # Internal Builds use it to generate the App Icon as part of the build process
+        begin
+            Action.sh("which gs")
+        rescue
+            UI.user_error!("Couldn't find Ghostscript. Please install it by running `brew install ghostscript`")
+            raise
+        end
+
+        # Check gems and pods are up to date. This will exit if it fails
+        begin
+          Action.sh("bundle check")
+        rescue 
+          UI.user_error!("You should run 'rake dependencies' to make sure gems are up to date")
+          raise
+        end
+
+        Action.sh("rake dependencies:pod:clean")
+        other_action.cocoapods()
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Clean the environment to ensure a safe build"
+      end
+
+      def self.details
+        "Clean the environment to ensure a safe build"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+       
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -1,0 +1,70 @@
+module Fastlane
+  module Actions
+    class IosBumpVersionBetaAction < Action
+      def self.run(params)
+        UI.message "Bumping app release version..."
+         
+        require_relative '../../helper/ios/ios_git_helper.rb'
+        require_relative '../../helper/ios/ios_version_helper.rb'
+
+        Fastlane::Helpers::IosGitHelper.check_on_branch("release")
+        create_config()
+        show_config()
+
+        UI.message "Updating XcConfig..."
+        Fastlane::Helpers::IosVersionHelper.update_xc_configs(@new_beta_version, @short_version, @new_internal_version) 
+        UI.message "Done!"
+ 
+        Fastlane::Helpers::IosGitHelper.bump_version_beta        
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Bumps the version of the app for a new beta"
+      end
+
+      def self.details
+        "Bumps the version of the app for a new beta"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+
+      private 
+      def self.create_config()
+        @current_version = Fastlane::Helpers::IosVersionHelper.get_build_version()
+        @current_version_internal = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @new_internal_version = Fastlane::Helpers::IosVersionHelper.create_internal_version(@current_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @new_beta_version = Fastlane::Helpers::IosVersionHelper.calc_next_build_version(@current_version)
+        @short_version = Fastlane::Helpers::IosVersionHelper.get_short_version_string(@new_beta_version)
+      end
+
+      def self.show_config()
+        UI.message("Current build version: #{@current_version}")
+        UI.message("Current internal version: #{@current_version_internal}") unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        UI.message("New beta version: #{@new_beta_version}")
+        UI.message("New internal version: #{@new_internal_version}") unless ENV["INTERNAL_CONFIG_FILE"].nil?
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -1,0 +1,88 @@
+module Fastlane
+  module Actions
+    class IosBumpVersionHotfixAction < Action
+      def self.run(params)
+        UI.message "Bumping app release version for hotfix..."
+        
+        require_relative '../../helpers/ios/ios_git_helper.rb'
+        Fastlane::Helpers::IosGitHelper.branch_for_hotfix(params[:previous_version], params[:version])
+        create_config(params[:previous_version], params[:version])
+        show_config()
+        
+        UI.message "Updating Fastlane deliver file..."
+        Fastlane::Helpers::IosVersionHelper.update_fastlane_deliver(@new_short_version)
+        UI.message "Done!"
+        UI.message "Updating XcConfig..."
+        Fastlane::Helpers::IosVersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
+        UI.message "Done!"
+
+        Fastlane::Helpers::IosGitHelper.bump_version_hotfix(params[:version])
+        
+        UI.message "Done."
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Bumps the version of the app and creates the new release branch"
+      end
+
+      def self.details
+        "Bumps the version of the app and creates the new release branch"
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_IOS_BUMP_VERSION_HOTFIX_VERSION", 
+                                       description: "The version of the hotfix", 
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :previous_version,
+                                       env_name: "FL_IOS_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION",
+                                       description: "The version to branch from",
+                                       is_string: true) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+
+      private 
+      def self.create_config(previous_version, new_short_version)
+        @current_version = previous_version
+        @current_version_internal = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @new_version = "#{new_short_version}.0"
+        @new_version_internal = Fastlane::Helpers::IosVersionHelper.create_internal_version(@new_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @new_short_version = new_short_version
+        @new_release_branch = "release/#{@new_short_version}"
+      end
+
+      def self.show_config()
+        UI.message("Current build version: #{@current_version}")
+        UI.message("Current internal version: #{@current_version_internal}") unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        UI.message("New build version: #{@new_version}")
+        UI.message("New internal version: #{@new_version_internal}") unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        UI.message("New short version: #{@new_short_version}")
+        UI.message("Release branch: #{@new_release_branch}")
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -1,0 +1,100 @@
+module Fastlane
+    module Actions    
+      class IosBumpVersionReleaseAction < Action
+        def self.run(params)
+          # fastlane will take care of reading in the parameter and fetching the environment variable:
+          UI.message "Bumping app release version..."
+
+          require_relative '../../helper/ios/ios_version_helper.rb'
+          require_relative '../../helper/ios/ios_git_helper.rb'
+          
+          other_action.ensure_git_branch(branch: "develop")
+
+          # Create new configuration
+          @new_version = Fastlane::Helpers::IosVersionHelper.bump_version_release()
+          create_config()
+          show_config()
+
+          # Update local develop and branch
+          Fastlane::Helpers::IosGitHelper.git_checkout_and_pull("develop")
+          Fastlane::Helpers::IosGitHelper.do_release_branch(@new_release_branch)
+          UI.message "Done!"
+
+          UI.message "Updating glotPressKeys..."
+          update_glotpress_key
+          UI.message "Done"
+
+          UI.message "Updating Fastlane deliver file..."
+          Fastlane::Helpers::IosVersionHelper.update_fastlane_deliver(@new_short_version)
+          UI.message "Done!"
+          UI.message "Updating XcConfig..."
+          Fastlane::Helpers::IosVersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
+          UI.message "Done!"
+
+          Fastlane::Helpers::IosGitHelper.bump_version_release()
+          
+          UI.message "Done."
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Bumps the version of the app and creates the new release branch"
+        end
+  
+        def self.details
+          "Bumps the version of the app and creates the new release branch"
+        end
+  
+        def self.available_options
+          
+        end
+  
+        def self.output
+          
+        end
+  
+        def self.return_value
+          
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+
+
+        private
+        def self.create_config()
+          @current_version = Fastlane::Helpers::IosVersionHelper.get_build_version()
+          @current_version_internal = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+          @new_version_internal = Fastlane::Helpers::IosVersionHelper.create_internal_version(@current_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+          @new_short_version = Fastlane::Helpers::IosVersionHelper.get_short_version_string(@new_version)
+          @new_release_branch = "release/#{@new_short_version}"
+        end
+
+        def self.show_config()
+          UI.message("Current build version: #{@current_version}")
+          UI.message("Current internal version: #{@current_version_internal}") unless ENV["INTERNAL_CONFIG_FILE"].nil?
+          UI.message("New build version: #{@new_version}")
+          UI.message("New internal version: #{@new_version_internal}") unless ENV["INTERNAL_CONFIG_FILE"].nil?
+          UI.message("New short version: #{@new_short_version}")
+          UI.message("Release branch: #{@new_release_branch}")
+        end
+
+        def self.update_glotpress_key()
+          dm_file = ENV["DOWNLOAD_METADATA"]
+          if (File.exist?(dm_file)) then
+            sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")
+          else
+            UI.user_error!("Can't find #{dm_file}.")
+          end
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -73,7 +73,7 @@ module Fastlane
         def self.create_config()
           @current_version = Fastlane::Helpers::IosVersionHelper.get_build_version()
           @current_version_internal = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
-          @new_version_internal = Fastlane::Helpers::IosVersionHelper.create_internal_version(@current_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+          @new_version_internal = Fastlane::Helpers::IosVersionHelper.create_internal_version(@new_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
           @new_short_version = Fastlane::Helpers::IosVersionHelper.get_short_version_string(@new_version)
           @new_release_branch = "release/#{@new_short_version}"
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -1,0 +1,50 @@
+module Fastlane
+  module Actions
+    class IosClearIntermediateTagsAction < Action
+      def self.run(params)
+        UI.message("Deleting tags for version: #{params[:version]}")
+        
+        require_relative '../../helper/ios/ios_git_helper.rb'
+        Fastlane::Helpers::IosGitHelper.delete_tags(params[:version])
+
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Cleans all the intermediate tags for the given version"
+      end
+
+      def self.details
+        "Cleans all the intermediate tags for the given version"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_IOS_CLEAN_INTERMEDIATE_TAGS_VERSION",
+                                       description: "The version of the tags to clear",
+                                       is_string: true) 
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -1,0 +1,73 @@
+module Fastlane
+    module Actions
+      class IosCodefreezePrechecksAction < Action
+        def self.run(params)
+          # fastlane will take care of reading in the parameter and fetching the environment variable:
+          UI.message "Skip confirm on code freeze: #{params[:skip_confirm]}"
+  
+          require_relative '../../helper/ios/ios_version_helper.rb'
+          require_relative '../../helper/ios/ios_git_helper.rb'
+  
+          # Checkout develop and update
+          Fastlane::Helpers::IosGitHelper.git_checkout_and_pull("develop")
+  
+          # Create versions
+          current_version = Fastlane::Helpers::IosVersionHelper.get_public_version
+          current_build_version = Fastlane::Helpers::IosVersionHelper.get_build_version
+          next_version = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(current_version)
+  
+          # Ask user confirmation
+          if (!params[:skip_confirm])
+            if (!UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?"))
+              UI.user_error!("Aborted by user request")
+            end
+          end
+  
+          # Check local repo status
+          other_action.ensure_git_status_clean()
+  
+          # Return the current version
+          current_version
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Runs some prechecks before code freeze"
+        end
+  
+        def self.details
+          "Updates the develop branch, checks the app version and ensure the branch is clean"
+        end
+  
+        def self.available_options
+          # Define all options your action supports. 
+          [
+            FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                         env_name: "FL_IOS_CODEFREEZE_PRECHECKS_SKIPCONFIRM",
+                                         description: "Skips confirmation before codefreeze",
+                                         is_string: false, # true: verifies the input is a string, false: every kind of value
+                                         default_value: false) # the default value if the user didn't provide one
+          ]
+        end
+  
+        def self.output
+  
+        end
+  
+        def self.return_value
+          "Version of the app before code freeze"
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
@@ -1,0 +1,42 @@
+module Fastlane
+  module Actions
+    class IosCurrentBranchIsHotfixAction < Action
+      def self.run(params)
+        require_relative '../../helper/ios/ios_version_helper.rb'
+        Fastlane::Helpers::IosVersionHelper::is_hotfix(Fastlane::Helpers::IosVersionHelper::get_public_version)
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Checks if the current branch is for a hotfix"
+      end
+
+      def self.details
+        "Checks if the current branch is for a hotfix"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        "True if the branch is for a hotfix, false otherwise"
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -1,0 +1,54 @@
+module Fastlane
+  module Actions
+    class IosFinalTagAction < Action
+      def self.run(params)
+        require_relative '../../helper/ios/ios_git_helper.rb'
+        require_relative '../../helper/ios/ios_version_helper.rb'
+        version = Fastlane::Helpers::IosVersionHelper::get_public_version
+        
+        UI.message("Tagging final #{version}...")
+
+        Fastlane::Helpers::IosGitHelper.final_tag(version)
+        
+        other_action.ios_clear_intermediate_tags(version: version)
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Finalize a relasae"
+      end
+
+      def self.details
+        "Removes the temp tags and pushes the final one"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                        env_name: "FL_IOS_FINAL_TAG_VERSION", 
+                                        description: "The version of the release to finalize", 
+                                        is_string: true)
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -1,0 +1,67 @@
+module Fastlane
+  module Actions
+    class IosFinalizePrechecksAction < Action
+      def self.run(params)
+        UI.message "Skip confirm: #{params[:skip_confirm]}"
+        
+        require_relative '../../helper/ios/ios_version_helper.rb'
+        require_relative '../../helper/ios/ios_git_helper.rb'
+
+        UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
+
+        version = Fastlane::Helpers::IosVersionHelper::get_public_version
+        message = "Finalizing release: #{version}\n"
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
+        version
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before finalizing a release"
+      end
+
+      def self.details
+        "Runs some prechecks before finalizing a release"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                       env_name: "FL_IOS_FINALIZE_PRECHECKS_SKIPCONFIRM",
+                                       description: "Skips confirmation",
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        "The current app version"
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -1,0 +1,45 @@
+module Fastlane
+    module Actions
+      class IosGetAppVersionAction < Action
+        def self.run(params)
+          require_relative '../../helper/ios/ios_version_helper.rb'
+          Fastlane::Helpers::IosVersionHelper::get_public_version
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Gets the public version of the app"
+        end
+  
+        def self.details
+          "Gets the public version of the app"
+        end
+  
+        def self.available_options
+          # Define all options your action supports. 
+        end
+  
+        def self.output
+          # Define the shared values you are going to provide
+          
+        end
+  
+        def self.return_value
+          # If you method provides a return value, you can describe here what it does
+          "Return the public version of the app"
+        end
+  
+        def self.authors
+          # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
@@ -1,0 +1,86 @@
+module Fastlane
+  module Actions
+    class IosHotfixPrechecksAction < Action
+      def self.run(params)
+        UI.message "Skip confirm: #{params[:skip_confirm]}"
+        UI.message "" 
+
+        require_relative '../../helpers/ios/ios_version_helper.rb'
+        require_relative '../../helpers/ios/ios_git_helper.rb'
+
+        # Evaluate previous tag
+        new_ver = params[:version]
+        prev_ver = Fastlane::Helpers::IosVersionHelper::calc_prev_hotfix_version(new_ver)
+
+        # Confirm
+        message = "Requested Hotfix version: #{new_ver}\n"
+        message << "Branching from: #{prev_ver}\n"
+
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check tags
+        if other_action.git_tag_exists(tag: new_ver)
+          UI.crash!("Version #{new_ver} already exists! Abort!")
+        end
+
+        if !other_action.git_tag_exists(tag: prev_ver)
+          UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!")
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
+        # Return the current version
+        prev_ver
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before preparing for a new hotfix"
+      end
+
+      def self.details
+        "Checks out a new branch from a tag and updates tags"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                       env_name: "FL_IOS_HOTFIX_PRECHECKS_VERSION", 
+                                       description: "The version to work on", # a short description of this parameter
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                        env_name: "FL_IOS_HOTFIX_PRECHECKS_SKIPCONFIRM",
+                                        description: "Skips confirmation",
+                                        is_string: false, # true: verifies the input is a string, false: every kind of value
+                                        default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
@@ -1,0 +1,46 @@
+module Fastlane
+  module Actions
+    class IosLocalizeProjectAction < Action
+      def self.run(params)
+        UI.message "Updating project localisation..."
+  
+        require_relative '../../helper/ios/ios_git_helper.rb'
+        Fastlane::Helpers::IosGitHelper.localize_project()
+          
+        UI.message "Done."
+      end
+  
+      #####################################################
+      # @!group Documentation
+      #####################################################
+  
+      def self.description
+        "Gathers the string to localise"
+      end
+  
+      def self.details
+        "Gathers the string to localise"
+      end
+  
+      def self.available_options
+          
+      end
+  
+      def self.output
+          
+      end
+  
+      def self.return_value
+          
+      end
+  
+      def self.authors
+        ["loremattei"]
+      end
+  
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
@@ -1,0 +1,46 @@
+module Fastlane
+  module Actions
+    class IosTagBuildAction < Action
+      def self.run(params)
+        require_relative '../../helper/ios/ios_version_helper.rb'
+        require_relative '../../helper/ios/ios_git_helper.rb'
+  
+        itc_ver = Fastlane::Helpers::IosVersionHelper.get_build_version()
+        int_ver = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        Fastlane::Helpers::IosGitHelper.tag_build(itc_ver, int_ver)
+      end
+  
+      #####################################################
+      # @!group Documentation
+      #####################################################
+  
+      def self.description
+        "Tags the current build"
+      end
+  
+      def self.details
+        "Tags the current build"
+      end
+  
+      def self.available_options
+        
+      end
+  
+      def self.output
+          
+      end
+  
+      def self.return_value
+          
+      end
+  
+      def self.authors
+        ["loremattei"]
+      end
+  
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
@@ -1,0 +1,43 @@
+module Fastlane
+  module Actions
+    class IosUpdateMetadataAction < Action
+      def self.run(params)
+        require_relative '../../helper/ios/ios_git_helper.rb'
+
+        Fastlane::Helpers::IosGitHelper.update_metadata()
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Downloads translated metadata from the translation system"
+      end
+
+      def self.details
+        "Downloads translated metadata from the translation system"
+      end
+
+      def self.available_options
+    
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -1,0 +1,53 @@
+module Fastlane
+  module Actions    
+    class IosUpdateReleaseNotesAction < Action
+      def self.run(params)
+        UI.message "Updating the release notes..."
+
+        require_relative '../../helper/ios/ios_git_helper.rb'
+        require_relative '../../helper/ios/ios_version_helper.rb'
+        next_version = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(params[:new_version])
+        Fastlane::Helpers::IosGitHelper.update_release_notes(next_version)
+          
+        UI.message "Done."
+      end
+  
+      #####################################################
+      # @!group Documentation
+      #####################################################
+  
+      def self.description
+        "Updates the release notes file for the next app version"
+      end
+  
+      def self.details
+        "Updates the release notes file for the next app version"
+      end
+  
+      def self.available_options
+      [
+        FastlaneCore::ConfigItem.new(key: :new_version,
+                                    env_name: "FL_IOS_UPDATE_RELEASE_NOTES_VERSION", 
+                                    description: "The new version to add to the release notes",
+                                    is_string: true)
+      ]
+      end
+
+      def self.output
+          
+      end
+  
+      def self.return_value
+          
+      end
+  
+      def self.authors
+        ["loremattei"]
+      end
+  
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -1,0 +1,131 @@
+module Fastlane
+    module Helpers
+      module IosGitHelper
+       
+        def self.git_checkout_and_pull(branch)
+          Action.sh("git checkout #{branch}")
+          Action.sh("git pull")
+        end
+  
+        def self.git_checkout_and_pull_release_branch_for(version)
+          branch_name = "release/#{version}"
+          Action.sh("git pull")
+          begin
+            Action.sh("git checkout #{branch_name}")
+            Action.sh("git pull origin #{branch_name}")
+            return true
+          rescue
+            return false
+          end
+        end
+  
+        def self.branch_for_hotfix(tag_version, new_version)
+          Action.sh("git checkout #{tag_version}")
+          Action.sh("git checkout -b release/#{new_version}")
+          Action.sh("git push --set-upstream origin release/#{new_version}")
+        end
+  
+        def self.bump_version_release()
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git add ./config/.")
+          Action.sh("git add fastlane/Deliverfile")
+          Action.sh("git add fastlane/download_metadata.swift")
+          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/Resources/#{ENV["APP_STORE_STRINGS_FILE_NAME"]}")
+          Action.sh("git commit -m \"Bump version number\"")
+          Action.sh("git push")
+        end
+  
+        def self.bump_version_hotfix(version)
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git add ./config/.")
+          Action.sh("git add fastlane/Deliverfile")
+          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/Resources/#{ENV["APP_STORE_STRINGS_FILE_NAME"]}")
+          Action.sh("git commit -m \"Bump version number\"")
+          Action.sh("git push")
+        end
+  
+        def self.bump_version_beta()
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git add ./config/.")
+          Action.sh("git commit -m \"Bump version number\"")
+          Action.sh("git push")
+        end
+  
+        def self.delete_tags(version)
+          Action.sh("git tag | xargs git tag -d; git fetch --tags")
+          tags = Action.sh("git tag")
+          tags.split("\n").each do | tag |
+            if (tag.split(".").length == 4) then
+              if tag.start_with?(version) then
+                UI.message("Removing: #{tag}")
+                Action.sh("git tag -d #{tag}")
+                Action.sh("git push origin :refs/tags/#{tag}")
+              end
+            end
+          end
+        end
+  
+        def self.final_tag(version)
+          Action.sh("git tag #{version}")
+          Action.sh("git push origin #{version}")
+        end
+  
+        def self.localize_project()
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
+          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}*.lproj/Localizable.strings")
+          Action.sh("git commit -m \"Updates strings for localization\"")
+          Action.sh("git push")
+        end
+  
+        def self.update_release_notes(new_version)
+          Action.sh("cp #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/Resources/release_notes.txt ")
+          Action.sh("echo \"#{new_version}\n-----\n \" > #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
+          Action.sh("cat #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/Resources/release_notes.txt >> #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
+          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/Resources/release_notes.txt")
+          Action.sh("git commit -m \"Update release notes.\"")
+          Action.sh("git push")
+        end
+  
+        def self.tag_build(itc_version, internal_version)
+          tag_and_push(itc_version)
+          tag_and_push(internal_version) unless internal_version.nil?
+        end
+  
+        def self.update_metadata()
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/update-translations.rb")
+          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/*.lproj/Localizable.strings")
+          Action.sh("git commit -m \"Updates translation\"")
+  
+          Action.sh("cd fastlane && ./download_metadata.swift")
+          Action.sh("git add ./fastlane/metadata/")
+          Action.sh("git commit -m \"Updates metadata translation\"")
+  
+          Action.sh("git push")
+        end
+  
+        def self.do_release_branch(branch_name)
+          if (check_branch_exists(branch_name) == true) then
+            UI.message("Branch #{branch_name} already exists. Skipping creation.")
+            Action.sh("git checkout #{branch_name}")
+            Action.sh("git pull origin #{branch_name}")
+          else
+            Action.sh("git checkout -b #{branch_name}")
+      
+            # Push to origin
+            Action.sh("git push -u origin #{branch_name}")
+          end    
+        end
+
+        def self.check_branch_exists(branch_name)
+          !Action.sh("git branch --list #{branch_name}").empty?
+        end
+
+        def self.check_on_branch(branch_name) 
+          current_branch_name=Action.sh("git symbolic-ref -q HEAD")
+          UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
+        end
+
+        private
+        def self.tag_and_push(version)
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git tag #{version} && git push origin #{version}") 
+        end
+      end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -1,0 +1,174 @@
+module Fastlane
+    module Helpers
+      module IosVersionHelper
+        MAJOR_NUMBER = 0
+        MINOR_NUMBER = 1
+        HOTFIX_NUMBER = 2
+        BUILD_NUMBER = 3
+  
+        def self.get_public_version
+          version = get_build_version
+          vp = get_version_parts(version)
+          return "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}" unless is_hotfix(version)
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}"
+        end
+  
+        def self.calc_next_release_version(version)
+          vp = get_version_parts(version)
+          vp[MINOR_NUMBER] += 1
+          if (vp[MINOR_NUMBER] == 10)
+            vp[MAJOR_NUMBER] += 1
+            vp[MINOR_NUMBER] = 0
+          end
+  
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
+        end
+  
+        def self.get_short_version_string(version)
+          vp = get_version_parts(version)
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
+        end
+
+        def self.calc_prev_release_version(version)
+          vp = get_version_parts(version)
+          if (vp[MINOR_NUMBER] == 0)
+            vp[MAJOR_NUMBER] -= 1
+            vp[MINOR_NUMBER] = 9
+          else
+            vp[MINOR_NUMBER] -= 1
+          end
+          
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
+        end
+  
+        def self.calc_next_build_version(version)
+          vp = get_version_parts(version)
+          vp[BUILD_NUMBER] += 1
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}.#{vp[BUILD_NUMBER]}"
+        end
+  
+        def self.calc_next_hotfix_version(version)
+          vp = get_version_parts(version)
+          vp[HOTFIX_NUMBER] += 1
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}"
+        end
+  
+        def self.calc_prev_build_version(version)
+          vp = get_version_parts(version)
+          vp[BUILD_NUMBER] -= 1 unless vp[BUILD_NUMBER] == 0
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}.#{vp[BUILD_NUMBER]}"
+        end
+  
+        def self.calc_prev_hotfix_version(version)
+          vp = get_version_parts(version)
+          vp[HOTFIX_NUMBER] -= 1 unless vp[HOTFIX_NUMBER] == 0
+          return "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}" unless vp[HOTFIX_NUMBER] == 0
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
+        end
+
+        def self.create_internal_version(version)
+          vp = get_version_parts(version)
+          d = DateTime.now
+          todayDate = d.strftime("%Y%m%d")
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}.#{todayDate}"
+        end
+  
+        def self.is_hotfix(version)
+          vp = get_version_parts(version)
+          return (vp.length > 2) && (vp[HOTFIX_NUMBER] != 0)
+        end
+  
+        def self.get_build_version
+          versions = get_version_strings()[0]
+        end
+  
+        def self.get_internal_version
+          get_version_strings()[1]
+        end
+  
+        def self.bump_version_release
+          # Bump release
+          current_version=get_public_version()
+          UI.message("Current version: #{current_version}")
+          new_version=calc_next_release_version(current_version)
+          UI.message("New version: #{new_version}")
+          verified_version=verify_version(new_version)
+
+          return verified_version
+        end
+
+        def self.update_fastlane_deliver(new_version)
+          fd_file = "./fastlane/Deliverfile"
+          if (File.exist?(fd_file)) then
+            Action.sh("sed -i '' \"s/app_version.*/app_version \\\"#{new_version}\\\"/\" #{fd_file}")
+          else
+            UI.user_error!("Can't find #{fd_file}.")
+          end
+        end
+
+        def self.update_xc_configs(new_version, new_version_short, internal_version)
+          update_xc_config(ENV["PUBLIC_CONFIG_FILE"], new_version, new_version_short) 
+          update_xc_config(ENV["INTERNAL_CONFIG_FILE"], internal_version, new_version_short) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        end
+
+        def self.update_xc_config(file_path, new_version, new_version_short)
+          if File.exist?(file_path) then
+            UI.message("Updating #{file_path} to version #{new_version_short}/#{new_version}")
+            Action.sh("sed -i '' \"$(awk '/^VERSION_SHORT/{ print NR; exit }' \"#{file_path}\")s/=.*/=#{new_version_short}/\" \"#{file_path}\"") 
+            Action.sh("sed -i '' \"$(awk '/^VERSION_LONG/{ print NR; exit }' \"#{file_path}\")s/=.*/=#{new_version}/\" \"#{file_path}\"")
+          else
+            UI.user_error!("#{file_path} not found")
+          end
+        end
+
+        private 
+  
+        def self.get_version_parts(version)
+          parts=version.split(".")
+          parts=parts.fill("0", parts.length...4).map{|chr| chr.to_i}
+          if (parts.length > 4) then        
+            UI.user_error!("Bad version string: #{version}")
+          end
+
+          return parts
+        end
+  
+        def self.read_long_version_from_config_file(filePath)
+          File.open(filePath, "r") do |f|
+            f.each_line do |line|
+              line = line.strip()
+              if line.start_with?("VERSION_LONG=") then
+                  return line.split("=")[1]
+                end
+              end
+          end
+
+          return nil
+        end
+
+        def self.get_version_strings
+          version_strings = Array.new
+          version_strings << read_long_version_from_config_file(ENV["PUBLIC_CONFIG_FILE"])
+          version_strings << read_long_version_from_config_file(ENV["INTERNAL_CONFIG_FILE"]) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+
+          return version_strings
+        end
+
+        def self.verify_version(version)
+          v_parts = get_version_parts(version)
+          
+          v_parts.each do | part |
+            if (!is_number?(part)) then
+              UI.user_error!("Version value can only contains numbers.")
+            end
+          end
+
+          "#{v_parts[MAJOR_NUMBER]}.#{v_parts[MINOR_NUMBER]}.#{v_parts[HOTFIX_NUMBER]}.#{v_parts[BUILD_NUMBER]}"
+        end
+
+        def self.is_number? string
+          true if Float(string) rescue false
+        end
+      end
+    end
+  end


### PR DESCRIPTION
This PR adds some actions that help to handle iOS releases. The actions have been extracted from WPiOS and can be tested in this WooCommerce iOS PR: https://github.com/woocommerce/woocommerce-ios/pull/802