### PR TITLE
Ensure secrets repo is on correct hash before copying files

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -14,11 +14,13 @@ module Fastlane
         ### Make sure secrets repo is at the proper hash as specified in .configure
         repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
         file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
+        original_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
 
         unless repo_hash == file_hash
           sh("cd #{repository_path} && git fetch && git checkout #{file_hash}")
         end
 
+        ### Copy the files
         files_to_copy.each { |x|
 
             source = absolute_secret_store_path(x["file"])
@@ -30,6 +32,9 @@ module Fastlane
                 copy_with_confirmation(source, destination)
             end
         }
+
+        ### Restore secrets repo to original branch
+        sh("cd #{repository_path} && git checkout #{original_repo_branch}")
 
         UI.success "Applied configuration"
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -18,7 +18,7 @@ module Fastlane
         file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
 
         unless repo_branch_name == file_branch_name && repo_hash == file_hash
-          sh("cd #{repository_path} && git checkout #{file_hash}")
+          sh("cd #{repository_path} && git fetch && git checkout #{file_hash}")
         end
 
         files_to_copy.each { |x|

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -34,8 +34,8 @@ module Fastlane
         }
 
         ### Restore secrets repo to original branch.  If it was originally in a 
-        ### detached HEAD state, we need to extract the hash from the branch name.
-        original_repo_branch = original_repo_branch.sub("(HEAD detached at ", "").sub(")", "")
+        ### detached HEAD state, we need to use the hash since there's no branch name.
+        original_repo_branch = repo_commit_hash if (original_repo_branch == nil)
 
         sh("cd #{repository_path} && git checkout #{original_repo_branch}")
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -11,7 +11,7 @@ module Fastlane
     class ConfigureApplyAction < Action
       def self.run(params = {})
 
-        ### Make sure secrets repo is at the proper hash as specified in .configure
+        ### Make sure secrets repo is at the proper hash as specified in .configure.
         repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
         file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
         original_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
@@ -33,7 +33,10 @@ module Fastlane
             end
         }
 
-        ### Restore secrets repo to original branch
+        ### Restore secrets repo to original branch.  If it was originally in a 
+        ### detached HEAD state, we need to extract the hash from the branch name.
+        original_repo_branch = original_repo_branch.sub("(HEAD detached at ", "").sub(")", "")
+
         sh("cd #{repository_path} && git checkout #{original_repo_branch}")
 
         UI.success "Applied configuration"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -12,12 +12,10 @@ module Fastlane
       def self.run(params = {})
 
         ### Make sure secrets repo is at the proper hash as specified in .configure
-        repo_branch_name = Fastlane::Helper::ConfigureHelper.repo_branch_name
-        file_branch_name = Fastlane::Helper::ConfigureHelper.configure_file_branch_name
         repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
         file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
 
-        unless repo_branch_name == file_branch_name && repo_hash == file_hash
+        unless repo_hash == file_hash
           sh("cd #{repository_path} && git fetch && git checkout #{file_hash}")
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -35,7 +35,7 @@ module Fastlane
 
         ### Restore secrets repo to original branch.  If it was originally in a 
         ### detached HEAD state, we need to use the hash since there's no branch name.
-        original_repo_branch = repo_commit_hash if (original_repo_branch == nil)
+        original_repo_branch = repo_hash if (original_repo_branch == nil)
 
         sh("cd #{repository_path} && git checkout #{original_repo_branch}")
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -10,6 +10,17 @@ module Fastlane
   module Actions
     class ConfigureApplyAction < Action
       def self.run(params = {})
+
+        ### Make sure secrets repo is at the proper hash as specified in .configure
+        repo_branch_name = Fastlane::Helper::ConfigureHelper.repo_branch_name
+        file_branch_name = Fastlane::Helper::ConfigureHelper.configure_file_branch_name
+        repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
+        file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
+
+        unless repo_branch_name == file_branch_name && repo_hash == file_hash
+          sh("cd #{repository_path} && git checkout #{file_hash}")
+        end
+
         files_to_copy.each { |x|
 
             source = absolute_secret_store_path(x["file"])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -10,16 +10,26 @@ module Fastlane
         UI.message "Running Configure Download"
 
         # If the `~/.mobile-secrets` repository doesn't exist
-        unless File.directory?("#{Dir.home}/.mobile-secrets")
-            UI.user_error!("The local secrets store does not exist. Please clone it to ~/.mobile-secrets before continuing.")
+        unless File.directory?("#{secrets_dir}")
+            UI.user_error!("The local secrets store does not exist. Please clone it to #{secrets_dir} before continuing.")
         else
           update_repository # If the repo already exists, just update it
         end
       end
       
-      # Ensure the git repository at `~/.mobile-secrets` is up to date
+      # Ensure the git repository at `~/.mobile-secrets` is up to date.
+      # If the secrets repo is in a detached HEAD state, skip the pull,
+      # since it will fail.
       def self.update_repository
-        sh("cd ~/.mobile-secrets && git pull")
+        secrets_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
+
+        unless secrets_repo_branch == nil
+          sh("cd #{secrets_dir} && git pull")
+        end
+      end
+
+      def self.secrets_dir
+        Fastlane::Helper::FilesystemHelper.secret_store_dir
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -32,11 +32,15 @@ module Fastlane
       end
 
       def self.prompt_to_switch_branches
-
-        if UI.confirm("The current branch is `#{current_branch}`. Would you like to switch branches?")
+        branch_name_to_display = current_branch == nil ? current_hash : current_branch
+        if UI.confirm("The current branch is `#{branch_name_to_display}`. Would you like to switch branches?")
           new_branch = UI.select("Select the branch you'd like to switch to: ", get_branches)
           checkout_branch(new_branch)
           update_configure_file
+        else
+          if current_branch == nil
+            UI.user_error!("The local secrets store is in a deatched HEAD state.  Please check out a branch and try again.")
+          end
         end
       end
 
@@ -55,6 +59,10 @@ module Fastlane
 
       def self.current_branch
         Fastlane::Helper::ConfigureHelper.repo_branch_name
+      end
+
+      def self.current_hash
+        Fastlane::Helper::ConfigureHelper.repo_commit_hash
       end
 
       def self.update_configure_file

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -23,6 +23,8 @@ module Fastlane
 
         validate_that_branches_match
 
+        validate_that_hashes_match
+
         validate_that_no_dependent_files_have_changed
 
         validate_that_all_copied_files_match
@@ -48,6 +50,26 @@ module Fastlane
             "To fix this issue, switch back to the `#{file_branch_name}` branch in the mobile secrets repository.",
           ].join("\n"))
         end
