### PR TITLE
Add actions to support Android builds

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -1,0 +1,89 @@
+module Fastlane
+  module Actions
+    class AndroidBuildPrechecksAction < Action
+      def self.run(params)
+        require_relative '../../helper/android/android_version_helper.rb'
+
+        if (params[:final] and params[:beta])
+          UI.user_error!("Can't build beta and final at the same time!")
+        end
+
+        message = ""
+        beta_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version() unless !params[:beta] and !params[:final]
+        alpha_version = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version() unless !params[:alpha]
+        
+        if (params[:final] and Fastlane::Helpers::AndroidVersionHelper.is_beta_version(beta_version))
+          UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!")
+        end
+
+        message << "Building version #{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) (for upload to Release Channel)\n" unless !params[:final]
+        message << "Building version #{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) (for upload to Beta Channel)\n" unless !params[:beta] 
+        message << "Building version #{alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" unless !params[:alpha]
+
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before the build"
+      end
+
+      def self.details
+        "Runs some prechecks before the build"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                       env_name: "FL_ANDROID_BUILD_PRECHECKS_SKIP_CONFIRM", 
+                                       description: "True to avoid the system ask for confirmation", 
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :alpha,
+                                       env_name: "FL_ANDROID_BUILD_PRECHECKS_ALPHA_BUILD",
+                                       description: "True if this is for an alpha build",
+                                       is_string: false, 
+                                       default_value: false), 
+          FastlaneCore::ConfigItem.new(key: :beta,
+                                      env_name: "FL_ANDROID_BUILD_PRECHECKS_BETA_BUILD",
+                                      description: "True if this is for a beta build",
+                                      is_string: false, 
+                                      default_value: false), 
+          FastlaneCore::ConfigItem.new(key: :final,
+                                      env_name: "FL_ANDROID_BUILD_PRECHECKS_FINAL_BUILD",
+                                      description: "True if this is for a final build",
+                                      is_string: false, 
+                                      default_value: false), 
+        ]
+      end
+
+      def self.output
+
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb
@@ -1,0 +1,58 @@
+module Fastlane
+  module Actions
+    class AndroidBuildPreflightAction < Action
+      def self.run(params)
+
+        # Validate mobile configuration secrets
+        other_action.configure_apply
+
+        # Check gems and pods are up to date. This will exit if it fails
+        begin
+          Action.sh("bundle check")
+        rescue 
+          UI.user_error!("You should run 'bundle install' to make sure gems are up to date")
+          raise
+        end
+
+        begin
+          Action.sh("command -v bundletool > /dev/null")
+        rescue
+          UI.user_error!("bundletool is required to build the APKs. Install it with 'brew install bundletool'")
+          raise
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Clean the environment to ensure a safe build"
+      end
+
+      def self.details
+        "Clean the environment to ensure a safe build"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+       
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -8,7 +8,7 @@ module Fastlane
           require_relative '../../helper/android/android_version_helper.rb'
           require_relative '../../helper/android/android_git_helper.rb'
           
-          # TODO: Re-enable before merging into develop other_action.ensure_git_branch(branch: "develop")
+          other_action.ensure_git_branch(branch: "develop")
 
           # Create new configuration
           @new_short_version = Fastlane::Helpers::AndroidVersionHelper.bump_version_release()

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
@@ -1,0 +1,45 @@
+module Fastlane
+    module Actions
+      class AndroidGetAlphaVersionAction < Action
+        def self.run(params)
+          require_relative '../../helper/android/android_version_helper.rb'
+          Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Gets the alpha version of the app"
+        end
+  
+        def self.details
+          "Gets the alpha version of the app"
+        end
+  
+        def self.available_options
+          # Define all options your action supports. 
+        end
+  
+        def self.output
+          # Define the shared values you are going to provide
+          
+        end
+  
+        def self.return_value
+          # If you method provides a return value, you can describe here what it does
+          "Return the alpha version of the app"
+        end
+  
+        def self.authors
+          # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :android
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
@@ -1,0 +1,45 @@
+module Fastlane
+    module Actions
+      class AndroidGetReleaseVersionAction < Action
+        def self.run(params)
+          require_relative '../../helper/android/android_version_helper.rb'
+          Fastlane::Helpers::AndroidVersionHelper.get_release_version()
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Gets the public version of the app"
+        end
+  
+        def self.details
+          "Gets the public version of the app"
+        end
+  
+        def self.available_options
+          # Define all options your action supports. 
+        end
+  
+        def self.output
+          # Define the shared values you are going to provide
+          
+        end
+  
+        def self.return_value
+          # If you method provides a return value, you can describe here what it does
+          "Return the public version of the app"
+        end
+  
+        def self.authors
+          # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :android
+        end
+      end
+    end
+  end


### PR DESCRIPTION
This PR adds some actions required to support the new Android builds. 
It can be tested with the companion PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10143