### PR TITLE
Fix Android build on CI

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -8,7 +8,7 @@ module Fastlane
           UI.user_error!("Can't build beta and final at the same time!")
         end
 
-        Fastlane::Helpers::AndroidGitHelper.check_on_branch("release")
+        Fastlane::Helpers::AndroidGitHelper.check_on_branch("release") unless other_action.is_ci()
         
         message = ""
         beta_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version() unless !params[:beta] and !params[:final]
@@ -31,7 +31,7 @@ module Fastlane
         end
 
         # Check local repo status
-        other_action.ensure_git_status_clean()
+        other_action.ensure_git_status_clean() unless other_action.is_ci()
       end
 
       #####################################################


### PR DESCRIPTION
This PR disables:

- The branch name check on CI. Since the build is started on tags, there's less risk of building something unwanted. Also, due to the way the CI does the checkouts on tags (shallow checkout on the tag itself, not the branch), the branch name is not actually available on CI. We could get it pulling the entire repository and verifying that the tagged commit is on a release branch, but it adds time on CI (pulling the repo can be quite slow) and I don't think it adds a lot of value on CI.
- The git status clean check on CI. We use some temp files on CI to handle the cache, some notification messages, etc. They don't impact the build at all, but due to the way automatic cache works on CircleCI, they have to stay inside the project folder, so the project is technically "dirty" for Git. Since CI always starts from a clean container, we can disable the check.

This can be tested as a part of https://github.com/woocommerce/woocommerce-android/pull/2613