+      end
+
+      ### Validate that the pinned hash specified in .configure matches
+      ### the current hash of ~/.mobile-secrets
+      def self.validate_that_hashes_match
+        puts "### MPTEST ###"
+        repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
+        file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
+
+        puts repo_hash
+        puts file_hash
+
+        unless repo_hash == file_hash
+
+          UI.user_error!([
+            "The pinned_hash specified in `.configure` is not the currently checked out hash in the secrets repository.",
+            "To fix this issue, check out the `#{file_hash}` hash in the mobile secrets repository.",
+          ].join("\n"))
+        end
+        puts "### MPTEST ###"
       end
 
       ### Validate that based on the commit hash in the .configure file, no files have changed

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -55,12 +55,8 @@ module Fastlane
       ### Validate that the pinned hash specified in .configure matches
       ### the current hash of ~/.mobile-secrets
       def self.validate_that_hashes_match
-        puts "### MPTEST ###"
         repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
         file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
-
-        puts repo_hash
-        puts file_hash
 
         unless repo_hash == file_hash
 
@@ -69,7 +65,6 @@ module Fastlane
             "To fix this issue, check out the `#{file_hash}` hash in the mobile secrets repository.",
           ].join("\n"))
         end
-        puts "### MPTEST ###"
       end
 
       ### Validate that based on the commit hash in the .configure file, no files have changed

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -88,13 +88,10 @@ module Fastlane
       ###
 
       ### Returns the currently checked out branch for the `~/.mobile-secrets` repository.
+      ### NB: Returns nil if the repo is in a detached HEAD state.
       def self.repo_branch_name
-        result = `cd #{repository_path} && git branch`
-
-        result.each_line
-            .select { |s| s.strip.start_with?('*') }
-            .map{ |s| s.sub('*', '').strip }
-            .first
+        result = `cd #{repository_path} && git rev-parse --abbrev-ref HEAD`.strip!
+        (result == "HEAD") ? nil : result
       end
 
       ### Returns the most recent commit hash in the `~/.mobile-secrets` repository.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -90,7 +90,7 @@ module Fastlane
       ### Returns the currently checked out branch for the `~/.mobile-secrets` repository.
       ### NB: Returns nil if the repo is in a detached HEAD state.
       def self.repo_branch_name
-        result = `cd #{repository_path} && git rev-parse --abbrev-ref HEAD`.strip!
+        result = `cd #{repository_path} && git rev-parse --abbrev-ref HEAD`.strip
         (result == "HEAD") ? nil : result
       end
 


### PR DESCRIPTION
Currently in the WCAndroid/WPAndroid projects, running the command `bundle exec fastlane install configure_apply` ignores the `pinned_hash` and `branch` in `.configure`.  This has the potential to introduce bugs if the `mobile-secrets` repo is at a different hash.  

We can avoid this by checking to see if the secrets repo is on the correct hash (both branch and commit) and, if not, go ahead and check out `pinned_hash` before copying any files.  If the secrets repo is already on the correct branch and commit, then do nothing and go ahead with the file copy.

**To test:**
* Change Fastlane’s Pluginfile in WCAndroid/WPAndroid to point to this fork and branch, like so:
`gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/markpar/release-toolkit', branch: 'add/checkout-correct-hash'`
* `bundle install` or `bundle update` to pull down the changes
* `cd ~/.mobile-secrets`
* `git checkout HEAD~1` (to go back one commit - you could also switch to a new branch here)
* Go back to the app folder and run `bundle exec fastlane run config_apply`

The secrets repo should now be back on the commit specified by `pinned_hash`.  I tried all 4 combinations of right/wrong branch/commit and they all put the secrets repo into the same correct and expected state.

NB:  This change will result in the secrets repo being in a detached head state. Not _too_ big of a deal (you can just `git checkout master` to get back), but I did notice that the Download action will fail in this state, since it does a straight `git pull`, which fails in the detached head state.  If we want, we could address this separately, or not at all depending on how much pain it causes.  🙂 

Big thanks to @jtreanor for assistance!  🎉 
