### PR TITLE
Fix: move away from deprecated syntax to call other actions

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -47,7 +47,7 @@ module Fastlane
         UI.success "Configuration Secrets are up to date – don't forget to commit your changes to `.configure`."
 
         # Apply the changes that are now in the .configure file
-        ConfigureApplyAction::run
+        other_action.configure_apply
       end
 
       def self.prompt_to_switch_branches


### PR DESCRIPTION
This PR updates the `configure_update` action to call other actions with the proper syntax, instead of a deprecated one. 
This can be tested in https://github.com/wordpress-mobile/WordPress-Android/pull/11630