### PR TITLE
Fix PromoScreenshots error message

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -1,11 +1,9 @@
 require 'tmpdir'
 begin
-  skip_magick = false
+  $skip_magick = false
   require 'RMagick'
 rescue LoadError
-  puts "Please, install RMagick if you aim to generate the PromoScreenshots."
-  puts "\'bundle install --with screenshots\' should do it if your project is configured for PromoScreenshots."
-  skip_magick = true
+  $skip_magick = true
 end
 require 'json'
 require 'tempfile'
@@ -15,7 +13,7 @@ require 'progress_bar'
 require 'parallel'
 require 'jsonlint'
 
-include Magick unless skip_magick
+include Magick unless $skip_magick
 
 module Fastlane
   module Helper
@@ -23,6 +21,14 @@ module Fastlane
     class PromoScreenshots
 
       def initialize(configFilePath, imageDirectory, translationDirectory, outputDirectory)
+        if ($skip_magick)
+          message = "PromoScreenshots feature is currently disabled.\n"
+          message << "Please, install RMagick if you aim to generate the PromoScreenshots.\n"
+          message << "\'bundle install --with screenshots\' should do it if your project is configured for PromoScreenshots.\n"
+          message << "Aborting."
+          UI.user_error!(message)
+        end
+
         @configFilePath = resolve_path(configFilePath)
         @imageDirectory = resolve_path(imageDirectory)
         @translationDirectory = resolve_path(translationDirectory)


### PR DESCRIPTION
This PR changes the way the load error message for RMagick is shown. Currently, it's shown every time the plugin is loaded. With the changes in this PR, it will be shown only when the PromoScreenshot action is called. 

This can be tested as a part of https://github.com/wordpress-mobile/WordPress-iOS/pull/12133. 