### PR TITLE
Add actions for Android releases

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -4,8 +4,7 @@ module Fastlane
   module Wpmreleasetoolkit
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper,actions/configure,actions/android,helper/android}/*.rb', File.dirname(__FILE__))]
-      Dir[File.expand_path('**/{actions,helper,actions/configure,actions/ios,helper/ios}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,helper,actions/configure,actions/android,helper/android,actions/ios,helper/ios}/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Wpmreleasetoolkit
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper,actions/configure}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,helper,actions/configure,actions/android,helper/android}/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze.rb
@@ -1,0 +1,132 @@
+module Fastlane
+    module Actions
+      module SharedValues
+      end
+  
+      class AndroidCodefreezeAction < Action
+        def self.run(params)
+          # fastlane will take care of reading in the parameter and fetching the environment variable:
+          UI.message "Skip confirm on code freeze: #{params[:skip_confirm]}"
+          UI.message "Code freezing release: #{params[:codefreeze_version]}"
+          UI.message "Update release branch version: #{params[:update_release_branch_version]}"
+  
+          require_relative '../../helper/android/android_version_helper.rb'
+          require_relative '../../helper/android/android_git_helper.rb'
+  
+          # Checkout develop and update
+          Fastlane::Helpers::AndroidGitHelper.git_checkout_and_pull("develop")
+  
+          # Get current versions
+          current_version = Fastlane::Helpers::AndroidVersionHelper.get_version_name
+          current_build_version_code = Fastlane::Helpers::AndroidVersionHelper.get_build_version_code.to_i()
+  
+          # Check is an alpha version
+          if (!ENV["HAS_ALPHA_VERSION"].nil?) && (!Fastlane::Helpers::AndroidVersionHelper.is_alpha_version(current_version))
+            UI.user_error!("Develop branch is not on an Alpha version. Can't continue with the standard flow.")
+          end
+  
+          # Check the release branch
+          current_release_version = Fastlane::Helpers::AndroidVersionHelper.calc_prev_release_version(params[:codefreeze_version])
+          current_release_version_code = current_build_version_code
+          Fastlane::Helpers::AndroidGitHelper.git_checkout_and_pull("release/#{current_release_version}") unless !params[:update_release_branch_version] 
+          current_release_version_code = current_release_version_code + 1 unless !params[:update_release_branch_version] 
+  
+          # Create new versions
+          new_beta_version = "#{params[:codefreeze_version]}-rc-1"
+          new_beta_version_code = current_release_version_code + 1
+          new_alpha_version = Fastlane::Helpers::AndroidVersionHelper.calc_next_alpha_version_name(current_version)
+          new_alpha_version_code = new_beta_version_code + 1
+  
+          # Ask user confirmation
+          message = "Building a new release branch starting from develop.\n"
+          message << "Version in develop is #{current_version} (code: #{current_build_version_code}).\n"
+          message << "After code freeze:\n"
+          message << "#{current_release_version} on branch release/#{current_release_version}: version name: #{current_release_version} - version code: #{current_release_version_code}.\n" unless !params[:update_release_branch_version] 
+          message << "New #{params[:codefreeze_version]} on branch release/#{params[:codefreeze_version]}: version name: #{new_beta_version} - version code: #{new_beta_version_code}.\n"
+          message << "New alpha on branch develop: version name: #{new_alpha_version} - version code: #{new_alpha_version_code}.\n" unless ENV["HAS_ALPHA_VERSION"].nil?
+          message << "Do you want to continue?\n"
+          
+          next_version_for_release_notes = Fastlane::Helpers::AndroidVersionHelper.calc_next_release_version(params[:codefreeze_version])
+
+          if (!params[:skip_confirm])
+            if (!UI.confirm(message))
+              UI.user_error!("Aborted by user request")
+            end
+          end
+  
+          # Check local repo status
+          other_action.ensure_git_status_clean()
+  
+          # Creates the new branch
+          Fastlane::Helpers::AndroidGitHelper.get_create_codefreeze_branch("release/#{params[:codefreeze_version]}", next_version_for_release_notes)
+  
+          # Updates the version codes
+          if (!ENV["HAS_ALPHA_VERSION"].nil?) then 
+            if (params[:update_release_branch_version])
+              Action.sh("./tools/update-release-names.sh #{current_release_version_code} #{current_release_version} #{new_beta_version} #{new_alpha_version}")
+            else
+              Action.sh("./tools/update-name-alpha-beta.sh #{new_beta_version_code} #{new_beta_version} #{new_alpha_version}")
+            end 
+          else
+            Action.sh("./tools/update-release-names.sh #{new_beta_version_code} #{new_beta_version}")
+            Action.sh("git push")
+          end
+  
+          current_release_version
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Runs some prechecks before code freeze"
+        end
+  
+        def self.details
+          "Updates the develop branch, checks the app version and ensure the branch is clean"
+        end
+  
+        def self.available_options
+          # Define all options your action supports. 
+          
+          # Below a few examples
+          [
+            FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                         env_name: "FL_ANDROID_CODEFREEZE_PRECHECKS_SKIPCONFIRM",
+                                         description: "Skips confirmation before codefreeze",
+                                         is_string: false, # true: verifies the input is a string, false: every kind of value
+                                         default_value: false), # the default value if the user didn't provide one
+            FastlaneCore::ConfigItem.new(key: :codefreeze_version,
+                                         env_name: "FL_ANDROID_CODEFREEZE_PRECHECKS_NEW_VERSION", 
+                                         description: "The version to freeze", # a short description of this parameter
+                                         is_string: true,
+                                         optional: false),
+            FastlaneCore::ConfigItem.new(key: :update_release_branch_version, # true: Update the version for the code frozen branch
+                                         env_name: "FL_ANDROID_CODEFREEZE_PRECHECKS_UPDATERELEASEBRANCH",
+                                         description: "true: update the version code on the releasing branch; false: only develop and the new code freeze branch",
+                                         is_string: false, 
+                                         default_value: true), # the default value if the user didn't provide one
+  
+          ]
+        end
+  
+        def self.output
+  
+        end
+  
+        def self.return_value
+          "Version of the app before code freeze"
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :android
+        end
+      end
+    end
+  end
+  

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
@@ -1,0 +1,46 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      ANDROID_CURRENT_BRANCH_IS_HOTFIX_CUSTOM_VALUE = :ANDROID_CURRENT_BRANCH_IS_HOTFIX_CUSTOM_VALUE
+    end
+
+    class AndroidCurrentBranchIsHotfixAction < Action
+      def self.run(params)
+        require_relative '../../helper/android/android_version_helper.rb'
+        Fastlane::Helpers::AndroidVersionHelper::is_hotfix(Fastlane::Helpers::AndroidVersionHelper::get_version_name)
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Checks if the current branch is for a hotfix"
+      end
+
+      def self.details
+        "Checks if the current branch is for a hotfix"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        "True if the branch is for a hotfix, false otherwise"
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -1,0 +1,74 @@
+module Fastlane
+    module Actions
+      module SharedValues
+        ANDROID_FINALIZE_PRECHECKS_CUSTOM_VALUE = :ANDROID_FINALIZE_PRECHECKS_CUSTOM_VALUE
+      end
+  
+      class AndroidFinalizePrechecksAction < Action
+        def self.run(params)
+          UI.message "Skip confirm: #{params[:skip_confirm]}"
+          
+          require_relative '../../helper/android/android_version_helper.rb'
+          require_relative '../../helper/android/android_git_helper.rb'
+  
+          UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
+  
+          version = Fastlane::Helpers::AndroidVersionHelper::get_version_name
+          message = "Finalizing release: #{version}\n"
+          if (!params[:skip_confirm])
+            if (!UI.confirm("#{message}Do you want to continue?"))
+              UI.user_error!("Aborted by user request")
+            end
+          else 
+            UI.message(message)
+          end
+  
+          # Check local repo status
+          other_action.ensure_git_status_clean()
+  
+          version
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Runs some prechecks before finalizing a release"
+        end
+  
+        def self.details
+          "Runs some prechecks before finalizing a release"
+        end
+  
+        def self.available_options
+          # Define all options your action supports. 
+          
+          # Below a few examples
+          [
+            FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                         env_name: "FL_ANDROID_FINALIZE_PRECHECKS_SKIPCONFIRM",
+                                         description: "Skips confirmation",
+                                         is_string: false, # true: verifies the input is a string, false: every kind of value
+                                         default_value: false) # the default value if the user didn't provide one
+          ]
+        end
+  
+        def self.output
+           
+        end
+  
+        def self.return_value
+          "The current app version"
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :android
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_metadata.rb
@@ -1,0 +1,48 @@
+module Fastlane
+  module Actions
+    module SharedValues
+      ANDROID_UPDATE_METADATA_CUSTOM_VALUE = :ANDROID_UPDATE_METADATA_CUSTOM_VALUE
+    end
+
+    class AndroidUpdateMetadataAction < Action
+      def self.run(params)
+        require_relative '../../helper/android/android_git_helper.rb'
+
+        Fastlane::Helpers::AndroidGitHelper.update_metadata(ENV["validate_translations"])
+        Fastlane::Action::sh("./tools/release-checks.sh")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Downloads translated metadata from the translation system"
+      end
+
+      def self.details
+        "Downloads translated metadata from the translation system"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -1,0 +1,36 @@
+module Fastlane
+    module Helpers
+      module AndroidGitHelper
+       
+        def self.git_checkout_and_pull(branch)
+          Action.sh("git checkout #{branch}")
+          Action.sh("git pull")
+        end
+        
+        def self.get_create_codefreeze_branch(branch, new_version)
+          Action.sh("git checkout develop")
+          Action.sh("git pull")
+          Action.sh("git checkout -b #{branch}")
+          commit_release_notes_for_code_freeze(new_version)
+          Action.sh("git push --set-upstream origin #{branch}")
+        end
+  
+        def self.commit_release_notes_for_code_freeze(new_version)
+          Action.sh("cp #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/metadata/release_notes.txt")
+          Action.sh("echo \"#{new_version}\n-----\n \" > #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
+          Action.sh("cat #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/metadata/release_notes.txt >> #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
+          Action.sh("git add RELEASE-NOTES.txt #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/metadata/release_notes.txt")
+          Action.sh("git commit -m \"Update release notes for code freeze\"")
+        end
+  
+        def self.update_metadata(validate_translation_command)
+          Action.sh("./tools/update-translations.sh")
+          Action.sh("./gradlew #{validate_translation_command}")
+          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/src/main/res")
+          Action.sh("git commit -m \"Updates translations\"")
+  
+          Action.sh("git push")
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -1,0 +1,75 @@
+module Fastlane
+    module Helpers
+      module AndroidVersionHelper
+        MAJOR_NUMBER = 0
+        MINOR_NUMBER = 1
+        HOTFIX_NUMBER = 2
+        ALPHA_PREFIX = "alpha-"
+        RC_SUFFIX = "-rc"
+  
+        def self.get_version_name
+          get_version_name_from_file("#{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/build.gradle")
+        end
+  
+        def self.get_build_version_code
+          get_version_build_from_file("#{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/build.gradle")
+        end
+  
+        def self.is_alpha_version(version)
+          version.start_with?(ALPHA_PREFIX)
+        end
+  
+        def self.is_beta_version(version)
+          version.include?(RC_SUFFIX)
+        end
+  
+        def self.calc_next_alpha_version_name(version)
+          alpha_number = version.sub(ALPHA_PREFIX, '')
+          "#{ALPHA_PREFIX}#{alpha_number.to_i() + 1}"
+        end
+  
+        def self.calc_next_release_version(version)
+          vp = get_version_parts(version)
+          vp[MINOR_NUMBER] += 1
+          if (vp[MINOR_NUMBER] == 10)
+            vp[MAJOR_NUMBER] += 1
+            vp[MINOR_NUMBER] = 0
+          end
+
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
+        end
+
+        def self.calc_prev_release_version(version)
+          vp = get_version_parts(version)
+          if (vp[MINOR_NUMBER] == 0)
+            vp[MAJOR_NUMBER] -= 1
+            vp[MINOR_NUMBER] = 9
+          else
+            vp[MINOR_NUMBER] -= 1
+          end
+          
+           "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
+        end
+  
+        def self.is_hotfix(version)
+          return false if is_alpha_version(version)
+          vp = get_version_parts(version)
+          return (vp.length > 2) && (vp[HOTFIX_NUMBER] != 0)
+        end
+  
+        # private 
+  
+        def self.get_version_parts(version)
+          version.split(".").fill("0", version.length...2).map{|chr| chr.to_i}
+        end
+  
+        def self.get_version_name_from_file(file_path)
+          Action.sh("cat #{file_path} | grep versionName").split(' ')[1].tr('\"', '')
+        end
+  
+        def self.get_version_build_from_file(file_path)
+          Action.sh("cat #{file_path} | grep versionCode").split(' ')[1]
+        end
+      end
+    end
+  end


### PR DESCRIPTION
This PR adds some actions that help to handle Android releases. The actions have been extracted from WPAndroid and can be tested in this WooCommerce Android PR: https://github.com/woocommerce/woocommerce-android/pull/924.