### PR TITLE
Fix iOS localization

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
@@ -5,6 +5,7 @@ module Fastlane
         UI.message "Updating project localisation..."
   
         require_relative '../../helper/ios/ios_git_helper.rb'
+        other_action.cocoapods()
         Fastlane::Helpers::IosGitHelper.localize_project()
           
         UI.message "Done."

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -69,7 +69,7 @@ module Fastlane
         def self.localize_project()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
           Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}*.lproj/Localizable.strings")
-	        is_repo_clean = `git status --porcelain`.empty?
+          is_repo_clean = `git status --porcelain`.empty?
           if is_repo_clean then
             UI.message("No new strings, skipping commit.")  
           else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -69,12 +69,12 @@ module Fastlane
         def self.localize_project()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
           Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}*.lproj/Localizable.strings")
-	  is_repo_clean = `git status --porcelain`.empty?
+	        is_repo_clean = `git status --porcelain`.empty?
           if is_repo_clean then
-            Action.sh("git diff-index --quiet HEAD || git commit -m \"Updates strings for localization\"")
-            Action.sh("git push origin HEAD")
+            UI.message("No new strings, skipping commit.")  
           else
-            UI.message("No new strings, skipping commit.")
+            Action.sh("git commit -m \"Updates strings for localization\"")
+            Action.sh("git push origin HEAD")
           end        
         end
   


### PR DESCRIPTION
This PR fixes two iOS localization issues: 
- it makes sure that the latest version of the pods is installed before localization.
- it makes sure that `localizable.strings` is committed when there are changes. 

This can be tested in https://github.com/woocommerce/woocommerce-ios/pull/2125