### PR TITLE
Add actions for Android beta/hotfix versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+
+orbs:
+  ios: wordpress-mobile/ios@0.0.29
+
+jobs: # a collection of steps
+  build: # runs not using Workflows must have a `build` job as entry point
+    executor:
+      name: ios/default
+      xcode-version: "10.2.1"
+    steps: # a collection of executable commands
+      - checkout # special step to check out source code to working directory

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -1,0 +1,106 @@
+module Fastlane
+  module Actions
+    class AndroidBetabuildPrechecksAction < Action
+      def self.run(params)
+        UI.message "Skip confirm: #{params[:skip_confirm]}"
+        UI.message "Work on version: #{params[:base_version]}" unless params[:base_version].nil?
+        
+        require_relative '../../helper/android/android_version_helper.rb'
+        require_relative '../../helper/android/android_git_helper.rb'
+
+        # Checkout develop and update
+        Fastlane::Helpers::AndroidGitHelper::git_checkout_and_pull("develop")
+
+        # Check versions
+        release_version = Fastlane::Helpers::AndroidVersionHelper::get_release_version
+        message = "The following current version has been detected: #{release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}\n"
+        alpha_release_version = Fastlane::Helpers::AndroidVersionHelper::get_alpha_version
+        message << "The following Alpha version has been detected: #{alpha_release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
+        
+        # Check branch
+        app_version = Fastlane::Helpers::AndroidVersionHelper::get_public_version
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helpers::AndroidGitHelper::git_checkout_and_pull_release_branch_for(app_version))
+        
+        # Check user overwrite
+        if (!params[:base_version].nil?)
+          overwrite_version = get_user_build_version(params[:base_version], message)
+          release_version = overwrite_version[0]
+          alpha_release_version = overwrite_version[1]
+        end
+
+        next_beta_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_beta_version(release_version, alpha_release_version)
+        next_alpha_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_alpha_version(release_version, alpha_release_version)
+
+        # Verify
+        message << "Updating branch to version: #{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) "
+        message << "and #{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n"
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
+        # Return the current version
+        [next_beta_version, next_alpha_version]
+      end
+
+      def self.get_user_build_version(version, message)
+        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helpers::AndroidGitHelper::git_checkout_and_pull_release_branch_for(version)
+        release_version = Fastlane::Helpers::AndroidVersionHelper::get_release_version
+        message << "Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}.\n"
+        alpha_release_version = Fastlane::Helpers::AndroidVersionHelper::get_alpha_version
+        message << "and Alpha Version: #{alpha_release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
+        [release_version, alpha_release_version]
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before preparing for a new test build"
+      end
+
+      def self.details
+        "Updates the relevant release branch, checks the app version and ensure the branch is clean"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :base_version,
+                                       env_name: "FL_ANDROID_BETABUILD_PRECHECKS_BASE_VERSION", 
+                                       description: "The version to work on", # a short description of this parameter
+                                       is_string: true,
+                                       optional: true), # true: verifies the input is a string, false: every kind of value),
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                        env_name: "FL_ANDROID_BETABUILD_PRECHECKS_SKIPCONFIRM",
+                                        description: "Skips confirmation",
+                                        is_string: false, # true: verifies the input is a string, false: every kind of value
+                                        default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -29,11 +29,11 @@ module Fastlane
         end
 
         next_beta_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_beta_version(release_version, alpha_release_version)
-        next_alpha_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_alpha_version(release_version, alpha_release_version)
+        next_alpha_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_alpha_version(release_version, alpha_release_version) unless alpha_release_version.nil?
 
         # Verify
         message << "Updating branch to version: #{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) "
-        message << "and #{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n"
+        message << "and #{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n" unless alpha_release_version.nil?
         if (!params[:skip_confirm])
           if (!UI.confirm("#{message}Do you want to continue?"))
             UI.user_error!("Aborted by user request")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -11,7 +11,7 @@ module Fastlane
         create_config()
         show_config()
 
