### PR TITLE
Don't update Android release_notes_short if the source file is empty

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -148,6 +148,9 @@ module Fastlane
         key.start_with?(@rel_note_key) && values.length == 4 && (Integer(values[3].sub(/^[0]*/, "")) != nil rescue false)
       end
 
+      def generate_block(fw)
+        super(fw) unless File.zero?(@content_file_path)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR tweaks the action that updates the PO file for Android metadata strings in order to omit the `release_notes_short` key update if the source file is empty. 

This can be tested as a part of https://github.com/wordpress-mobile/WordPress-Android/pull/12452