### PR TITLE
Prevent localize_project to fail if there are no changes

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -69,7 +69,7 @@ module Fastlane
         def self.localize_project()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
           Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}*.lproj/Localizable.strings")
-          Action.sh("git commit -m \"Updates strings for localization\"")
+          Action.sh("git diff-index --quiet HEAD || git commit -m \"Updates strings for localization\"")
           Action.sh("git push")
         end
   


### PR DESCRIPTION
This PR adds a small change to `git_helper::localize_project` to fix an issue where the action fails if there are no changes in the strings because it tries to run a `git commin` with no staged changes. 