### PR TITLE
Force encryption/decryption to use UTF8 strings

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
@@ -18,6 +18,9 @@ module Fastlane
       end
 
       def self.encrypt(plain_text, key)
+        # Ensure consistent encoding
+        plain_text.force_encoding(Encoding::UTF_8)
+
         cipher = cipher(OperationType::ENCRYPT)
         cipher.key = key
 
@@ -33,6 +36,9 @@ module Fastlane
 
         decrypted = cipher.update(encrypted)
         decrypted << cipher.final
+
+        # Ensure consistent encoding
+        decrypted.force_encoding(Encoding::UTF_8)
 
         decrypted
       end


### PR DESCRIPTION
This is a small enhancement to the encryption/decryption functionality to force it to always use UTF-8 strings.

Without this, everything works fine but the tool sometimes thinks that binary files (such as the keystore in https://github.com/wordpress-mobile/WordPress-Android/pull/10404) have changed, when they haven't.