### PR TITLE
Fix regex to remove leading zeros

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -94,7 +94,7 @@ module Fastlane
 
       def is_handler_for(key)
         values = key.split('_')
-        key.start_with?(@rel_note_key) && values.length == 3 && (Integer(values[2].sub(/^00/, "")) != nil rescue false)
+        key.start_with?(@rel_note_key) && values.length == 3 && (Integer(values[2].sub(/^[0]*/, "")) != nil rescue false)
       end
 
       def handle_line(fw, line)


### PR DESCRIPTION
This PR updates `release-toolkit` to fix a bug in `update_appstore_strings` where the new release notes sometimes are not added to the .pot file.
It can be tested in the related client PR here: https://github.com/woocommerce/woocommerce-android/pull/1079