### PR TITLE
Refactor actions folder

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Wpmreleasetoolkit
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper,actions/common,actions/configure,actions/android,helper/android,actions/ios,helper/ios}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,helper}/**/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -4,7 +4,7 @@ module Fastlane
   module Wpmreleasetoolkit
     # Return all .rb files inside the "actions" and "helper" directory
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper,actions/configure,actions/android,helper/android,actions/ios,helper/ios}/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,helper,actions/common,actions/configure,actions/android,helper/android,actions/ios,helper/ios}/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/android_localize_helper'
+require_relative '../../helper/android_localize_helper'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -1,9 +1,9 @@
 require 'fastlane/action'
-require_relative '../helper/metadata_update_helper.rb'
+require_relative '../../helper/an_metadata_update_helper.rb'
 
 module Fastlane
   module Actions
-    class GpUpdateMetadataSourceAction < Action
+    class AnUpdateMetadataSourceAction < Action
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
         UI.message "Parameter .po file path: #{params[:po_file_path]}"
@@ -77,8 +77,6 @@ module Fastlane
         block_files.each do | key, file_path |
           if (key == :release_note) 
             @blocks.push (Fastlane::Helper::ReleaseNoteMetadataBlock.new(key, file_path, release_version))
-          elsif (key == :whats_new) 
-            @blocks.push (Fastlane::Helper::WhatsNewMetadataBlock.new(key, file_path, release_version))
           else
             @blocks.push (Fastlane::Helper::StandardMetadataBlock.new(key, file_path))
           end
@@ -168,7 +166,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-         [:ios, :android].include?(platform)
+        [:android].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/android_localize_helper'
+require_relative '../../helper/android_localize_helper'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -1,8 +1,8 @@
 require 'fastlane/action'
 require 'date'
-require_relative '../helper/ghhelper_helper'
-require_relative '../helper/ios/ios_version_helper'
-require_relative '../helper/android/android_version_helper'
+require_relative '../../helper/ghhelper_helper'
+require_relative '../../helper/ios/ios_version_helper'
+require_relative '../../helper/android/android_version_helper'
 module Fastlane
   module Actions
     class CloseMilestoneAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -1,8 +1,8 @@
 require 'fastlane/action'
 require 'date'
-require_relative '../helper/ghhelper_helper'
-require_relative '../helper/ios/ios_version_helper'
-require_relative '../helper/android/android_version_helper'
+require_relative '../../helper/ghhelper_helper'
+require_relative '../../helper/ios/ios_version_helper'
+require_relative '../../helper/android/android_version_helper'
 module Fastlane
   module Actions
     class CreateNewMilestoneAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/ghhelper_helper'
+require_relative '../../helper/ghhelper_helper'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/metadata_download_helper.rb'
+require_relative '../../helper/metadata_download_helper.rb'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -1,9 +1,9 @@
 require 'fastlane/action'
-require_relative '../helper/an_metadata_update_helper.rb'
+require_relative '../../helper/metadata_update_helper.rb'
 
 module Fastlane
   module Actions
-    class AnUpdateMetadataSourceAction < Action
+    class GpUpdateMetadataSourceAction < Action
       def self.run(params)
         # fastlane will take care of reading in the parameter and fetching the environment variable:
         UI.message "Parameter .po file path: #{params[:po_file_path]}"
@@ -77,6 +77,8 @@ module Fastlane
         block_files.each do | key, file_path |
           if (key == :release_note) 
             @blocks.push (Fastlane::Helper::ReleaseNoteMetadataBlock.new(key, file_path, release_version))
+          elsif (key == :whats_new) 
+            @blocks.push (Fastlane::Helper::WhatsNewMetadataBlock.new(key, file_path, release_version))
           else
             @blocks.push (Fastlane::Helper::StandardMetadataBlock.new(key, file_path))
           end
@@ -166,7 +168,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:android].include?(platform)
+         [:ios, :android].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/promo_screenshots_helper.rb'
+require_relative '../../helper/promo_screenshots_helper.rb'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/ghhelper_helper'
+require_relative '../../helper/ghhelper_helper'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/ghhelper_helper'
+require_relative '../../helper/ghhelper_helper'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -1,5 +1,5 @@
 require 'fastlane/action'
-require_relative '../helper/ghhelper_helper'
+require_relative '../../helper/ghhelper_helper'
 
 module Fastlane
   module Actions


### PR DESCRIPTION
This PR moves some actions from the `actions` folder to the proper subfolder in order to give a better organization to the repository. 

### To Test
1. Update your `Pluginfile` to point to this branch.
2. Run `bundle install`.
3. Run `bundle exec fastlane actions` and verify that the moved actions are still listed. 
4. Try to run some actions and verify that they are executed without errors. For example: `bundle exec fastlane get_pullrequests_list start_tag:13.0`.