### PR TITLE
configure_apply: Don't print commands and their output

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -39,7 +39,7 @@ module Fastlane
         original_repo_ref = repo_hash if original_repo_ref.nil?
 
         unless repo_hash == file_hash
-          sh("cd #{repository_path} && git fetch && git checkout #{file_hash}")
+          other_action.sh(command: "cd #{repository_path} && git fetch && git checkout #{file_hash}", log: false)
         end
 
         # Run the provided block
@@ -47,7 +47,7 @@ module Fastlane
       
         ### Restore secrets repo to original branch.  If it was originally in a 
         ### detached HEAD state, we need to use the hash since there's no branch name.
-        sh("cd #{repository_path} && git checkout #{original_repo_ref}")
+        other_action.sh(command: "cd #{repository_path} && git checkout #{original_repo_ref}", log: false)
       end
 
       ### Check with the user whether we should overwrite the file, if it exists


### PR DESCRIPTION
Since we have started running `configure_apply` more regularly on WordPress-iOS (https://github.com/wordpress-mobile/WordPress-iOS/pull/12609), @frosty pointed out that the output is a little noisy.

Here is the output of `bundle exec fastlane run configure_apply` now:

```
[✔] 🚀
[10:48:42]: -----------------------------
[10:48:42]: --- Step: configure_apply ---
[10:48:42]: -----------------------------
[10:48:42]: Applied configuration
[10:48:42]: Result: true
```

If you wish to test this manually, you can run `bundle exec fastlane run configure_apply` on this branch.