### PR TITLE
Rename HockeyApp to App Center

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,13 +50,14 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    codecov (0.1.15)
+    codecov (0.2.6)
+      colorize
       json
       simplecov
-      url
     coderay (1.1.2)
     colored (1.2)
     colored2 (3.1.2)
+    colorize (0.8.1)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
     concurrent-ruby (1.1.7)
@@ -80,7 +81,7 @@ GEM
     diff-lcs (1.3)
     diffy (3.4.0)
     digest-crc (0.5.1)
-    docile (1.3.1)
+    docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
@@ -173,7 +174,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     jmespath (1.4.0)
-    json (2.3.0)
+    json (2.3.1)
     jsonlint (0.3.0)
       oj (~> 3)
       optimist (~> 3)
@@ -290,7 +291,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.6.1)
-    url (0.3.2)
     word_wrap (1.0.0)
     xcodeproj (1.16.0)
       CFPropertyList (>= 2.3.3, < 4.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -5,8 +5,8 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper.rb'
 
         message = ""
-        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_internal_version()} and uploading to HockeyApp\n" unless !params[:internal]
-        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_build_version()} and uploading to HockeyApp\n" unless !params[:internal_on_single_version]
+        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_internal_version()} and uploading to App Center\n" unless !params[:internal]
+        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_build_version()} and uploading to App Center\n" unless !params[:internal_on_single_version]
         message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
 
         if (!params[:skip_confirm])


### PR DESCRIPTION
Noticed this while running the `build_and_upload_release` lane for the Simplenote iOS 4.22.1 hotfix.