### PR TITLE
Fix/android strings import attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.9.13)
       activesupport (~> 4)
+      bigdecimal (~> 1.4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -44,6 +44,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency('parallel', '~> 1.14')
   spec.add_dependency('chroma', '0.2.0')
   spec.add_dependency('activesupport', '~> 4')
+  # Some of the upstream code uses `BigDecimal.new` which version 2.0 of the
+  # `bigdecimal` gem removed. Until we'll find the time to identify the
+  # dependencies and see if we can move them to something compatible with
+  # modern `bigdecimal`, let's constrain the gem to a version still supporting
+  # `.new` but which warns about it deprecation.
+  spec.add_dependency('bigdecimal', '~> 1.4')
 
   spec.add_development_dependency('pry', '~> 0.12.2')
   spec.add_development_dependency('bundler', '>= 1.17')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android_localize_helper.rb
@@ -41,22 +41,32 @@ module Fastlane
         return :skipped if skip_string_by_exclusion_list(library, string_name)
       
         # Search for the string in the main file
+        result = :added
         main_strings.xpath('//string').each do | this_string | 
           if (this_string.attr("name") == string_name) then
             # Skip if the string has the content_override tag
             return :skipped if skip_string_by_tag(this_string)
             
-            # Update if needed
-            (if (this_string.content == string_content) then return :found else this_string.content = string_content ; return :updated end)   
+            # If nodes are equivalent, skip
+            return :found if (string_line =~ this_string) 
+            
+            # The string needs an update
+            result = :updated
+            if (this_string.attr("tools:ignore").nil?) 
+              # It can be updated, so remove the current one and move ahead
+              this_string.remove 
+              break 
+            else
+              # It has the tools:ignore flag, so update the content without touching the other attributes
+              this_string.content = string_content
+              return result
+            end 
           end
         end
       
-        # String not found and not in the exclusion list: add to the main file
-        new_element = Nokogiri::XML::Node.new "string", main_strings
-        new_element['name'] = string_name
-        new_element.content = string_content
-        main_strings.xpath('//string').last().add_next_sibling("\n#{" " * 4}#{new_element.to_xml()}")
-        return :added
+        # String not found, or removed because needing update and not in the exclusion list: add to the main file
+        main_strings.xpath('//string').last().add_next_sibling("\n#{" " * 4}#{string_line.to_xml()}")
+        return result
       end
 
       # Verify a string
@@ -167,5 +177,27 @@ module Fastlane
         end
       end
     end
+  end
+end
+
+class Nokogiri::XML::Node
+  # Return true if this node is content-equivalent to other, false otherwise
+  def =~(other)
+    return true if self == other
+    return false unless name == other.name
+    stype = node_type; otype = other.node_type
+    return false unless stype == otype
+    sa = attributes; oa = other.attributes
+    return false unless sa.length == oa.length
+    sa = sa.sort.map{ |n,a| [n,a.value,a.namespace && a.namespace.href] }
+    oa = oa.sort.map{ |n,a| [n,a.value,a.namespace && a.namespace.href] }
+    return false unless sa == oa
+    skids = children; okids = other.children
+    return false unless skids.length == okids.length
+    return false if stype == TEXT_NODE && (content != other.content)
+    sns = namespace; ons = other.namespace
+    return false if !sns ^ !ons
+    return false if sns && (sns.href != ons.href)
+    skids.to_enum.with_index.all?{ |ski,i| ski =~ okids[i] }
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android_localize_helper.rb
@@ -65,7 +65,7 @@ module Fastlane
         end
       
         # String not found, or removed because needing update and not in the exclusion list: add to the main file
-        main_strings.xpath('//string').last().add_next_sibling("\n#{" " * 4}#{string_line.to_xml()}")
+        main_strings.xpath('//string').last().add_next_sibling("\n#{" " * 4}#{string_line.to_xml().strip}")
         return result
       end
 
@@ -180,6 +180,8 @@ module Fastlane
   end
 end
 
+# Source: https://stackoverflow.com/questions/7825258/determine-if-two-nokogiri-nodes-are-equivalent?rq=1
+# There may be better solutions now that Ruby supports canonicalization.
 class Nokogiri::XML::Node
   # Return true if this node is content-equivalent to other, false otherwise
   def =~(other)


### PR DESCRIPTION
This PR fixes an issue with Android strings import from libraries where the attributes are not imported to the main `strings.xml`.

This PR updates `android_localize_helper` so that: 
- when a string is imported, all the attributes are brought in. 
- on updates, all the attributes are considered. 
- if the target string has the `tools:ignore` attribute, only the string content is updated and the attributes are not.

This PR can be tested as a part of https://github.com/wordpress-mobile/WordPress-Android/pull/12825.
