### PR TITLE
Use configure_apply instead of validate

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
 
         # Validate mobile configuration secrets
-        other_action.configure_validate
+        other_action.configure_apply
 
         Action.sh("cd .. && rm -rf ~/Library/Developer/Xcode/DerivedData")
 


### PR DESCRIPTION
This PR updates the iOS Build Preflight action to use the `configure_apply` instead of `configure_validate` during the initial check.
This way, the commit referenced in the `.configure` file is checked out in the mobile secrets repository before starting the build.

This PR is related to https://github.com/wordpress-mobile/WordPress-iOS/pull/12207 and can be tested from there. 