### PR TITLE
Add a Git Helper to determine repo and LFS state

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -1,0 +1,17 @@
+require 'git'
+
+module Fastlane
+  module Helper
+    module GitHelper
+
+      def self.is_git_repo
+        system "git rev-parse --git-dir 1> /dev/null 2>/dev/null"
+      end
+
+      def self.has_git_lfs
+        return false unless is_git_repo
+        `git config --get-regex lfs`.length > 0
+      end
+    end
+  end
+end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -1,0 +1,37 @@
+require 'tmpdir'
+require_relative './spec_helper'
+
+describe Fastlane::Helper::GitHelper do
+  before(:each) do
+    @path = Dir.mktmpdir
+    @tmp = Dir.pwd
+    Dir.chdir(@path)
+  end
+
+  after(:each) do
+    Dir.chdir(@tmp)
+    FileUtils.rm_rf(@path)
+  end
+
+  it 'can detect a missing git repository' do
+    expect(Fastlane::Helper::GitHelper.is_git_repo).to be false
+  end
+
+  it 'can detect a valid git repository' do
+    `git init`
+    expect(Fastlane::Helper::GitHelper.is_git_repo).to be true
+  end
+
+  it 'can detect a repository with Git-lfs enabled' do
+    `git init`
+    `git lfs install`
+    expect(Fastlane::Helper::GitHelper.has_git_lfs).to be true
+  end
+
+  it 'can detect a repository without Git-lfs enabled' do
+    `git init`
+    `git lfs uninstall &>/dev/null`
+    expect(Fastlane::Helper::GitHelper.is_git_repo).to be true
+    expect(Fastlane::Helper::GitHelper.has_git_lfs).to be false
+  end
+end


### PR DESCRIPTION
As discussed [in this thread](https://github.com/woocommerce/woocommerce-ios/pull/1314), this PR adds support for checking the state of a directory for various Git things, including determining:
- Is this directory actually a Git repository?
- Does this Git repository have `git-lfs` enabled?

**To Test**
- Take a look through the code for the test cases. If that looks good, and the tests pass, this should be good to go!