### PR TITLE
Add ios code freeze split

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -1,0 +1,63 @@
+module Fastlane
+    module Actions
+      class IosCheckBetaDepsAction < Action
+        def self.run(params)          
+          require_relative '../../helper/ios/ios_version_helper.rb'
+          require_relative '../../helper/ios/ios_git_helper.rb'
+  
+           beta_pods = []
+           File.open(params[:podfile]).each do | li |
+             beta_pods << li if (li.match('^\s*\t*pod.*beta'))
+           end
+
+          if beta_pods.count == 0
+            UI.message("No beta pods found. You can continue with the code freeze.")
+          else
+            message = "The following pods are still in beta:\n"
+            beta_pods.each do | bpod |
+                message << "#{bpod}\n"
+            end
+            message << "Please update to the released version before continuing with the code freeze."
+          end
+          UI.important(message)
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Runs some prechecks before finalizing a release"
+        end
+  
+        def self.details
+          "Runs some prechecks before finalizing a release"
+        end
+  
+        def self.available_options
+          [
+            FastlaneCore::ConfigItem.new(key: :podfile,
+                                         env_name: "FL_IOS_CHECKBETADEPS_PODFILE",
+                                         description: "Path to the Podfile to analyse",
+                                         is_string: true),
+          ]
+        end
+  
+        def self.output
+          
+        end
+  
+        def self.return_value
+          ""
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -1,0 +1,67 @@
+module Fastlane
+    module Actions
+      class IosCompletecodefreezePrechecksAction < Action
+        def self.run(params)
+          UI.message "Skip confirm: #{params[:skip_confirm]}"
+          
+          require_relative '../../helper/ios/ios_version_helper.rb'
+          require_relative '../../helper/ios/ios_git_helper.rb'
+  
+          UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
+  
+          version = Fastlane::Helpers::IosVersionHelper::get_public_version
+          message = "Completing code freeze for: #{version}\n"
+          if (!params[:skip_confirm])
+            if (!UI.confirm("#{message}Do you want to continue?"))
+              UI.user_error!("Aborted by user request")
+            end
+          else 
+            UI.message(message)
+          end
+  
+          # Check local repo status
+          other_action.ensure_git_status_clean()
+  
+          version
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Runs some prechecks before finalizing a code freeze"
+        end
+  
+        def self.details
+          "Runs some prechecks before finalizing a code freeze"
+        end
+  
+        def self.available_options
+          [
+            FastlaneCore::ConfigItem.new(key: :skip_confirm,
+                                         env_name: "FL_IOS_COMPLETECODEFREEZE_PRECHECKS_SKIPCONFIRM",
+                                         description: "Skips confirmation",
+                                         is_string: false, # true: verifies the input is a string, false: every kind of value
+                                         default_value: false) # the default value if the user didn't provide one
+          ]
+        end
+  
+        def self.output
+          
+        end
+  
+        def self.return_value
+          
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+      end
+    end
+  end


### PR DESCRIPTION
This PR adds two new lanes to iOS that supports the new flow where beta pods are released after the release branch cut. 

This can be tested as a part of:  https://github.com/wordpress-mobile/WordPress-iOS/pull/14107