### PR TITLE
Fix alpha version code evaluation

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -29,7 +29,7 @@ module Fastlane
         end
 
         next_beta_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_beta_version(release_version, alpha_release_version)
-        next_alpha_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_alpha_version(release_version, alpha_release_version) unless alpha_release_version.nil?
+        next_alpha_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_alpha_version(next_beta_version, alpha_release_version) unless alpha_release_version.nil?
 
         # Verify
         message << "Updating branch to version: #{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) "


### PR DESCRIPTION
This PR fixes a bug in `android_betabuild_prechecks` where the `versionCode` for `alpha` builds was not evaluated correctly. 
The PR can be tested in https://github.com/wordpress-mobile/WordPress-Android/pull/10421