### PR TITLE
Build Android artifacts only out of release branches

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -8,6 +8,8 @@ module Fastlane
           UI.user_error!("Can't build beta and final at the same time!")
         end
 
+        Fastlane::Helpers::AndroidGitHelper.check_on_branch("release")
+        
         message = ""
         beta_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version() unless !params[:beta] and !params[:final]
         alpha_version = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version() unless !params[:alpha]


### PR DESCRIPTION
This PR adds a check to the _android build prechecks_ set that assures that the build is run on a `release` branch. 
This will help avoid that release builds are created out of the `develop` branch by mistake and will be especially useful as we start to autoupload artificats to the Play Store. 

## To test
1. Update the `Pluginfile` in your project to make it use this branch. 
2. In your project, checkout the `develop` branch.
3. Run `bundle exec fastlane build_pre_releases` and verify that an error is raised. 
4. In your project, checkout a `relase/xx` branch.
5. Run `bundle exec fastlane build_pre_releases` and verify that the build succeeds. 