### PR TITLE
Add support for storing configured files encrypted in project itself

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
@@ -26,6 +26,10 @@ module Fastlane
           else
             continue = false
           end
+
+          Fastlane::Helper::ConfigureHelper.files_to_copy.each do |file_reference|
+            file_reference.update
+          end
         end
       end
 
@@ -55,7 +59,9 @@ module Fastlane
 
         destination = UI.input("Destination File Path:") # Leave the destination as a relative path, as no validation is required.
 
-        Fastlane::Helper::ConfigureHelper.add_file(source: source, destination: destination)
+        encrypt = UI.confirm("Encrypt file?:")
+
+        Fastlane::Helper::ConfigureHelper.add_file(source: source, destination: destination, encrypt: encrypt)
       end
 
       def self.secret_store_dir

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -10,60 +10,61 @@ module Fastlane
   module Actions
     class ConfigureApplyAction < Action
       def self.run(params = {})
+        # Checkout the right commit hash etc. before applying the configuration
+        prepare_repository do
+          # Copy/decrypt the files
+          files_to_copy.each do |file_reference|
+            apply_file(file_reference, params[:force])
+          end
+        end
+        UI.success "Applied configuration"
+      end
 
-        ### Make sure secrets repo is at the proper hash as specified in .configure.
-        repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
-        file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
-        original_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
+      def self.prepare_repository
+        secrets_respository_exists = File.file?(repository_path)
+        if secrets_respository_exists
+          ### Make sure secrets repo is at the proper hash as specified in .configure.
+          repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash
+          file_hash = Fastlane::Helper::ConfigureHelper.configure_file_commit_hash
 
-        unless repo_hash == file_hash
-          sh("cd #{repository_path} && git fetch && git checkout #{file_hash}")
+          unless repo_hash == file_hash
+            sh("cd #{repository_path} && git fetch && git checkout #{file_hash}")
+          end
         end
 
-        ### Copy the files
-        files_to_copy.each { |x|
-            source = absolute_secret_store_path(x.file)
-            destination = absolute_project_path(x.destination)
+        # Run the provided block
+        yield
 
-            if(params[:force])
-                copy(source, destination)
-            else
-                copy_with_confirmation(source, destination)
-            end
-        }
+        if secrets_respository_exists
+          ### Restore secrets repo to original branch.  If it was originally in a 
+          ### detached HEAD state, we need to use the hash since there's no branch name.
+          original_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
+          original_repo_branch = Fastlane::Helper::ConfigureHelper.repo_commit_hash if (original_repo_branch == nil)
 
-        ### Restore secrets repo to original branch.  If it was originally in a 
-        ### detached HEAD state, we need to use the hash since there's no branch name.
-        original_repo_branch = repo_hash if (original_repo_branch == nil)
-
-        sh("cd #{repository_path} && git checkout #{original_repo_branch}")
-
-        UI.success "Applied configuration"
+          sh("cd #{repository_path} && git checkout #{original_repo_branch}")
+        end
       end
 
       ### Check with the user whether we should overwrite the file, if it exists
       ###
-      def self.copy_with_confirmation(source, destination)
-
-        unless File.file?(destination)
-            self.copy(source, destination)
-            return  # Don't continue if we were able to copy the file without conflict
+      def self.apply_file(file_reference, force)
+        # If the file doesn't exist or force is true, we don't need to confirm
+        if !File.file?(file_reference.destination) || force
+          file_reference.apply
+          return  # Don't continue if we were able to copy the file without conflict
         end
 
-        sourceHash = Digest::SHA256.file source
-        destinationHash = Digest::SHA256.file destination
-
-        unless sourceHash != destinationHash
-            return # Don't continue if the files are identical
+        unless file_reference.needs_apply?
+          return # Nothing to do if the files are identical
         end
 
-        if UI.confirm("#{destination} has changes that need to be merged. Would you like to see a diff?")
-            puts Diffy::Diff.new(destination, source, :source=>"files",)
+        if UI.confirm("#{file_reference.destination} has changes that need to be merged. Would you like to see a diff?")
+            puts Diffy::Diff.new(file_reference.destination_contents, file_reference.source_contents)
         end
 
