### PR TITLE
Auto-increment build number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source('https://rubygems.org')
 gemspec
 gem 'codecov', :require => false, :group => :test
 gem "danger", "~> 8.0"
-gem "bigdecimal", "~> 1.4"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source('https://rubygems.org')
 gemspec
 gem 'codecov', :require => false, :group => :test
 gem "danger", "~> 8.0"
+gem "bigdecimal", "~> 1.4"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     aws-sigv4 (1.1.4)
       aws-eventstream (~> 1.0, >= 1.0.2)
     babosa (1.0.3)
+    bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.0.3)
     claide-plugins (0.9.2)
@@ -307,6 +308,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal (~> 1.4)
   bundler (>= 1.17)
   codecov
   danger (~> 8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.9.13)
       activesupport (~> 4)
+      bigdecimal (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
@@ -308,7 +309,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bigdecimal (~> 1.4)
   bundler (>= 1.17)
   codecov
   danger (~> 8.0)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -44,6 +44,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency('parallel', '~> 1.14')
   spec.add_dependency('chroma', '0.2.0')
   spec.add_dependency('activesupport', '~> 4')
+  # Some of the upstream code uses `BigDecimal.new` which version 2.0 of the
+  # `bigdecimal` gem removed. Until we'll find the time to identify the
+  # dependencies and see if we can move them to something compatible with
+  # modern `bigdecimal`, let's constrain the gem to a version still supporting
+  # `.new` but which warns about it deprecation.
+  spec.add_dependency('bigdecimal', '~> 1.4')
 
   spec.add_development_dependency('pry', '~> 0.12.2')
   spec.add_development_dependency('bundler', '>= 1.17')


### PR DESCRIPTION
The version scheme on Simplenote MacOS has been historically different from the one on the other apps where `CFBundleVersion` is set with a stripped string without dots.  

In order to make the app compatible with our standard tooling, @mokagio added a `BUILD_NUMBER` field in `Version.public.xcconfig` and switched `CFBundleVersion` to it.

This PR updates the iOSVersionHelper to bump `BUILD_NUMBER` when it's present in the `xcconfig` file.

This can be tested as a part of https://github.com/Automattic/simplenote-macos/pull/657