### PR TITLE
Add 'project_name' to .configure

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -23,6 +23,10 @@ module Fastlane
 
         if configure_file_is_behind_repo
           prompt_to_update_configure_file_to_most_recent_hash
+        else
+          # Update configure file even if already update to date
+          # This ensures the file format is up to date
+          update_configure_file
         end
 
         UI.success "Configuration Secrets are up to date – don't forget to commit your changes to `.configure`."

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
@@ -3,9 +3,10 @@ require 'json'
 
 module Fastlane
   class Configuration
-    attr_accessor :branch, :pinned_hash, :files_to_copy, :file_dependencies
+    attr_accessor :project_name, :branch, :pinned_hash, :files_to_copy, :file_dependencies
 
     def initialize(params = {})
+      self.project_name = params[:project_name] || Fastlane::Helper::FilesystemHelper.project_path.basename.to_s
       self.branch = params[:branch] || ""
       self.pinned_hash = params[:pinned_hash] || ""
       self.files_to_copy = (params[:files_to_copy] || []).map { |f| FileReference.new(f) }
@@ -30,6 +31,7 @@ module Fastlane
 
     def to_hash
       {
+        project_name: self.project_name,
         branch: self.branch,
         pinned_hash: self.pinned_hash,
         files_to_copy: self.files_to_copy.map { |f| f.to_hash },

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper.rb'
 describe Fastlane::Configuration do
   describe 'initialization' do
     it 'creates an empty config' do
+      expect(subject.project_name).to eq(Fastlane::Helper::FilesystemHelper.project_path.basename.to_s)
       expect(subject.branch).to eq("")
       expect(subject.pinned_hash).to eq("")
       expect(subject.files_to_copy).to eq([])
@@ -15,6 +16,7 @@ describe Fastlane::Configuration do
 
     let(:configure_json) do
       {
+        project_name: "MyProject",
         branch: "a_branch",
         pinned_hash: 'a_hash',
         files_to_copy: [ { file: 'a_file_to_copy', destination: 'a_destination' } ],


### PR DESCRIPTION
This is a simple change to add a `project_name` entry to `.configure` that defaults to the name of the project directory. It's not used for anything yet but will allow for project-specific config (such as encryption keys) to be stored in the secrets repo (see https://github.com/wordpress-mobile/release-toolkit/pull/69).

It will be added to existing projects the next time `configure_update` is run.

## To Test

For new projects:

1. Checkout this branch and run `bundle install`.
2. Run `bundle exec fastlane run configure_setup`, choosing not to copy any files and see that `.configure` has a `project_name` entry.

For existing projects

1. Remove the `project_name` path from the `.configure` created above.
2. Run `bundle exec run configure_update` and see that `.configure` now has a `project_name` entry.
3. Change `project_name` to something else (e.g. `ReleaseToolkit`) and see that it keeps the changed value when you run `bundle exec run configure_update`.