-        UI.message "Updating gradle.properties..."
+        UI.message "Updating build.gradle..."
         Fastlane::Helpers::AndroidVersionHelper.update_versions(@new_version_beta, @new_version_alpha)  
         UI.message "Done!"
  

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -1,0 +1,71 @@
+module Fastlane
+  module Actions
+    class AndroidBumpVersionBetaAction < Action
+      def self.run(params)
+        UI.message "Bumping app release version..."
+         
+        require_relative '../../helper/android/android_git_helper.rb'
+        require_relative '../../helper/android/android_version_helper.rb'
+
+        Fastlane::Helpers::AndroidGitHelper.check_on_branch("release")
+        create_config()
+        show_config()
+
+        UI.message "Updating gradle.properties..."
+        Fastlane::Helpers::AndroidVersionHelper.update_versions(@new_version_beta, @new_version_alpha)  
+        UI.message "Done!"
+ 
+        Fastlane::Helpers::AndroidGitHelper.bump_version_beta()        
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Bumps the version of the app for a new beta"
+      end
+
+      def self.details
+        "Bumps the version of the app for a new beta"
+      end
+
+      def self.available_options
+        
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      private 
+      def self.create_config()
+        @current_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
+        @current_version_alpha = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
+        @new_version_beta = Fastlane::Helpers::AndroidVersionHelper.calc_next_beta_version(@current_version, @current_version_alpha)
+        @new_version_alpha = ENV["HAS_ALPHA_VERSION"].nil? ? nil : Fastlane::Helpers::AndroidVersionHelper.calc_next_alpha_version(@new_version_beta, @current_version_alpha)
+      end
+
+      def self.show_config()
+        vname = Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME
+        vcode = Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE
+        UI.message("Current version: #{@current_version[vname]}(#{@current_version[vcode]})")
+        UI.message("Current alpha version: #{@current_version_alpha[vname]}(#{@current_version_alpha[vcode]})") unless ENV["HAS_ALPHA_VERSION"].nil?
+        UI.message("New beta version: #{@new_version_beta[vname]}(#{@new_version_beta[vcode]})")
+        UI.message("New alpha version: #{@new_version_alpha[vname]}(#{@new_version_alpha[vcode]})") unless ENV["HAS_ALPHA_VERSION"].nil?
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -1,0 +1,84 @@
+module Fastlane
+  module Actions
+    class AndroidBumpVersionHotfixAction < Action
+      def self.run(params)
+        UI.message "Bumping app release version for hotfix..."
+        
+        require_relative '../../helper/android/android_git_helper.rb'
+        Fastlane::Helpers::AndroidGitHelper.branch_for_hotfix(params[:previous_version_name], params[:version_name])
+        create_config(params[:previous_version_name], params[:version_name], params[:version_code])
+        show_config()
+        
+        UI.message "Updating gradle.properties.."
+        Fastlane::Helpers::AndroidVersionHelper.update_versions(@new_version, @current_version_alpha) 
+        UI.message "Done!"
+
+        Fastlane::Helpers::AndroidGitHelper.bump_version_hotfix(params[:version_name])
+        
+        UI.message "Done."
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Bumps the version of the app and creates the new release branch"
+      end
+
+      def self.details
+        "Bumps the version of the app and creates the new release branch"
+      end
+
+      def self.available_options
+        # Define all options your action supports. 
+        
+        # Below a few examples
+        [
+          FastlaneCore::ConfigItem.new(key: :version_name,
+                                       env_name: "FL_ANDROID_BUMP_VERSION_HOTFIX_VERSION", 
+                                       description: "The version of the hotfix", 
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :version_code,
+                                        env_name: "FL_ANDROID_BUMP_VERSION_HOTFIX_CODE", 
+                                        description: "The version of the hotfix"),
+          FastlaneCore::ConfigItem.new(key: :previous_version_name,
+                                       env_name: "FL_ANDROID_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION",
+                                       description: "The version to branch from",
+                                       is_string: true) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      private 
+      def self.create_config(previous_version, new_version_name, new_version_code)
+        @current_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
+        @current_version_alpha = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
+        @new_version = Fastlane::Helpers::AndroidVersionHelper.calc_next_hotfix_version(new_version_name, new_version_code)
+        @new_short_version = new_version_name
+        @new_release_branch = "release/#{@new_short_version}"
+      end
+
+      def self.show_config()
+        UI.message("Current version: #{@current_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{@current_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]})")
+        UI.message("New hotifx version: #{@new_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{@new_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]})")
+        UI.message("Release branch: #{@new_release_branch}")
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -9,7 +9,7 @@ module Fastlane
         create_config(params[:previous_version_name], params[:version_name], params[:version_code])
         show_config()
         
-        UI.message "Updating gradle.properties.."
+        UI.message "Updating build.gradle..."
         Fastlane::Helpers::AndroidVersionHelper.update_versions(@new_version, @current_version_alpha) 
         UI.message "Done!"
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
@@ -1,0 +1,86 @@
+module Fastlane
+  module Actions
+    class AndroidHotfixPrechecksAction < Action
+      def self.run(params)
+        UI.message "Skip confirm: #{params[:skip_confirm]}"
+        UI.message "" 
+
+        require_relative '../../helper/android/android_version_helper.rb'
+        require_relative '../../helper/android/android_git_helper.rb'
+
+        # Evaluate previous tag
+        new_ver = params[:version_name]
+        prev_ver = Fastlane::Helpers::AndroidVersionHelper::calc_prev_hotfix_version_name(new_ver)
+
+        # Confirm
+        message = "Requested Hotfix version: #{new_ver}\n"
+        message << "Branching from: #{prev_ver}\n"
+
+        if (!params[:skip_confirm])
+          if (!UI.confirm("#{message}Do you want to continue?"))
+            UI.user_error!("Aborted by user request")
+          end
+        else 
+          UI.message(message)
+        end
+
+        # Check tags
+        if other_action.git_tag_exists(tag: new_ver)
+          UI.crash!("Version #{new_ver} already exists! Abort!")
+        end
+
+        if !other_action.git_tag_exists(tag: prev_ver)
+          UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!")
+        end
+
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
+        # Return the current version
+        prev_ver
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Runs some prechecks before preparing for a new hotfix"
+      end
+
+      def self.details
+        "Checks out a new branch from a tag and updates tags"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version_name,
+                                       env_name: "FL_ANDROID_HOTFIX_PRECHECKS_VERSION", 
+                                       description: "The version to work on", # a short description of this parameter
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                        env_name: "FL_ANDROID_HOTFIX_PRECHECKS_SKIPCONFIRM",
+                                        description: "Skips confirmation",
+                                        is_string: false, # true: verifies the input is a string, false: every kind of value
+                                        default_value: false) # the default value if the user didn't provide one
+        ]
+      end
+
+      def self.output
+        
+      end
+
+      def self.return_value
+        
+      end
+
+      def self.authors
+        ["loremattei"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -7,7 +7,7 @@ module Fastlane
     
           release_ver = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
           alpha_ver = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version() unless ENV["HAS_ALPHA_VERSION"].nil?
-          Fastlane::Helpers::AndroidGitHelper.tag_build(release_ver[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME], ENV["HAS_ALPHA_VERSION"].nil? ? nil : alpha_ver[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME])
+          Fastlane::Helpers::AndroidGitHelper.tag_build(release_ver[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME], (ENV["HAS_ALPHA_VERSION"].nil? or (params[:tag_alpha] == false)) ? nil : alpha_ver[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME])
         end
     
         #####################################################
@@ -23,7 +23,13 @@ module Fastlane
         end
     
         def self.available_options
-          
+          [
+            FastlaneCore::ConfigItem.new(key: :tag_alpha,
+                                         env_name: "FL_ANDROID_TAG_BUILD_ALPHA", 
+                                         description: "True to skip tagging the alpha version", 
+                                         is_string: false,
+                                         default_value: true)
+          ]
         end
     
         def self.output

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -6,6 +6,18 @@ module Fastlane
           Action.sh("git checkout #{branch}")
           Action.sh("git pull")
         end
+
+        def self.git_checkout_and_pull_release_branch_for(version)
+          branch_name = "release/#{version}"
+          Action.sh("git pull")
+          begin
+            Action.sh("git checkout #{branch_name}")
+            Action.sh("git pull origin #{branch_name}")
+            return true
+          rescue
+            return false
+          end
+        end
         
         def self.do_release_branch(branch_name)
           if (check_branch_exists(branch_name) == true) then
@@ -48,9 +60,32 @@ module Fastlane
           Action.sh("git push")
         end
 
+        def self.bump_version_beta()
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]} && git add ./build.gradle")
+          Action.sh("git commit -m \"Bump version number\"")
+          Action.sh("git push")
+        end
+
+        def self.bump_version_hotfix(version)
+          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]} && git add ./build.gradle")
+          Action.sh("git commit -m \"Bump version number\"")
+          Action.sh("git push")
+        end
+
         def self.tag_build(release_version, alpha_version)
           tag_and_push(release_version)
           tag_and_push(alpha_version) unless alpha_version.nil?
