### PR TITLE
Short release notes on Android: Download

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -75,8 +75,11 @@ module Fastlane
 
         # Init special handlers
         block_files.each do | key, file_path |
-          if (key == :release_note) 
+          case key
+          when :release_note
             @blocks.push (Fastlane::Helper::ReleaseNoteMetadataBlock.new(key, file_path, release_version))
+          when :release_note_short
+            @blocks.push (Fastlane::Helper::ReleaseNoteShortMetadataBlock.new(key, file_path, release_version))
           else
             @blocks.push (Fastlane::Helper::StandardMetadataBlock.new(key, file_path))
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -134,5 +134,24 @@ module Fastlane
       end
     end
 
+    class ReleaseNoteShortMetadataBlock < ReleaseNoteMetadataBlock     
+
+      def initialize(block_key, content_file_path, release_version)
+        super(block_key, content_file_path, release_version)
+        @rel_note_key = "release_note_short"
+        @release_version = release_version
+        generate_keys(release_version)
+      end
+  
+      def is_handler_for(key)
+        values = key.split('_')
+        key.start_with?(@rel_note_key) && values.length == 4 && (Integer(values[3].sub(/^[0]*/, "")) != nil rescue false)
+      end
+
+    end
   end
+
+
+
 end
+  

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -150,8 +150,5 @@ module Fastlane
 
     end
   end
-
-
-
 end
-  
+

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -58,7 +58,9 @@ module Fastlane
           source = d[0].split(/\u0004/).last
 
           @alternates.each do | file |
+            puts "Data: #{file[0].to_s} - key: #{key}"
             if (file[0].to_s == key)
+              puts "Alternate: #{key}"
               data = file[1]
               msg = is_source ? source : d[1]
               update_key(target_locale, key, file, data, msg)
@@ -71,7 +73,7 @@ module Fastlane
         if (data.key?(:max_size)) && (data[:max_size] != 0) && ((msg.to_s.length - 3) > data[:max_size]) then
           if (data.key?(:alternate_key)) then
             UI.message("#{target_locale} traslation for #{key} exceeds maximum lenght (#{msg.to_s.length}). Switching to the alternate translation.")
-            @alternates[data[:alternate_key]] = {desc: data[:desc], max_size: data[:max_size] }
+            @alternates[data[:alternate_key]] = {desc: data[:desc], max_size: 0 }
           else
             UI.message("Rejecting #{target_locale} traslation for #{key}: translation length: #{msg.to_s.length} - max allowed length: #{data[:max_size]}")
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -72,7 +72,7 @@ module Fastlane
       def update_key(target_locale, key, file, data, msg)
         if (data.key?(:max_size)) && (data[:max_size] != 0) && ((msg.to_s.length - 3) > data[:max_size]) then
           if (data.key?(:alternate_key)) then
-            UI.message("#{target_locale} traslation for #{key} exceeds maximum lenght (#{msg.to_s.length}). Switching to the alternate translation.")
+            UI.message("#{target_locale} translation for #{key} exceeds maximum length (#{msg.to_s.length}). Switching to the alternate translation.")
             @alternates[data[:alternate_key]] = {desc: data[:desc], max_size: 0 }
           else
             UI.message("Rejecting #{target_locale} traslation for #{key}: translation length: #{msg.to_s.length} - max allowed length: #{data[:max_size]}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -10,6 +10,7 @@ module Fastlane
       def initialize(target_folder, target_files)
         @target_folder = target_folder
         @target_files = target_files
+        @alternates = {}
       end
 
       # Downloads data from GlotPress, 
@@ -21,8 +22,10 @@ module Fastlane
           response = Net::HTTP.get_response(URI.parse(response.header['location']))
         end
 
+        @alternates.clear
         loc_data = JSON.parse(response.body) rescue loc_data = nil
-        parse_data(target_locale, loc_data, is_source)       
+        parse_data(target_locale, loc_data, is_source) 
+        reparse_alternates(target_locale, loc_data, is_source) unless (@alternates.length == 0)     
       end
 
       # Parse JSON data and update the local files
@@ -42,13 +45,38 @@ module Fastlane
             if (file[0].to_s == key)
               data = file[1]
               msg = is_source ? source : d[1]
-              if (data.key?(:max_size)) && (data[:max_size] != 0) && ((msg.to_s.length - 3) > data[:max_size]) then
-                UI.message("Rejecting #{target_locale} traslation for #{key}: translation length: #{msg.to_s.length} - max allowed length: #{data[:max_size]}")
-              else
-                save_metadata(target_locale, file[1][:desc], msg)
-              end 
+              update_key(target_locale, key, file, data, msg)
             end
           end
+        end
+      end
+
+      # Parse JSON data and update the local files
+      def reparse_alternates(target_locale, loc_data, is_source)
+        loc_data.each do | d |
+          key = d[0].split(/\u0004/).first
+          source = d[0].split(/\u0004/).last
+
+          @alternates.each do | file |
+            if (file[0].to_s == key)
+              data = file[1]
+              msg = is_source ? source : d[1]
+              update_key(target_locale, key, file, data, msg)
+            end
+          end
+        end
+      end
+
+      def update_key(target_locale, key, file, data, msg)
+        if (data.key?(:max_size)) && (data[:max_size] != 0) && ((msg.to_s.length - 3) > data[:max_size]) then
+          if (data.key?(:alternate_key)) then
+            UI.message("#{target_locale} traslation for #{key} exceeds maximum lenght (#{msg.to_s.length}). Switching to the alternate translation.")
+            @alternates[data[:alternate_key]] = {desc: data[:desc], max_size: data[:max_size] }
+          else
+            UI.message("Rejecting #{target_locale} traslation for #{key}: translation length: #{msg.to_s.length} - max allowed length: #{data[:max_size]}")
+          end
+        else
+          save_metadata(target_locale, file[1][:desc], msg)
         end
       end
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/wordpress-mobile/release-toolkit/pull/122 and adds the download of the shorter release notes version.

This can be tested as a part of https://github.com/wordpress-mobile/WordPress-Android/pull/12019.