-        if UI.confirm("Would you like to make a backup of #{destination}?")
-            extension = File.extname(destination)
-            base = File.basename(Pathname.new(destination), extension)
+        if UI.confirm("Would you like to make a backup of #{file_reference.destination}?")
+            extension = File.extname(file_reference.destination)
+            base = File.basename(Pathname.new(file_reference.destination), extension)
 
             date_string = Time.now.strftime('%m-%d-%Y--%H-%M-%S')
 
@@ -73,24 +74,16 @@ module Fastlane
             .concat(extension)      # and the original file extension
             .concat(".bak")        # add the .bak file extension - easier to .gitignore
 
-            self.copy(destination, backup_path)
+            # Create the destination directory if it doesn't exist
+            FileUtils.mkdir_p(Pathname.new(file_reference.destination).dirname)
+            FileUtils.cp(file_reference.destination, backup_path)
         end
 
-        if UI.confirm("Would you like to overwrite #{destination}?")
-            self.copy(source, destination)
+        if UI.confirm("Would you like to overwrite #{file_reference.destination}?")
+            file_reference.apply
         else
-            UI.message "Skipping #{destination}"
+            UI.message "Skipping #{file_reference.destination}"
         end
-      end
-
-      ### Copy the file at `source` to `destination`, overwriting it if it already exists
-      ###
-      def self.copy(source, destination)
-
-        pn = Pathname.new(destination)
-
-        FileUtils.mkdir_p(pn.dirname)   # Create the destination directory if it doesn't exist
-        FileUtils.cp(source, destination)
       end
 
       def self.repository_path

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -29,6 +29,10 @@ module Fastlane
           update_configure_file
         end
 
+        Fastlane::Helper::ConfigureHelper.files_to_copy.each do |file_reference|
+          file_reference.update
+        end
+
         UI.success "Configuration Secrets are up to date – don't forget to commit your changes to `.configure`."
 
         # Apply the changes that are now in the .configure file

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -243,13 +243,17 @@ module Fastlane
         end
 
         new_config = self.configuration
-        new_config.add_file_to_copy(params[:source], params[:destination])
+        new_config.add_file_to_copy(params[:source], params[:destination], params[:encrypt])
         update_configuration(new_config)
       end
 
       ## Turns a relative mobile secrets path into an absolute path
       def self.mobile_secrets_path(path)
         "#{repository_path}/#{path}"
+      end
+
+      def self.encryption_key
+        ENV['CONFIGURE_ENCRYPTION_KEY']
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
@@ -1,0 +1,40 @@
+require 'openssl'
+
+module Fastlane
+  module Helper
+    class EncryptionHelper    
+      module OperationType
+        ENCRYPT = 1
+        DECRYPT = 2
+      end
+
+      def self.cipher(op_type, key)
+        cipher = OpenSSL::Cipher::AES256.new :CBC
+
+        cipher.encrypt if op_type == OperationType::ENCRYPT
+        cipher.decrypt if op_type == OperationType::DECRYPT
+
+        cipher.key = key
+        cipher
+      end
+
+      def self.encrypt(plain_text, key)
+        cipher = cipher(OperationType::ENCRYPT, key)
+
+        encrypted = cipher.update(plain_text)
+        encrypted << cipher.final
+
+        encrypted
+      end
+
+      def self.decrypt(encrypted, key)
+        cipher = cipher(OperationType::DECRYPT, key)
+
+        decrypted = cipher.update(encrypted)
+        decrypted << cipher.final
+
+        decrypted
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -38,6 +38,15 @@ module Fastlane
             Pathname.new(project_path) + ".configure"
         end
 
+        ### Returns the path to the project's `.configure-files` directory.
+        def self.configure_files_dir
+            Pathname.new(project_path) + ".configure-files"
+        end
+
+        def self.encrypted_file_path(file)
+            File.join(configure_files_dir, "#{File.basename(file)}.enc")
+        end
+
         ### Returns the path to the `~/.mobile-secrets` directory.
         def self.secret_store_dir
             return "#{Dir.home}/.mobile-secrets"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
@@ -1,5 +1,6 @@
 
 require 'json'
