### PR TITLE
Fix configure_apply repo checkout

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -21,7 +21,7 @@ module Fastlane
       end
 
       def self.prepare_repository
-        secrets_respository_exists = File.file?(repository_path)
+        secrets_respository_exists = File.exists?(repository_path)
         if secrets_respository_exists
           ### Make sure secrets repo is at the proper hash as specified in .configure.
           repo_hash = Fastlane::Helper::ConfigureHelper.repo_commit_hash


### PR DESCRIPTION
@malinajirka came across an issue this morning when running `bundle exec fastlane run configure_apply` where the repo wouldn't be checkout correctly and it failed.

It turns out we were using `File.file?` to check if the repo is present, but that only works for files (not directories). This is a small update to use the more correct `File.exists?`.

Additionally, the logic to restore the repo back to its original state wasn't working correctly so I have refactored `prepare_repository` to fix that.

To test:

- Checkout an old secrets repo hash: `cd ~/.mobile-secrets && git reset --hard HEAD~10`.
- Point a project at this branch that has a newer hash in `.configure` that you checked out above and run `bundle exec fastlane run configure_apply`.
- It should work and your `~/.mobile-secrets` should still be at the old revision you checked out above. 