### PR TITLE
Generate and store project keys in keys.json when configure_update or configure_setup is run

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -29,6 +29,17 @@ module Fastlane
           update_configure_file
         end
 
+        # If there is no encryption key for the project, generate one
+        if Fastlane::Helper::ConfigureHelper.project_encryption_key.nil?
+          # If the user chose not to update the repo but there is no encryption key, throw an error
+          if repo_is_behind_remote
+            UI.user_error!("The local secrets behind the remote but it is missing a keys.json entry for this project. Please update it to the latest commit.")
+          end
+          Fastlane::Helper::ConfigureHelper.update_project_encryption_key
+          # Update the configure file to the new hash
+          update_configure_file
+        end
+
         Fastlane::Helper::ConfigureHelper.files_to_copy.each do |file_reference|
           file_reference.update
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
@@ -8,18 +8,18 @@ module Fastlane
         DECRYPT = 2
       end
 
-      def self.cipher(op_type, key)
+      def self.cipher(op_type)
         cipher = OpenSSL::Cipher::AES256.new :CBC
 
         cipher.encrypt if op_type == OperationType::ENCRYPT
         cipher.decrypt if op_type == OperationType::DECRYPT
 
-        cipher.key = key
         cipher
       end
 
       def self.encrypt(plain_text, key)
-        cipher = cipher(OperationType::ENCRYPT, key)
+        cipher = cipher(OperationType::ENCRYPT)
+        cipher.key = key
 
         encrypted = cipher.update(plain_text)
         encrypted << cipher.final
@@ -28,12 +28,17 @@ module Fastlane
       end
 
       def self.decrypt(encrypted, key)
-        cipher = cipher(OperationType::DECRYPT, key)
+        cipher = cipher(OperationType::DECRYPT)
+        cipher.key = key
 
         decrypted = cipher.update(encrypted)
         decrypted << cipher.final
 
         decrypted
+      end
+
+      def self.generate_key
+        cipher(OperationType::ENCRYPT).random_key
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -57,6 +57,11 @@ module Fastlane
             File.join(secret_store_dir, relative_path)
         end
 
+        ### Path to keys.json in the secrets repository
+        def self.secret_store_keys_path
+            File.join(secret_store_dir, 'keys.json')
+        end
+
         ### Transforms a relative path within the project to an absolute path on disk.
         def self.absolute_project_path(relative_path)
             File.join(project_path, relative_path)

--- a/spec/encryption_helper_spec.rb
+++ b/spec/encryption_helper_spec.rb
@@ -26,4 +26,11 @@ describe Fastlane::Helper::EncryptionHelper do
 
     expect(Fastlane::Helper::EncryptionHelper.decrypt('encrypted', 'key')).to eq('plain text!')
   end
+
+  it 'generates a random key' do
+    expect(cipher).to receive(:encrypt)
+    expect(cipher).to receive(:random_key).and_return('random key')
+
+    expect(Fastlane::Helper::EncryptionHelper.generate_key).to eq('random key')
+  end
 end


### PR DESCRIPTION
This is a follow up to https://github.com/wordpress-mobile/release-toolkit/pull/69.

This makes the previously added encryption functionality useful by adding a way for keys to be generated and stored in the secrets repo. Now, when `configure_setup` or `configure_update` is run, a new key is generated and saved in `~/mobile-secrets/keys.json`, if once odesn;t already exist. That is then used for all subsequent encryption/decryption options. If a `CONFIGURE_ENCRYPTION_KEY` env variable is present, that will be used instead (we will use that on CI).

## Testing

### New project

1. First, switch your mobile secrets branch so that testing doesn't modify master: `cd ~/.mobile-secrets && git checkout -b key-generation && git push -u origin key-generation`.
2. Back in the release toolkit, run `bundle install` and then `bundle exec fastlane run configure_setup`.
3. When asked if you would like to add a file, choose yes and type `android/WPAndroid/gradle.properties for the source and `gradle.properties` for the destination. Choose yes when asked if you want to encrypt the file and don't add additional files.
4. See that `.configure`, `.configure-files/gradle.properties.enc` and `gradle.properties` are now present.
5. Delete `gradle.properties` and confirm that it is recreated with `bundle exec fastlane run configure_apply`. This means both encryption and decryption works.
6. See that `~/.mobile-secrets/keys.json` contains an entry for `release-toolkit`.

### Existing project

Keys should be created and encryption/decryption should work for existing projects.

1. After following the steps above, change `project_name` in `.configure` to `ExistingProject` and remove the files: `rm -rf gradle.properties .configure-files`. This will mimic an exisiting project.
2. Run `bundle exec fastlane run configure_update`.
3. See that `.configure-files/gradle.properties.enc` and `gradle.properties` are now present.
4. Delete `gradle.properties` and confirm that it is recreated with `bundle exec fastlane run configure_apply`. This means both encryption and decryption works.
5. See that `~/.mobile-secrets/keys.json` contains an entry for `ExistingProject`.

### Clean up

1. Remove the testing files from your local repo: `rm -rf .configure gradle.properties .configure-files`
2. Switch your secrets repo back to master: `cd ~/.mobile-secrets && git checkout master`.