+require_relative 'file_reference.rb'
 
 module Fastlane
   class Configuration
@@ -22,12 +23,10 @@ module Fastlane
       File.write(path, JSON.pretty_generate(to_hash))
     end
 
-    def add_file_to_copy(source, destination)
-      file = FileReference.new(file: source, destination: destination)
+    def add_file_to_copy(source, destination, encrypt = false)
+      file = FileReference.new(file: source, destination: destination, encrypt: encrypt)
       self.files_to_copy << file
     end
-
-    private
 
     def to_hash
       {
@@ -37,19 +36,6 @@ module Fastlane
         files_to_copy: self.files_to_copy.map { |f| f.to_hash },
         file_dependencies: self.file_dependencies
       }
-    end
-
-    class FileReference
-      attr_accessor :file, :destination
-
-      def initialize(params = {})
-        self.file = params[:file] || ""
-        self.destination = params[:destination] || ""
-      end
-
-      def to_hash
-        { file: self.file, destination: self.destination }
-      end
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -1,0 +1,67 @@
+module Fastlane
+  class Configuration
+    class FileReference
+      attr_accessor :file, :destination, :encrypt
+  
+      def initialize(params = {})
+        self.file = params[:file] || ""
+        self.destination = params[:destination] || ""
+        self.encrypt = params[:encrypt] || false
+      end
+  
+      def source_contents
+        return File.read(secrets_repository_file_path) unless self.encrypt
+        return nil unless File.file?(encrypted_file_path)
+        encrypted = File.read(encrypted_file_path)
+        Fastlane::Helper::EncryptionHelper.decrypt(encrypted, encryption_key)
+      end
+    
+      def destination_contents
+        return nil unless File.file?(destination_file_path)
+        File.read(destination_file_path)
+      end
+    
+      def needs_apply?
+        destination = destination_contents
+        destination.nil? || source_contents != destination
+      end
+    
+      def update
+        return unless self.encrypt
+        # Create the destination directory if it doesn't exist
+        FileUtils.mkdir_p(Pathname.new(encrypted_file_path).dirname)
+        # Encrypt the file
+        file_contents = File.read(secrets_repository_file_path)
+        encrypted = Fastlane::Helper::EncryptionHelper.encrypt(file_contents, encryption_key)
+        File.write(encrypted_file_path, encrypted)
+      end
+    
+      def apply
+        # Create the destination directory if it doesn't exist
+        FileUtils.mkdir_p(Pathname.new(destination_file_path).dirname)
+        # Copy/decrypt the file
+        File.write(destination_file_path, source_contents)
+      end
+    
+      def secrets_repository_file_path
+        File.join(Fastlane::Helper::FilesystemHelper.secret_store_dir, self.file)
+      end
+    
+      def encrypted_file_path
+        Fastlane::Helper::FilesystemHelper.encrypted_file_path(self.file)
+      end
+  
+      def destination_file_path
+        File.join(Fastlane::Helper::FilesystemHelper.project_path, self.destination)
+      end
+    
+      def encryption_key
+        Fastlane::Helper::ConfigureHelper.encryption_key
+      end
+  
+      def to_hash
+        { file: self.file, destination: self.destination, encrypt: self.encrypt }
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane::Configuration do
         project_name: "MyProject",
         branch: "a_branch",
         pinned_hash: 'a_hash',
-        files_to_copy: [ { file: 'a_file_to_copy', destination: 'a_destination' } ],
+        files_to_copy: [ { file: 'a_file_to_copy', destination: 'a_destination', encrypt: true } ],
         file_dependencies: [ 'a_file_dependencies' ],
       }
     end
@@ -40,6 +40,7 @@ describe Fastlane::Configuration do
       expect(subject.files_to_copy.length).to eq(1)
       expect(subject.files_to_copy.first.file).to eq(configure_json[:files_to_copy][0][:file])
       expect(subject.files_to_copy.first.destination).to eq(configure_json[:files_to_copy][0][:destination])
+      expect(subject.files_to_copy.first.encrypt).to eq(configure_json[:files_to_copy][0][:encrypt])
     end
 
     it 'write the configuration to disk as JSON' do

