### PR TITLE
Create GitHub releases on Android

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -11,6 +11,7 @@ module Fastlane
         version = params[:version]
         assets = params[:release_assets]
         release_notes = params[:release_notes_file_path].nil? ? "" : IO.read(params[:release_notes_file_path]) 
+        prerelease = params[:prerelease]
 
         UI.message("Creating draft release #{version} in #{repository}.")
         # Verify assets
@@ -18,7 +19,7 @@ module Fastlane
           UI.user_error!("Can't find file #{file_path}!") unless File.exist?(file_path)
         end
  
-        Fastlane::Helper::GhhelperHelper.create_release(repository, version, release_notes, assets)
+        Fastlane::Helper::GhhelperHelper.create_release(repository, version, release_notes, assets, prerelease)
         UI.message("Done")
       end
 
@@ -62,6 +63,12 @@ module Fastlane
                                         type: Array,
                                         optional: false, 
                                       ),
+          FastlaneCore::ConfigItem.new(key: :prerelease,
+                                        env_name: "GHHELPER_CREATE_RELEASE_PRERELEASE",
+                                        description: "True if this is a pre-release",
+                                        optional: true,
+                                        default_value: false,
+                                        is_string: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -1,0 +1,91 @@
+require 'fastlane/action'
+
+module Fastlane
+  module Actions
+    class ExtractReleaseNotesForVersionAction < Action
+      def self.run(params)
+        version = params[:version]
+        release_notes_file_path = params[:release_notes_file_path]
+        extracted_notes_file_path = params[:extracted_notes_file_path]
+
+        extracted_notes_file = File.open(extracted_notes_file_path, 'w') unless extracted_notes_file_path.blank?
+
+        extract_notes(release_notes_file_path, version) do | line |
+          extracted_notes_file.nil? ? puts(line) : extracted_notes_file.write(line)
+        end 
+
+        unless extracted_notes_file.nil?
+          extracted_notes_file.close() 
+          check_and_commit_extracted_notes_file(extracted_notes_file_path, version)
+        end 
+      end
+
+      def self.extract_notes(release_notes_file_path, version)
+        state = :discarding
+        File.open(release_notes_file_path).each do | line |
+          case state
+          when :discarding
+            if (line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/)) and (line.strip() == version)
+              state = :evaluating
+            end
+          when :evaluating
+            state = (line.match(/-/)) ? :extracting : :discarding
+          when :extracting
+            if (line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/))
+              state = :discarding
+              return
+            else
+             yield(line)
+            end
+          end
+        end
+      end
+
+      def self.check_and_commit_extracted_notes_file(file_path, version)
+        Action.sh("git add #{file_path}")
+        Action.sh("git diff-index --quiet HEAD || git commit -m \"Update draft release notes for #{version}.\"")
+      end
+
+      def self.description
+        "Extract the release notes for a specific version"
+      end
+
+      def self.authors
+        ["Lorenzo Mattei"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        # Optional:
+        "Creates a release and uploads the provided assets"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :version,
+                                        env_name: "GHHELPER_EXTRACT_NOTES_VERSION",
+                                        description: "The version of the release",
+                                        optional: false,
+                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :release_notes_file_path,
+                                        env_name: "GHHELPER_EXTRACT_NOTES_FILE_PATH",
+                                        description: "The path to the file that contains the release notes",
+                                        optional: false,
+                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :extracted_notes_file_path,
+                                          env_name: "GHHELPER_EXTRACT_NOTES_EXTRACTED_FILE_PATH",
+                                          description: "The path to the file that will contain the extracted release notes",
+                                          optional: true,
+                                          is_string: true),
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ghhelper_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ghhelper_helper.rb
@@ -71,8 +71,8 @@ module Fastlane
         GHClient().create_milestone(repository, newmilestone_number, options)
       end
 
-      def self.create_release(repository, version, release_notes, assets)
-        release = GHClient().create_release(repository, version, { name: version, draft: true, body: release_notes })
+      def self.create_release(repository, version, release_notes, assets, prerelease)
+        release = GHClient().create_release(repository, version, { name: version, draft: true, prerelease: prerelease, body: release_notes })
         assets.each do | file_path |
           GHClient().upload_asset(release[:url], file_path, { content_type: "application/octet-stream"})
         end


### PR DESCRIPTION
On Android we create pre-releases on GitHub with the related .apk file on every beta release. 

This PR tweaks the GitHub release creation in order to add an option to create pre-releases and add a new lane to extract the draft release notes so that they can be attached to the pre-releases.

It can be tested as a part of https://github.com/woocommerce/woocommerce-android/pull/2573.