### PR TITLE
Temp fix for the android version helper

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -160,6 +160,8 @@ module Fastlane
           return res
         end
 
+        # FIXME: This implementation is very fragile. This should be done parsing the file in a proper way. 
+        # Leveraging gradle itself is probably the easiest way.
         def self.get_data_from_file(file_path, section, keyword)
           found_section = false
           File.open(file_path, 'r') do |file|
@@ -170,7 +172,7 @@ module Fastlane
                 end
               else
                 if (line.include? keyword)
-                  return line
+                  return line unless line.include?("\"#{keyword}\"") or line.include?("P#{keyword}")
                 end
               end
             end
@@ -198,6 +200,8 @@ module Fastlane
           "#{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/build.gradle"
         end
 
+        # FIXME: This implementation is very fragile. This should be done parsing the file in a proper way. 
+        # Leveraging gradle itself is probably the easiest way.
         def self.update_version(version, section)
           gradle_path = self.gradle_path
           temp_file = Tempfile.new('fastlaneIncrementVersion')
@@ -212,7 +216,7 @@ module Fastlane
                 end
               else
                 if (version_updated < 2)
-                  if (line.include? "versionName")
+                  if (line.include? "versionName") and (!line.include? "\"versionName\"") and (!line.include?"PversionName")
                     version_name = line.split(' ')[1].tr('\"', '')
                     line.replace line.sub(version_name, version[VERSION_NAME].to_s)
                     version_updated = version_updated + 1


### PR DESCRIPTION
With https://github.com/wordpress-mobile/WordPress-Android/pull/10404 we broke the versioning automation for WPAndroid, basically because the script relies on a simple `grep` to extract the version information. 
Since almost every action checks the version of the branch before doing anything, the toolkit is completely unusable on WPAndroid.

This PR is not a good fix, it's just a stop-gap solution to allow us to continue to use the toolkit with WPAndroid.
For a clean solution, the easiest way is probably to create dedicated tasks in gradle that can be triggered by the Fastlane gradle action.
Since we also have to make changes to this code to accommodate the different Simplenote versioning scheme, I think that doing all the changes together would be the most effective flow, though it would require a bit of analysis and testing.

In the meantime, this fix should resuscitate the toolkit on WPAndroid.

### To test
1. Checkout a test branch from WPAndroid develop.
2. Point the Pluginfile in WPAndroid to this branch.
3. `bundle install`.
4. Run any lane, for example `bundle exec fastlane new_beta_release` and verify that the prompt shows the correct versions. 
5. Answer `n` to abort the action.
