### PR TITLE
Short release notes  on Android: upload

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -75,8 +75,11 @@ module Fastlane
 
         # Init special handlers
         block_files.each do | key, file_path |
-          if (key == :release_note) 
+          case key
+          when :release_note
             @blocks.push (Fastlane::Helper::ReleaseNoteMetadataBlock.new(key, file_path, release_version))
+          when :release_note_short
+            @blocks.push (Fastlane::Helper::ReleaseNoteShortMetadataBlock.new(key, file_path, release_version))
           else
             @blocks.push (Fastlane::Helper::StandardMetadataBlock.new(key, file_path))
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -134,5 +134,24 @@ module Fastlane
       end
     end
 
+    class ReleaseNoteShortMetadataBlock < ReleaseNoteMetadataBlock     
+
+      def initialize(block_key, content_file_path, release_version)
+        super(block_key, content_file_path, release_version)
+        @rel_note_key = "release_note_short"
+        @release_version = release_version
+        generate_keys(release_version)
+      end
+  
+      def is_handler_for(key)
+        values = key.split('_')
+        key.start_with?(@rel_note_key) && values.length == 4 && (Integer(values[3].sub(/^[0]*/, "")) != nil rescue false)
+      end
+
+    end
   end
+
+
+
 end
+  


### PR DESCRIPTION
This PR adds support for handling a second version of the release notes in the `.po` file. This is meant to be used to upload a shorter version of the release notes as a fallback for the cases where the translation for the original doesn't fit the Play Store limits.

This can be tested as a part of https://github.com/wordpress-mobile/WordPress-Android/pull/12017