### PR TITLE
[Internal] Fix: cache issue in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - restore_cache:
           name: Restore Homebrew + Ruby Dependencies
           keys:
-            - brew-dependencies-{{ checksum ".circleci/.brewfile" }}-{{ checksum "Gemfile.lock" }}
+            - &cache_key brew-dependencies-{{ checksum ".circleci/.brewfile" }}-{{ checksum "Gemfile.lock" }}
 
       - run:
           name: Install Homebrew dependencies, if neeeded
@@ -30,7 +30,7 @@ jobs:
 
       - save_cache:
           name: Cache Homebrew + Ruby Dependencies
-          key: brew-dependencies-{{ checksum ".circleci/.brewfile" }}
+          key: *cache_key
           paths:
             - vendor/
             - /usr/local/Cellar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,4 +322,4 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
This fixes #139 : caching issue with the CircleCI config

# Why?

The keys used to save and restore the cache on CircleCI were not matching

# How?

Use YAML anchors and references to ensure the keys will always match (as we'll reference)

# Testing

While this PR is in draft state:
* push a dummy change to the Gemfile.lock
* Let the CI run in order to generate a new cache
* push a dummy change on a dummy file other than `Gemfile.lock` or `Brewfile`
* Let the CI run and check that it is re-using the previous cache
* Revert the 2 dummy changes
* Undraft the PR
