### PR TITLE
Replace deprecated constant of RMagick

### DIFF
--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -54,5 +54,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rubocop-require_tools', '~> 0.1.2')
   spec.add_development_dependency('simplecov', '~> 0.16.1')
   spec.add_development_dependency('fastlane', '~> 2')
-  spec.add_development_dependency('rmagick', '~> 2.15')
+  spec.add_development_dependency('rmagick', '~> 4.1')
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -292,7 +292,7 @@ module Fastlane
       #
       # @return [Magick::Image] The masked image
       def mask_image(image, mask, offset_x = 0, offset_y = 0)
-          image.composite(mask, offset_x, offset_y, CopyOpacityCompositeOp)
+          image.composite(mask, offset_x, offset_y, CopyAlphaCompositeOp)
       end
 
       # resize_image


### PR DESCRIPTION
This PRs replaces a deprecated constant of RMagick we use in our `promo_screenshots` action in order to be able to update RMagick to a version compatible with imagemagick 7

## Issue Context

Our `promo_screenshots_helper` code – used by the `fastlane create_promo_screenshots` lane in WPAndroid – relies on `RMagick 3.2.x` and currently uses a now-deprecated constant `CopyOpacityCompositeOp`.

The issue is, `RMagick` depends on `imagemagick`, but the latest version of `imagemagick` installed by `brew install` is imagemagick 7, which [the `RMagick` version 3.2.x we're currently using isn't compatible with](https://github.com/rmagick/rmagick/issues/256).

This means I'll need to update `RMagick` to `~> 4.1` for it to be able to work with imagemagick 7 (and with anyone doing a fresh `brew install imagemagic` on a Mac today), but in `RMagick 4.x` [that deprecated `CopyOpacityCompositeOp` constant got removed](https://github.com/rmagick/rmagick/pull/766/files#diff-44b17c82521848b51927db3120845c8fL11-L12) and doesn't exist anymore.

## Fix

The fix is simply to use the new name of that constant in our code, namely `CopyAlphaCompositeOp`, instead of the old, deprecated `CopyOpacityCompositeOp` constant name.

## Testing the change

I wasn't able to test/validate if that change would still make the release-toolkit work with people having imagemagick `< 7` – since I can only install imagemagick 7 on my machine – so it would be worth having someone with imagemagick 6 checking that PR against it.

To my understanding of the code of rmagick, it seems that the `CopyAlphaCompositeOp` constant (new name) was already present in rmagick 3.2.x (as the old name was deprecated) so I _think_ that this change will still work with other projects using `rmagick ~> 3.2` and imagemagick 6, but was unable to test it myself so it would be helpful if someone with imagemagick 6 could test that.

## PR Dependency

This PR is required prior to being able to merge https://github.com/wordpress-mobile/WordPress-Android/pull/12660