### PR TITLE
Introduce iOS Action to fetch Store App Sizes

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -102,8 +102,7 @@ module Fastlane
         end
   
         def self.return_value
-          # If you method provides a return value, you can describe here what it does
-          "Return the public version of the app"
+          "Return a Hash containing the details of download and install app size, for various device models, all that for each requested version of the app"
         end
   
         def self.authors

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -1,0 +1,120 @@
+require_relative '../../helper/ios/ios_adc_app_sizes_helper.rb'
+
+module Fastlane
+    module Actions
+      class IosGetStoreAppSizesAction < Action
+        Helper = Fastlane::Helpers::IosADCAppSizesHelper
+
+        def self.run(params)
+          app_sizes = Helper::get_adc_sizes(
+            adc_user: params[:adc_user],
+            adc_team: params[:adc_team],
+            bundle_id: params[:bundle_id],
+            only_version: params[:version],
+            limit: params[:limit]
+          )
+
+          devices = params[:devices]
+
+          case params[:format]
+          when 'csv'
+            csv = Helper::format_csv(app_sizes, devices: devices)
+            UI.message "Result (CSV)\n\n#{csv}\n"
+          when 'markdown'
+            tables = Helper::format_markdown(app_sizes, devices: devices)
+            tables.each do |table|
+              UI.message "Result (Markdown)\n\n#{table}\n"
+            end
+          end
+
+          return app_sizes
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Gets the size of the app as reported in Apple Developer Portal for recent versions"
+        end
+  
+        def self.details
+          "Gets the download + installed size of the app from the Apple Developer Portail for various app versions release to AppStore and various device types"
+        end
+  
+        def self.available_options
+          [
+            FastlaneCore::ConfigItem.new(
+              key: :adc_user,
+              env_name: "FL_IOS_STOREAPPSIZES_USER",
+              description: "The ADC user to use to log into ADC",
+              type: String
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :adc_team,
+              env_name: "FL_IOS_STOREAPPSIZES_TEAM",
+              description: "The ADC team name to use to log into ADC",
+              type: String,
+              optional: true,
+              default_value: "Automattic, Inc."
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :bundle_id,
+              env_name: "FL_IOS_STOREAPPSIZES_BUNDLEID",
+              description: "The bundleID of the app to retrieve sizes from",
+              type: String
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :version,
+              env_name: "FL_IOS_STOREAPPSIZES_VERSION",
+              description: "The version to retrive the data for. Keep nil to retrieve data for all the last {limit} versions",
+              type: String,
+              optional: true
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :limit,
+              env_name: "FL_IOS_STOREAPPSIZES_LIMIT",
+              description: "The maximum number of past versions to retrieve information from",
+              type: Integer,
+              optional: true,
+              default_value: 10
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :devices,
+              env_name: "FL_IOS_STOREAPPSIZES_DEVICES",
+              description: "The list of devices to print the app size for. If nil, will print data for all device types returned by ADC",
+              type: Array,
+              optional: true
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :format,
+              env_name: "FL_IOS_STOREAPPSIZES_FORMAT",
+              description: "The output format used to print the result. Can be one of 'csv' or 'markdown', or nil to print nothing (raw data will always be available as the the action's return value)",
+              type: String,
+              optional: true,
+            ),
+          ]
+        end
+  
+        def self.output
+          # Define the shared values you are going to provide
+          
+        end
+  
+        def self.return_value
+          # If you method provides a return value, you can describe here what it does
+          "Return the public version of the app"
+        end
+  
+        def self.authors
+          # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+          ["AliSoftware"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+      end
+    end
+  end
+  

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
@@ -1,0 +1,74 @@
+require 'spaceship'
+
+module Fastlane
+    module Helpers
+      module IosADCAppSizesHelper
+        DEFAULT_DEVICES = ["Universal", "iPhone 8", "iPhone X"]
+
+        # Fetch the App Sizes stats from ADC
+        #
+        # @return [Array<Hash>] app build details, one entry per app version found
+        #         Each entry is a hash with keys `cfBundleVersion` and `sizesInBytes`.
+        #         Value for key `sizeInBytes` is itself a Hash with one entry per device name (including special name "Universal")
+        #         whose value is a Hash with keys {'compressed', 'uncompressed'}
+        #
+        def self.get_adc_sizes(adc_user:, adc_team: 'Automattic, Inc.', bundle_id:, only_version: nil, limit: 10)
+          UI.message "Connecting to ADC..."
+          Spaceship::ConnectAPI.login(adc_user, team_name: adc_team)
+          app = Spaceship::ConnectAPI::App.find(bundle_id)
+
+          UI.message "Fetching the list of versions..."
+          versions = app.app_store_versions.select { |v| v.version_string == only_version && !v.build.nil? }
+          if versions.empty?
+            versions = app.get_app_store_versions.reject { |v| v.build.nil? }
+          end
+          UI.message "Found #{versions.count} versions." + (limit == 0 ? "" : " Limiting to last #{limit}")
+          versions = versions.first(limit) unless limit == 0
+
+          UI.message "Fetching App Sizes..."
+
+          builds_details = versions.each_with_index.map do |v, idx|
+            print "Fetching info for: #{v.version_string.rjust(8)} (#{v.build.version.rjust(11)}) [#{idx.to_s.rjust(3)}/#{versions.count}]\r"
+            Spaceship::Tunes.client.build_details(app_id: app.id, train: v.version_string, build_number: v.build.version, platform: 'ios') rescue nil
+          end.compact.reverse
+          print(" " * 55 + "\n")
+
+          builds_details
+        end
+
+        def self.sz(bytes)
+          (bytes.to_f / (1024*1024)).round(1)
+        end
+
+        def self.sz_mb(bytes)
+          sz(bytes).to_s.rjust(5) + " MB"
+        end
+
+        def self.format_csv(app_sizes, devices: nil)
+          devices = DEFAULT_DEVICES if devices.nil? || devices.empty?
+          csv = "Version\t" + devices.join("\t") + "\n"
+          app_sizes.each do |details|
+            build_number = details['cfBundleVersion']
+            sizes = details['sizesInBytes'].select { |name, _| devices.include?(name) }
+            csv += "#{build_number}\t" + devices.map { |d| sz(sizes[d]['compressed']) }.join("\t") + "\n"
+          end
+          csv
+        end
+
+        def self.format_markdown(app_sizes, devices: nil)
+          devices = DEFAULT_DEVICES if devices.nil? || devices.empty?
+          app_sizes.map do |details|
+            build_number = details['cfBundleVersion']
+            sizes = details['sizesInBytes'].select { |name, _| devices.include?(name) }
+            col_size = devices.map(&:length).max
+            table  = "| #{build_number.ljust(col_size)} | Download | Install  |\n"
+            table += "|:#{'-' * col_size}-|---------:|---------:|\n"
+            sizes.each do |(device_name, sizes)|
+              table += "| #{device_name.ljust(col_size)} | #{sz_mb(sizes['compressed'])} | #{sz_mb(sizes['uncompressed'])} |\n"
+            end
+            table
+          end
+        end
+      end
+    end
+end