--- a/spec/encryption_helper_spec.rb
+++ b/spec/encryption_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper.rb'
+
+describe Fastlane::Helper::EncryptionHelper do
+  let(:cipher) { double('cipher') }
+
+  before(:each) do
+    allow(OpenSSL::Cipher::AES256).to receive(:new).with(:CBC).and_return(cipher)
+  end
+
+  it 'encrypts the input' do
+    expect(cipher).to receive(:encrypt)
+    expect(cipher).to receive(:key=).with('key')
+
+    expect(cipher).to receive(:update).with('plain text').and_return('encrypted')
+    expect(cipher).to receive(:final).and_return('!')
+
+    expect(Fastlane::Helper::EncryptionHelper.encrypt('plain text', 'key')).to eq('encrypted!')
+  end
+
+  it 'decrypts the input' do
+    expect(cipher).to receive(:decrypt)
+    expect(cipher).to receive(:key=).with('key')
+
+    expect(cipher).to receive(:update).with('encrypted').and_return('plain text')
+    expect(cipher).to receive(:final).and_return('!')
+
+    expect(Fastlane::Helper::EncryptionHelper.decrypt('encrypted', 'key')).to eq('plain text!')
+  end
+end

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper.rb'
+
+RSpec.shared_examples 'shared examples' do
+  describe '#destination_contents' do
+    it 'gets the contents from the destination path, when it exists' do
+      allow(File).to receive(:file?).with(subject.destination_file_path).and_return(true)
+      allow(File).to receive(:read).with(subject.destination_file_path).and_return('destination contents')
+      expect(subject.destination_contents).to eq('destination contents')
+    end
+
+    it 'gives nil if the file does not exist' do
+      allow(File).to receive(:file?).with(subject.destination_file_path).and_return(false)
+      expect(subject.destination_contents).to eq(nil)
+    end
+  end
+
+  describe '#needs_apply?' do
+    it 'needs apply when source and destination differ' do
+      allow(subject).to receive(:source_contents).and_return('source contents')
+      allow(subject).to receive(:destination_contents).and_return('destination contents')
+      expect(subject.needs_apply?).to eq(true)
+    end
+
+    it 'does not need apply when source and destination are equal' do
+      allow(subject).to receive(:source_contents).and_return('source contents')
+      allow(subject).to receive(:destination_contents).and_return('source contents')
+      expect(subject.needs_apply?).to eq(false)
+    end
+  end
+
+  describe '#apply' do
+    it 'copies the source to the destination' do
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(subject).to receive(:source_contents).and_return('source contents')
+      expect(File).to receive(:write).with(subject.destination_file_path, 'source contents')
+      subject.apply
+    end
+  end
+end
+
+describe Fastlane::Configuration::FileReference do
+  describe 'initialization' do
+    it 'creates an empty file reference' do
+      expect(subject.file).to eq("")
+      expect(subject.destination).to eq("")
+      expect(subject.encrypt).to eq(false)
+    end
+  end
+
+  describe 'without encryption' do
+    let(:subject) { Fastlane::Configuration::FileReference.new(file: 'path/to/file', destination: 'destination', encrypt: false) }
+
+    include_examples 'shared examples'
+
+    describe '#source_contents' do
+      it 'gets the contents from the secrets repo' do
+        allow(File).to receive(:read).with(subject.secrets_repository_file_path).and_return('source contents')
+        expect(subject.source_contents).to eq('source contents')
+      end
+    end
+
+    describe '#update' do
+      it 'does nothing' do
+        expect(File).not_to receive(:write)
+        subject.update
+      end
+    end
+  end
+
+  describe 'with encryption' do
+    let(:subject) { Fastlane::Configuration::FileReference.new(file: 'path/to/file', destination: 'destination', encrypt: true) }
+
+    before(:each) do
+      allow(Fastlane::Helper::ConfigureHelper).to receive(:encryption_key).and_return('key')
+    end
+
+    include_examples 'shared examples'
+
+    describe '#source_contents' do
+      it 'gives the descrypted contents, when it exists' do
+        allow(File).to receive(:file?).with(subject.encrypted_file_path).and_return(true)
+        allow(File).to receive(:read).with(subject.encrypted_file_path).and_return('encrypted contents')
+        expect(Fastlane::Helper::EncryptionHelper).to receive(:decrypt).with('encrypted contents', 'key').and_return('decrypted contents')
+        expect(subject.source_contents).to eq('decrypted contents')
+      end
+  
+      it 'gives nil if the encrypted does not exist' do
+        allow(File).to receive(:file?).with(subject.encrypted_file_path).and_return(false)
+        expect(subject.source_contents).to eq(nil)
+      end
+    end
+
+    describe '#update' do
+      it 'updates the encrypted file' do
+        allow(FileUtils).to receive(:mkdir_p)
+        allow(File).to receive(:read).with(subject.secrets_repository_file_path).and_return('source contents')
+        expect(Fastlane::Helper::EncryptionHelper).to receive(:encrypt).with('source contents', 'key').and_return('encrypted contents')
+        expect(File).to receive(:write).with(subject.encrypted_file_path, 'encrypted contents')
+        subject.update
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a follow up to https://github.com/wordpress-mobile/release-toolkit/pull/68.

