### PR TITLE
Fix: typos in fastlane's close_milestone_action description

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -19,7 +19,7 @@ module Fastlane
       end
 
       def self.description
-        "Creates a new milestone for the project"
+        "Closes an existing milestone in the project"
       end
 
       def self.authors
@@ -32,7 +32,7 @@ module Fastlane
 
       def self.details
         # Optional:
-        "Creates a new milestone for the project"
+        "Closes an existing milestone in the project"
       end
 
       def self.available_options
@@ -43,7 +43,7 @@ module Fastlane
                                    optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :milestone,
-                                        env_name: "GHHELPER_MILESTORE",
+                                        env_name: "GHHELPER_MILESTONE",
                                      description: "The GitHub milestone",
                                         optional: false,
                                             type: String),


### PR DESCRIPTION
Found some copy/paste in description and a typo in ENV var.

Not sure if you want to actually fix the typo in ENV var because that would break the scripts of anyone depending on that env var though.