+        end
+
+        def self.check_on_branch(branch_name) 
+          current_branch_name=Action.sh("git symbolic-ref -q HEAD")
+          UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
+        end
+
+        def self.branch_for_hotfix(tag_version, new_version)
+          Action.sh("git checkout #{tag_version}")
+          Action.sh("git checkout -b release/#{new_version}")
+          Action.sh("git push --set-upstream origin release/#{new_version}")
         end
 
         private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -58,7 +58,7 @@ module Fastlane
         def self.calc_next_beta_version(version, alpha_version = nil)
           # Bump version name
           beta_number = is_beta_version(version) ? version[VERSION_NAME].split('-')[2].to_i + 1 : 1
-          version_name = "#{version[VERSION_NAME]}#{RC_SUFFIX}-#{beta_number}"
+          version_name = "#{version[VERSION_NAME].split('-')[0]}#{RC_SUFFIX}-#{beta_number}"
 
           # Bump version code
           version_code = alpha_version.nil? ? version[VERSION_CODE] + 1 : alpha_version[VERSION_CODE] + 1
@@ -85,6 +85,10 @@ module Fastlane
         def self.calc_next_release_version(version, alpha_version = nil)
           nv = calc_next_release_base_version({ VERSION_NAME => version[VERSION_NAME], VERSION_CODE => alpha_version.nil? ? version[VERSION_CODE] : [version[VERSION_CODE], alpha_version[VERSION_CODE]].max})
           calc_next_beta_version(nv)
+        end
+
+        def self.calc_next_hotfix_version(hotfix_version_name, hotfix_version_code)
+          { VERSION_NAME => hotfix_version_name, VERSION_CODE => hotfix_version_code}
         end
 
         def self.calc_prev_release_version(version)
@@ -119,6 +123,13 @@ module Fastlane
         def self.update_versions(new_version_beta, new_version_alpha)
           self.update_version(new_version_beta, ENV["HAS_ALPHA_VERSION"].nil? ? "defaultConfig" : "vanilla {")
           self.update_version(new_version_alpha, "defaultConfig") unless new_version_alpha.nil?
+        end
+
+        def self.calc_prev_hotfix_version_name(version_name)
+          vp = get_version_parts(version_name)
+          vp[HOTFIX_NUMBER] -= 1 unless vp[HOTFIX_NUMBER] == 0
+          return "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}" unless vp[HOTFIX_NUMBER] == 0
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}"
         end
 
         # private 


### PR DESCRIPTION
This PR adds some actions to support beta and hotfix versioning on Android.
The actions can be tested in the companion PR on WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/10156.