### PR TITLE
Fix a bug in `verify_diff` for some diff strings

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android_localize_helper.rb
@@ -121,8 +121,12 @@ module Fastlane
       def self.verify_diff(diff_string, main_strings, lib_strings, library)
         if diff_string.start_with?("name=") then
           diff_string.slice!('name="')
-          diff_string=diff_string.slice(0..(diff_string.index('"') - 1))
 
+          end_index = diff_string.index('"')
+          end_index ||= diff_string.length # Use the whole string if there's no '"'
+
+          diff_string=diff_string.slice(0..(end_index - 1))
+          
           lib_strings.xpath('//string').each do |string_line|
             if (string_line.attr("name") == diff_string) then 
               res = verifystring(main_strings, library, string_line) 


### PR DESCRIPTION
The PR over at https://github.com/wordpress-mobile/WordPress-Android/pull/9368 is failing due to the CircleCI `strings-check`.

**To Test**
1) In `wordpress-android`, run `bundle exec fastlane validate_login_strings pr_url:https://github.com/wordpress-mobile/WordPress-Android/pull/9368`. Note the failing lane.
2) Use this branch in that project, and run the command again. It should succeed this time.

I'm not 100% sure that this fix resolves the root cause, but applying the fix makes the checks pass, which makes me think that it's an appropriate solution. Let me know if not!