### PR TITLE
Update Nokogiri to fix a security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
-      nokogiri (= 1.10.1)
+      nokogiri (>= 1.10.4)
       octokit (~> 4.13)
       parallel (~> 1.14)
       progress_bar (~> 1.3)
@@ -130,7 +130,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
   spec.add_dependency 'diffy', '~> 3.3'
-  spec.add_dependency 'nokogiri', '1.10.1'
+  spec.add_dependency 'nokogiri', '>= 1.10.4'
   spec.add_dependency 'octokit', '~> 4.13'
   spec.add_dependency 'git', '~> 1.3'
   spec.add_dependency 'jsonlint'


### PR DESCRIPTION
This PR updates Nokogiri to 1.10.4 to fix a security alert.