### PR DESCRIPTION
## Context

This adds a new action to retrieve the Download and Install App Sizes (Universal + Thinned size for common devices) for iOS from the Apple Developer Portail – see pbMoDN-1o0-p2#comment-2800

_(Note: I tried to create a similar action for Android but wasn't able to find a way to fetch such data via API from the PlayStore Console)_

## Usage

### Calling it from your Fastfile

* Point your `Pluginfile` to the latest version of `fastlane-plugin-wpmreleasetoolkit` (i.e. point it to this specific branch while this PR is not merged yet)
* Run `bundle install`
* Add a lane to invoke the action, using something like this for example:

```ruby
  lane :app_sizes do
    ios_get_store_app_sizes(
      adc_user: get_required_env('DELIVER_USER'),
      bundle_id: 'org.wordpress',
      format: 'csv'
    )
  end
```

* Run the new lane (`bundle exec fastlane app_sizes`)

### Using the output

* The CSV output format is ideal to then copy/paste the result into your favorite spreadsheet app (Excel, Numbers, Google Spreadsheet…) and create a graph from it
* The Markdown output format is more suited to paste it into a blog post for example.

### Example outputs

<details><summary>Example output when using <tt>format: "csv"</tt></summary>

```
$ be fastlane app_sizes
[✔] 🚀 
/Users/olivier/.gem/ruby/2.6.0/gems/activesupport-4.2.11.1/lib/active_support/core_ext/object/duplicable.rb:111: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
+-----------------------------------+---------+------------------------------------------------------------------------+
|                                                     Used plugins                                                     |
+-----------------------------------+---------+------------------------------------------------------------------------+
| Plugin                            | Version | Action                                                                 |
+-----------------------------------+---------+------------------------------------------------------------------------+
| fastlane-plugin-wpmreleasetoolkit | 0.10.0  | configure_download configure_setup configure_apply configure_update    |
|                                   |         | configure_add_files_to_copy configure_validate ios_build_prechecks     |
|                                   |         | ios_betabuild_prechecks ios_build_preflight ios_localize_project       |
|                                   |         | ios_update_release_notes add_devices_to_provisioning_profiles          |
|                                   |         | ios_current_branch_is_hotfix                                           |
|                                   |         | add_development_certificates_to_provisioning_profiles                  |
|                                   |         | ios_merge_translators_strings ios_hotifx_prechecks ios_tag_build       |
|                                   |         | ios_final_tag ios_finalize_prechecks ios_bump_version_hotfix           |
|                                   |         | ios_check_beta_deps ios_validate_ci_build ios_get_app_version          |
|                                   |         | ios_codefreeze_prechecks ios_update_metadata                           |
|                                   |         | ios_clear_intermediate_tags ios_bump_version_beta                      |
|                                   |         | ios_completecodefreeze_prechecks ios_update_metadata_source            |
|                                   |         | ios_bump_version_release ios_get_store_app_sizes                       |
|                                   |         | extract_release_notes_for_version gp_downloadmetadata create_release   |
|                                   |         | setfrozentag close_milestone promo_screenshots removebranchprotection  |
|                                   |         | gp_update_metadata_source get_prs_list create_new_milestone            |
|                                   |         | setbranchprotection android_completecodefreeze_prechecks               |
|                                   |         | android_betabuild_prechecks android_bump_version_release               |
|                                   |         | android_current_branch_is_hotfix android_build_prechecks               |
|                                   |         | android_bump_version_final_release android_build_preflight             |
|                                   |         | android_get_release_version android_codefreeze_prechecks               |
|                                   |         | android_tag_build android_create_xml_release_notes                     |
|                                   |         | android_hotifx_prechecks an_localize_libs android_bump_version_hotfix  |
|                                   |         | android_update_release_notes android_update_metadata                   |
|                                   |         | an_validate_lib_strings android_get_alpha_version                      |
|                                   |         | android_get_app_version android_merge_translators_strings              |
|                                   |         | android_finalize_prechecks an_update_metadata_source                   |
|                                   |         | android_bump_version_beta                                              |
| fastlane-plugin-sentry            | 1.6.0   | sentry_upload_dsym sentry_set_commits sentry_upload_sourcemap          |
|                                   |         | sentry_finalize_release sentry_upload_file sentry_upload_proguard      |
|                                   |         | sentry_create_release                                                  |
| fastlane-plugin-appcenter         | 1.6.0   | appcenter_fetch_devices appcenter_upload                               |
| fastlane-plugin-test_center       | 3.10.2  | suppressed_tests suppress_tests suppress_tests_from_junit              |
|                                   |         | tests_from_xctestrun quit_core_simulator_service                       |
|                                   |         | collate_test_result_bundles tests_from_junit multi_scan                |
|                                   |         | collate_html_reports collate_junit_reports collate_json_reports        |
|                                   |         | collate_xcresults                                                      |
+-----------------------------------+---------+------------------------------------------------------------------------+

[13:58:01]: ------------------------------
[13:58:01]: --- Step: default_platform ---
[13:58:01]: ------------------------------
[13:58:01]: Driving the lane 'ios app_sizes' 🚀
[13:58:01]: -------------------
[13:58:01]: --- Step: is_ci ---
[13:58:01]: -------------------
[13:58:01]: -----------------------------
[13:58:01]: --- Step: setup_circle_ci ---
[13:58:01]: -----------------------------
[13:58:01]: Not running on CI, skipping CI setup
[13:58:01]: -------------------------------------
[13:58:01]: --- Step: ios_get_store_app_sizes ---
[13:58:01]: -------------------------------------
[13:58:01]: Connecting to ADC...
[13:58:09]: Fetching the list of versions...
[13:58:24]: Found 174 versions. Limiting to last 10
[13:58:24]: Fetching App Sizes...
                                                       
[13:58:31]: Result (CSV)

Version	Universal	iPhone 8	iPhone X
15.1.0.4	112.1	72.9	76.3
15.2.0.5	112.5	73.2	76.6
15.3.0.3	113.0	73.7	77.1
15.4.0.5	113.2	73.9	77.3
15.5.0.3	113.3	74.0	77.3
15.6.0.4	114.2	74.8	78.2
15.7.0.5	114.6	75.3	78.7
15.8.0.2	114.7	75.4	78.8
15.9.0.2	114.8	75.5	78.9
16.0.0.6	108.8	69.4	72.7



+------+-------------------------+-------------+
|               fastlane summary               |
+------+-------------------------+-------------+
| Step | Action                  | Time (in s) |
+------+-------------------------+-------------+
| 1    | default_platform        | 0           |
| 2    | is_ci                   | 0           |
| 3    | setup_circle_ci         | 0           |
| 4    | ios_get_store_app_sizes | 29          |
+------+-------------------------+-------------+

[13:58:31]: fastlane.tools finished successfully 🎉
```
</details>

<details><summary>Example output when using <tt>format: "markdown"</tt></summary>

```
$ be fastlane app_sizes
[✔] 🚀 
/Users/olivier/.gem/ruby/2.6.0/gems/activesupport-4.2.11.1/lib/active_support/core_ext/object/duplicable.rb:111: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
+-----------------------------------+---------+------------------------------------------------------------------------+
|                                                     Used plugins                                                     |
+-----------------------------------+---------+------------------------------------------------------------------------+
| Plugin                            | Version | Action                                                                 |
+-----------------------------------+---------+------------------------------------------------------------------------+
| fastlane-plugin-wpmreleasetoolkit | 0.10.0  | configure_download configure_setup configure_apply configure_update    |
|                                   |         | configure_add_files_to_copy configure_validate ios_build_prechecks     |
|                                   |         | ios_betabuild_prechecks ios_build_preflight ios_localize_project       |
|                                   |         | ios_update_release_notes add_devices_to_provisioning_profiles          |
|                                   |         | ios_current_branch_is_hotfix                                           |
|                                   |         | add_development_certificates_to_provisioning_profiles                  |
|                                   |         | ios_merge_translators_strings ios_hotifx_prechecks ios_tag_build       |
|                                   |         | ios_final_tag ios_finalize_prechecks ios_bump_version_hotfix           |
|                                   |         | ios_check_beta_deps ios_validate_ci_build ios_get_app_version          |
|                                   |         | ios_codefreeze_prechecks ios_update_metadata                           |
|                                   |         | ios_clear_intermediate_tags ios_bump_version_beta                      |
|                                   |         | ios_completecodefreeze_prechecks ios_update_metadata_source            |
|                                   |         | ios_bump_version_release ios_get_store_app_sizes                       |
|                                   |         | extract_release_notes_for_version gp_downloadmetadata create_release   |
|                                   |         | setfrozentag close_milestone promo_screenshots removebranchprotection  |
|                                   |         | gp_update_metadata_source get_prs_list create_new_milestone            |
|                                   |         | setbranchprotection android_completecodefreeze_prechecks               |
|                                   |         | android_betabuild_prechecks android_bump_version_release               |
|                                   |         | android_current_branch_is_hotfix android_build_prechecks               |
|                                   |         | android_bump_version_final_release android_build_preflight             |
|                                   |         | android_get_release_version android_codefreeze_prechecks               |
|                                   |         | android_tag_build android_create_xml_release_notes                     |
|                                   |         | android_hotifx_prechecks an_localize_libs android_bump_version_hotfix  |
|                                   |         | android_update_release_notes android_update_metadata                   |
|                                   |         | an_validate_lib_strings android_get_alpha_version                      |
|                                   |         | android_get_app_version android_merge_translators_strings              |
|                                   |         | android_finalize_prechecks an_update_metadata_source                   |
|                                   |         | android_bump_version_beta                                              |
| fastlane-plugin-sentry            | 1.6.0   | sentry_upload_dsym sentry_set_commits sentry_upload_sourcemap          |
|                                   |         | sentry_finalize_release sentry_upload_file sentry_upload_proguard      |
|                                   |         | sentry_create_release                                                  |
| fastlane-plugin-appcenter         | 1.6.0   | appcenter_fetch_devices appcenter_upload                               |
| fastlane-plugin-test_center       | 3.10.2  | suppressed_tests suppress_tests suppress_tests_from_junit              |
|                                   |         | tests_from_xctestrun quit_core_simulator_service                       |
|                                   |         | collate_test_result_bundles tests_from_junit multi_scan                |
|                                   |         | collate_html_reports collate_junit_reports collate_json_reports        |
|                                   |         | collate_xcresults                                                      |
+-----------------------------------+---------+------------------------------------------------------------------------+

[13:59:21]: ------------------------------
[13:59:21]: --- Step: default_platform ---
[13:59:21]: ------------------------------
[13:59:21]: Driving the lane 'ios app_sizes' 🚀
[13:59:21]: -------------------
[13:59:21]: --- Step: is_ci ---
[13:59:21]: -------------------
[13:59:21]: -----------------------------
[13:59:21]: --- Step: setup_circle_ci ---
[13:59:21]: -----------------------------
[13:59:21]: Not running on CI, skipping CI setup
[13:59:21]: -------------------------------------
[13:59:21]: --- Step: ios_get_store_app_sizes ---
[13:59:21]: -------------------------------------
[13:59:21]: Connecting to ADC...
[13:59:29]: Fetching the list of versions...
[13:59:44]: Found 174 versions. Limiting to last 10
[13:59:44]: Fetching App Sizes...
                                                       
[13:59:52]: Result (Markdown)

| 15.1.0.4  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 112.1 MB | 173.0 MB |
| iPhone 8  |  72.9 MB | 121.5 MB |
| iPhone X  |  76.3 MB | 125.0 MB |


[13:59:52]: Result (Markdown)

| 15.2.0.5  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 112.5 MB | 173.7 MB |
| iPhone 8  |  73.2 MB | 122.3 MB |
| iPhone X  |  76.6 MB | 125.7 MB |


[13:59:52]: Result (Markdown)

| 15.3.0.3  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 113.0 MB | 174.5 MB |
| iPhone 8  |  73.7 MB | 123.0 MB |
| iPhone X  |  77.1 MB | 126.5 MB |


[13:59:52]: Result (Markdown)

| 15.4.0.5  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 113.2 MB | 175.1 MB |
| iPhone 8  |  73.9 MB | 123.7 MB |
| iPhone X  |  77.3 MB | 127.1 MB |


[13:59:52]: Result (Markdown)

| 15.5.0.3  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 113.3 MB | 175.4 MB |
| iPhone 8  |  74.0 MB | 123.9 MB |
| iPhone X  |  77.3 MB | 127.3 MB |


[13:59:52]: Result (Markdown)

| 15.6.0.4  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 114.2 MB | 177.0 MB |
| iPhone 8  |  74.8 MB | 125.5 MB |
| iPhone X  |  78.2 MB | 129.0 MB |


[13:59:52]: Result (Markdown)

| 15.7.0.5  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 114.6 MB | 177.7 MB |
| iPhone 8  |  75.3 MB | 126.2 MB |
| iPhone X  |  78.7 MB | 129.7 MB |


[13:59:52]: Result (Markdown)

| 15.8.0.2  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 114.7 MB | 177.8 MB |
| iPhone 8  |  75.4 MB | 126.4 MB |
| iPhone X  |  78.8 MB | 129.8 MB |


[13:59:52]: Result (Markdown)

| 15.9.0.2  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 114.8 MB | 178.1 MB |
| iPhone 8  |  75.5 MB | 126.6 MB |
| iPhone X  |  78.9 MB | 130.1 MB |


[13:59:52]: Result (Markdown)

| 16.0.0.6  | Download | Install  |
|:----------|---------:|---------:|
| Universal | 108.8 MB | 171.8 MB |
| iPhone 8  |  69.4 MB | 120.0 MB |
| iPhone X  |  72.7 MB | 123.5 MB |



+------+-------------------------+-------------+
|               fastlane summary               |
+------+-------------------------+-------------+
| Step | Action                  | Time (in s) |
+------+-------------------------+-------------+
| 1    | default_platform        | 0           |
| 2    | is_ci                   | 0           |
| 3    | setup_circle_ci         | 0           |
| 4    | ios_get_store_app_sizes | 30          |
+------+-------------------------+-------------+

[13:59:52]: fastlane.tools finished successfully 🎉
```
</details>

Note: If you don't provide a value for `format:` the action won't print anything, but you can still use the action's return value (which will return a ruby `Hash` containing the raw data) to format the output to your liking.