### PR TITLE
Don’t include previous release notes in GlotPress

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
@@ -178,9 +178,23 @@ module Fastlane
         fw.puts("msgid \"\"")
 
         # insert content
+        is_reading = false
         File.open(@content_file_path, "r").each do | line |
-          fw.puts("\"#{line.strip}\\n\"")
-        end
+          
+          if is_reading
+            fw.puts("\"#{line.strip}\\n\"")
+          end
+
+          ## Don't start reading the file until after the version number header
+          if line === "-----\n"
+            is_reading = true
+          end
+          
+          ## Stop reading the file after the first empty line
+          if line.strip.empty?
+            break
+          end
+      end
 
         # close
         fw.puts("msgstr \"\"")


### PR DESCRIPTION
Works by using the current format – everything after the version tag, but before the first blank line will be included, rather than all the previous release notes. 

**To Test**
- Using WPiOS `develop`, update your fast lane `Pluginfile` to refer to this branch.
- Run `bundle install`
- Run `bundle exec fastlane update_appstore_strings version:13.2`.
- There should be no changes to `WordPress/Resources/AppStoreStrings.po`

**Note:**
I went through all of the previous release notes in `WordPress/Resources/release_notes.txt` and all of them follow this format. If we want to start including empty lines in release notes, we may need to update this implementation. 

WPAndroid uses its own lane for the time being, so this PR only resolves the issue on iOS.

**Alternatives Considered:**
- Using a regex to match version headers and stopping the parser after the second header [ Would've been slightly more complex ]
- Splitting the file on line breaks and just read the first entry. [slightly less efficient – this would require reading the whole file into memory, whereas the current implementation is streaming, and I wanted to preserve that]