As discussed, we would like a way to access files from the secrets repo on CI without needing access to the repo itself. The solution is to provide a new `"encrypt" : true` option in the `.configure` file. When this is enabled, `configure_update` will save an encrypted version of the file to `.configure-files` in the project and `configure_apply` will decrypt that instead of copying the file from the secrets repo (so access is not needed).

There are no breaking changes and the existing workflow still works exactly as before.

In the next PR I will add the logic needed for generating and storing encryption keys in the secrets repo. At the moment it just uses a `CONFIGURE_ENCRYPTION_KEY` environment variable.

## Testing

### Existing behaviour

To test the existing behaviour still works, follow these steps on this branch:

1. `bundle install`
2. Run `bundle exec fastlane run configure_setup`.
3. When prompted if you would like to specifiy a file to copy, type `y`.
4. For the source file path type `android/WPAndroid/gradle.properties` and press return.
5. For the destination file path type `gradle.properties`.
6. Type `n` when asked if you would like to encrypt the file and `n` again when asked if you want to add additional files.
7. Verify that `gradle.properties` has been copied and that there is no `.configure-files` directory in the project.

To validate that `configure_apply` still works:

1. Run `rm gradle.properties` and then `bundle exec fastlane run configure_apply`.
2. `gradle.properties` should be copied back to the project.

To validate that `configure_update` still works:

1. Run `bundle exec fastlane run configure_update`, following the prompts.
2. Validate that there is still no `.configure-files` directory.

### New functionality

To test the existing behaviour still works, follow these steps on this branch:

1. Set an encryption key (this won't be needed when I open my next PR): `export CONFIGURE_ENCRYPTION_KEY=$(openssl rand -base64 128)`
2. Clean up the existing config from above: `rm gradle.properties .configure`
3. Run `bundle exec fastlane run configure_setup`.
4. When prompted if you would like to specifiy a file to copy, type `y`.
5. For the source file path type `android/WPAndroid/gradle.properties` and press return.
6. For the destination file path type `gradle.properties`.
7. Type `y` when asked if you would like to encrypt the file and `n` when asked if you want to add additional files.
8. Verify that `gradle.properties` has been copied and that a `.configure-files/gradle.properties.enc` file has been created.

To validate that `configure_apply` works:

1. Rename your `~/.mobile-secrets` directory to confirm its not used: `mv ~/.mobile-secrets ~/.mobile-secrets-tmp`.
2. Run `rm gradle.properties` and then `bundle exec fastlane run configure_apply`.
3. `gradle.properties` should be in the project again.
4. Move your secrets repo back: `mv ~/.mobile-secrets-tmp ~/.mobile-secrets`.

To validate that `configure_update` still works:

1. Remove the encrypted file to show it will be recreated: `rm .configure-files/gradle.properties.enc`.
2. Run `bundle exec fastlane run configure_update`, following the prompts.
3. See that `.configure-files/gradle.properties.enc` has been recreated.

### Clean up

To clean up your repo after the above tests run this: `rm -rf .configure gradle.properties .configure-files`.