### PR TITLE
Add action to create releases on GitHub

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -1,0 +1,73 @@
+require 'fastlane/action'
+require 'date'
+require_relative '../../helper/ghhelper_helper'
+require_relative '../../helper/ios/ios_version_helper'
+require_relative '../../helper/android/android_version_helper'
+module Fastlane
+  module Actions
+    class CreateReleaseAction < Action
+      def self.run(params)
+        repository = params[:repository]
+        version = params[:version]
+        assets = params[:release_assets]
+        release_notes = params[:release_notes_file_path].nil? ? "" : IO.read(params[:release_notes_file_path]) 
+
+        UI.message("Creating draft release #{version} in #{repository}.")
+        # Verify assets
+        assets.each do | file_path |
+          UI.user_error!("Can't find file #{file_path}!") unless File.exist?(file_path)
+        end
+ 
+        Fastlane::Helper::GhhelperHelper.create_release(repository, version, release_notes, assets)
+        UI.message("Done")
+      end
+
+      def self.description
+        "Creates a release and uploads the provided assets"
+      end
+
+      def self.authors
+        ["Lorenzo Mattei"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "Creates a release and uploads the provided assets"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :repository,
+                                        env_name: "GHHELPER_REPOSITORY",
+                                        description: "The remote path of the GH repository on which we work",
+                                        optional: false,
+                                        type: String),
+          FastlaneCore::ConfigItem.new(key: :version,
+                                        env_name: "GHHELPER_CREATE_RELEASE_VERSION",
+                                        description: "The version of the release",
+                                        optional: false,
+                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :release_notes_file_path,
+                                        env_name: "GHHELPER_CREATE_RELEASE_NOTES",
+                                        description: "The path to the file that contains the release notes",
+                                        optional: true,
+                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :release_assets,
+                                        env_name: "GHHELPER_CREATE_RELEASE_ASSETS",
+                                        description: "Assets to upload",
+                                        type: Array,
+                                        optional: false, 
+                                      ),
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ghhelper_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ghhelper_helper.rb
@@ -71,6 +71,13 @@ module Fastlane
         GHClient().create_milestone(repository, newmilestone_number, options)
       end
 
+      def self.create_release(repository, version, release_notes, assets)
+        release = GHClient().create_release(repository, version, { name: version, draft: true, body: release_notes })
+        assets.each do | file_path |
+          GHClient().upload_asset(release[:url], file_path, { content_type: "application/octet-stream"})
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
This PR adds an action to draft a new release on GitHub and upload release notes and some assets.
It can be tested as a part of https://github.com/wordpress-mobile/WordPress-iOS/pull/13503.