### PR TITLE
Fix/error message on metadata download

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -70,12 +70,13 @@ module Fastlane
       end
 
       def update_key(target_locale, key, file, data, msg)
-        if (data.key?(:max_size)) && (data[:max_size] != 0) && ((msg.to_s.length - 3) > data[:max_size]) then
+        message_len = msg.to_s.length - 3 
+        if (data.key?(:max_size)) && (data[:max_size] != 0) && ((message_len) > data[:max_size]) then
           if (data.key?(:alternate_key)) then
-            UI.message("#{target_locale} translation for #{key} exceeds maximum length (#{msg.to_s.length}). Switching to the alternate translation.")
+            UI.message("#{target_locale} translation for #{key} exceeds maximum length (#{message_len}). Switching to the alternate translation.")
             @alternates[data[:alternate_key]] = {desc: data[:desc], max_size: 0 }
           else
-            UI.message("Rejecting #{target_locale} traslation for #{key}: translation length: #{msg.to_s.length} - max allowed length: #{data[:max_size]}")
+            UI.message("Rejecting #{target_locale} traslation for #{key}: translation length: #{message_len} - max allowed length: #{data[:max_size]}")
           end
         else
           save_metadata(target_locale, file[1][:desc], msg)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -70,7 +70,7 @@ module Fastlane
       end
 
       def update_key(target_locale, key, file, data, msg)
-        message_len = msg.to_s.length - 3 
+        message_len = msg.to_s.length - 4 # Don't count JSON delimiters.  
         if (data.key?(:max_size)) && (data[:max_size] != 0) && ((message_len) > data[:max_size]) then
           if (data.key?(:alternate_key)) then
             UI.message("#{target_locale} translation for #{key} exceeds maximum length (#{message_len}). Switching to the alternate translation.")


### PR DESCRIPTION
This PR fixes two issues in the Android metadata download action:

- the number of actual characters in the string is miscalculated. The string is JSON formatted, so `[""]` has to be removed by the char count. 
- the error message for strings that are too long doesn't show the actual count, but the total number of characters included the JSON delimiters. 