### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.6.0)
+    fastlane-plugin-wpmreleasetoolkit (0.7.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -134,7 +134,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.8.1)
+    oj (3.9.0)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.0)
@@ -233,7 +233,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler (>= 1.17)
   fastlane (~> 2)
   fastlane-plugin-wpmreleasetoolkit!
   pry (~> 0.12.2)
@@ -244,4 +244,4 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('parallel', '~> 1.14')
 
   spec.add_development_dependency('pry', '~> 0.12.2')
-  spec.add_development_dependency('bundler', '~> 1.17')
+  spec.add_development_dependency('bundler', '>= 1.17')
   spec.add_development_dependency('rspec', '~> 3.8')
   spec.add_development_dependency('rspec_junit_formatter', '~> 0.4.1')
   spec.add_development_dependency('rubocop', '0.49.1')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end


### PR DESCRIPTION
Bumping the version so that the changes for encryption in #68, #69, #70 and #71 can be used in our projects.