### PR TITLE
Add model for secrets configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,20 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.29
+  bundle-install: toshimaru/bundle-install@0.3.1
 
-jobs: # a collection of steps
-  build: # runs not using Workflows must have a `build` job as entry point
-    executor:
-      name: ios/default
-      xcode-version: "10.2.1"
-    steps: # a collection of executable commands
-      - checkout # special step to check out source code to working directory
+jobs:
+  test:
+    docker:
+      - image: circleci/ruby:2.4
+    steps:
+      - checkout
+      - bundle-install/bundle-install
+      - run:
+          name: Run Tests
+          command: bundle exec rspec
+
+workflows:
+  test:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,18 @@
 version: 2.1
 
 orbs:
+  ios: wordpress-mobile/ios@0.0.29
   bundle-install: toshimaru/bundle-install@0.3.1
 
 jobs:
   test:
-    docker:
-      - image: circleci/ruby:2.4
+    executor:
+      name: ios/default
+      xcode-version: "10.2.1"
     steps:
       - checkout
-      - bundle-install/bundle-install
+      - bundle-install/bundle-install:
+          cache_key_prefix: v1-bundler
       - run:
           name: Run Tests
           command: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /tmp
 /lib/drawText
+coverage/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.4.0)
+    fastlane-plugin-wpmreleasetoolkit (0.6.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -11,7 +11,6 @@ PATH
       progress_bar (~> 1.3)
       rake (~> 12.3)
       rake-compiler (~> 1.0)
-      rmagick (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -135,7 +134,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.7.12)
+    oj (3.8.1)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.0)
@@ -161,7 +160,6 @@ GEM
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rmagick (3.2.0)
     rouge (2.0.7)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -22,9 +22,8 @@ module Fastlane
 
         ### Copy the files
         files_to_copy.each { |x|
-
-            source = absolute_secret_store_path(x["file"])
-            destination = absolute_project_path(x["destination"])
+            source = absolute_secret_store_path(x[:file])
+            destination = absolute_project_path(x[:destination])
 
             if(params[:force])
                 copy(source, destination)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -22,8 +22,8 @@ module Fastlane
 
         ### Copy the files
         files_to_copy.each { |x|
-            source = absolute_secret_store_path(x[:file])
-            destination = absolute_project_path(x[:destination])
+            source = absolute_secret_store_path(x.file)
+            destination = absolute_project_path(x.destination)
 
             if(params[:force])
                 copy(source, destination)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -98,14 +98,14 @@ module Fastlane
       def self.validate_that_all_copied_files_match
         Fastlane::Helper::ConfigureHelper.files_to_copy.each{ |x|
 
-            source = absolute_secret_store_path(x[:file])
-            destination = absolute_project_path(x[:destination])
+            source = absolute_secret_store_path(x.file)
+            destination = absolute_project_path(x.destination)
 
             sourceHash = file_hash(source)
             destinationHash = file_hash(destination)
 
             unless sourceHash == destinationHash
-                UI.user_error!("`#{x[:destination]} doesn't match the file in the secrets repository (#{x[:file]}) – unable to continue")
+                UI.user_error!("`#{x.destination} doesn't match the file in the secrets repository (#{x.file}) – unable to continue")
             end
         }
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -98,14 +98,14 @@ module Fastlane
       def self.validate_that_all_copied_files_match
         Fastlane::Helper::ConfigureHelper.files_to_copy.each{ |x|
 
-            source = absolute_secret_store_path(x["file"])
-            destination = absolute_project_path(x["destination"])
+            source = absolute_secret_store_path(x[:file])
+            destination = absolute_project_path(x[:destination])
 
             sourceHash = file_hash(source)
             destinationHash = file_hash(destination)
 
             unless sourceHash == destinationHash
-                UI.user_error!("`#{x["destination"]} doesn't match the file in the secrets repository (#{x["file"]}) – unable to continue")
+                UI.user_error!("`#{x[:destination]} doesn't match the file in the secrets repository (#{x[:file]}) – unable to continue")
             end
         }
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -204,7 +204,7 @@ module Fastlane
             end
         }
 
-        self.files_to_copy.map { |o| o[:file] } + expanded_file_dependencies
+        self.files_to_copy.map { |o| o.file } + expanded_file_dependencies
       end
 
       ## If we specify a directory in `file_dependencies` instead of listing each file
@@ -242,13 +242,8 @@ module Fastlane
             UI.user_error!("You must pass a `destination` to `add_file`")
         end
 
-        new_file = {
-            file: params[:source],
-            destination: params[:destination],
-        }
-
         new_config = self.configuration
-        new_config.files_to_copy.push(new_file)
+        new_config.add_file_to_copy(params[:source], params[:destination])
         update_configuration(new_config)
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
@@ -1,0 +1,35 @@
+
+require 'json'
+
+module Fastlane
+  class Configuration
+    attr_accessor :branch, :pinned_hash, :files_to_copy, :file_dependencies
+
+    def initialize(branch = "", pinned_hash = "", files_to_copy = [], file_dependencies = [])
+      self.branch = branch
+      self.pinned_hash = pinned_hash
+      self.files_to_copy = files_to_copy
+      self.file_dependencies = file_dependencies
+    end
+
+    def self.from_file(path)
+      json = JSON.parse(File.read(path), { symbolize_names: true })
+      self.new(json[:branch], json[:pinned_hash], json[:files_to_copy], json[:file_dependencies])
+    end
+
+    def save_to_file(path)
+      File.write(path, JSON.pretty_generate(to_hash))
+    end
+
+    private
+
+    def to_hash
+      {
+        branch: self.branch,
+        pinned_hash: self.pinned_hash,
+        files_to_copy: self.files_to_copy,
+        file_dependencies: self.file_dependencies
+      }
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
@@ -5,20 +5,25 @@ module Fastlane
   class Configuration
     attr_accessor :branch, :pinned_hash, :files_to_copy, :file_dependencies
 
-    def initialize(branch = "", pinned_hash = "", files_to_copy = [], file_dependencies = [])
-      self.branch = branch
-      self.pinned_hash = pinned_hash
-      self.files_to_copy = files_to_copy
-      self.file_dependencies = file_dependencies
+    def initialize(params = {})
+      self.branch = params[:branch] || ""
+      self.pinned_hash = params[:pinned_hash] || ""
+      self.files_to_copy = (params[:files_to_copy] || []).map { |f| FileReference.new(f) }
+      self.file_dependencies = params[:file_dependencies] || []
     end
 
     def self.from_file(path)
       json = JSON.parse(File.read(path), { symbolize_names: true })
-      self.new(json[:branch], json[:pinned_hash], json[:files_to_copy], json[:file_dependencies])
+      self.new(json)
     end
 
     def save_to_file(path)
       File.write(path, JSON.pretty_generate(to_hash))
+    end
+
+    def add_file_to_copy(source, destination)
+      file = FileReference.new(file: source, destination: destination)
+      self.files_to_copy << file
     end
 
     private
@@ -27,9 +32,22 @@ module Fastlane
       {
         branch: self.branch,
         pinned_hash: self.pinned_hash,
-        files_to_copy: self.files_to_copy,
+        files_to_copy: self.files_to_copy.map { |f| f.to_hash },
         file_dependencies: self.file_dependencies
       }
+    end
+
+    class FileReference
+      attr_accessor :file, :destination
+
+      def initialize(params = {})
+        self.file = params[:file] || ""
+        self.destination = params[:destination] || ""
+      end
+
+      def to_hash
+        { file: self.file, destination: self.destination }
+      end
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -17,7 +17,7 @@ describe Fastlane::Configuration do
       {
         branch: "a_branch",
         pinned_hash: 'a_hash',
-        files_to_copy: [ 'a_file_to_copy' ],
+        files_to_copy: [ { file: 'a_file_to_copy', destination: 'a_destination' } ],
         file_dependencies: [ 'a_file_dependencies' ],
       }
     end
@@ -33,14 +33,29 @@ describe Fastlane::Configuration do
     it 'reads instantiates the configuration object from JSON' do
       expect(subject.branch).to eq(configure_json[:branch])
       expect(subject.pinned_hash).to eq(configure_json[:pinned_hash])
-      expect(subject.files_to_copy).to eq(configure_json[:files_to_copy])
       expect(subject.file_dependencies).to eq(configure_json[:file_dependencies])
+
+      expect(subject.files_to_copy.length).to eq(1)
+      expect(subject.files_to_copy.first.file).to eq(configure_json[:files_to_copy][0][:file])
+      expect(subject.files_to_copy.first.destination).to eq(configure_json[:files_to_copy][0][:destination])
     end
 
     it 'write the configuration to disk as JSON' do
       expect(File).to receive(:write).with(configure_path, configure_json_string)
 
       subject.save_to_file(configure_path)
+    end
+  end
+
+  describe '#add_file_to_copy' do
+    it 'adds files to copy' do
+      expect(subject.files_to_copy).to eq([])
+
+      subject.add_file_to_copy('copy_file', 'to_here')
+
+      expect(subject.files_to_copy.length).to eq(1)
+      expect(subject.files_to_copy.first.file).to eq('copy_file')
+      expect(subject.files_to_copy.first.destination).to eq('to_here')
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper.rb'
+
+describe Fastlane::Configuration do
+  describe 'initialization' do
+    it 'creates an empty config' do
+      expect(subject.branch).to eq("")
+      expect(subject.pinned_hash).to eq("")
+      expect(subject.files_to_copy).to eq([])
+      expect(subject.file_dependencies).to eq([])
+    end
+  end
+
+  describe 'file reading/writing' do
+    let(:configure_path) { 'path/to/.configure' }
+
+    let(:configure_json) do
+      {
+        branch: "a_branch",
+        pinned_hash: 'a_hash',
+        files_to_copy: [ 'a_file_to_copy' ],
+        file_dependencies: [ 'a_file_dependencies' ],
+      }
+    end
+    let(:configure_json_string) { JSON.pretty_generate(configure_json) }
+
+    subject { Fastlane::Configuration.from_file(configure_path) }
+
+    before(:each) do
+      allow(File).to receive(:read).with(configure_path).and_return(configure_json_string)
+      allow(File).to receive(:write).with(configure_path, configure_json_string)
+    end
+
+    it 'reads instantiates the configuration object from JSON' do
+      expect(subject.branch).to eq(configure_json[:branch])
+      expect(subject.pinned_hash).to eq(configure_json[:pinned_hash])
+      expect(subject.files_to_copy).to eq(configure_json[:files_to_copy])
+      expect(subject.file_dependencies).to eq(configure_json[:file_dependencies])
+    end
+
+    it 'write the configuration to disk as JSON' do
+      expect(File).to receive(:write).with(configure_path, configure_json_string)
+
+      subject.save_to_file(configure_path)
+    end
+  end
+end

--- a/spec/ghhelper_action_spec.rb
+++ b/spec/ghhelper_action_spec.rb
@@ -1,9 +1,0 @@
-describe Fastlane::Actions::GhhelperAction do
-  describe '#run' do
-    it 'prints a message' do
-      expect(Fastlane::UI).to receive(:message).with("The ghhelper plugin is working!")
-
-      Fastlane::Actions::GhhelperAction.run(nil)
-    end
-  end
-end


### PR DESCRIPTION
I'm starting to work on some changes to make the configure tool more powerful. As a first step I have extracted the logic for the configuration into a model of its own with tests. There are no functional changes here.

I have also added config to run the tests on CI.

To Test:

- See that CI passes.
- Point a repo with a `.configure` file to this branch (`gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch:'configure-object' 
`).
- Run `bundle install`.
- Run `bundle exec fastlane run configure_apply` and `bundle exec fastlane run configure_validate`. It should work exactly as before.