### PR TITLE
Make RMagick optional

### DIFF
--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '1.10.1'
   spec.add_dependency 'octokit', '~> 4.13'
   spec.add_dependency 'git', '~> 1.3'
-  spec.add_dependency 'rmagick', '~> 3.0'
   spec.add_dependency 'jsonlint'
   spec.add_dependency('rake', '~> 12.3')
   spec.add_dependency('rake-compiler', '~> 1.0')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -1,5 +1,12 @@
 require 'tmpdir'
-require 'RMagick'
+begin
+  skip_magick = false
+  require 'RMagick'
+rescue LoadError
+  puts "Please, install RMagick if you aim to generate the PromoScreenshots."
+  puts "\'bundle install --with screenshots\' should do it if your project is configured for PromoScreenshots."
+  skip_magick = true
+end
 require 'json'
 require 'tempfile'
 require 'optparse'
@@ -8,7 +15,7 @@ require 'progress_bar'
 require 'parallel'
 require 'jsonlint'
 
-include Magick
+include Magick unless skip_magick
 
 module Fastlane
   module Helper


### PR DESCRIPTION
This PR makes RMagick an optional dependency for the release toolkit. 

The reason for this is that the RMagick pod seems to be quite troublesome to install for a lot of people (and on CI) and, since it's required only by Promo Screenshots so far, it makes sense to require it only when that feature is used. 

There's a companion PR in WPiOS to test the changes here: https://github.com/wordpress-mobile/WordPress-iOS/pull/12133