### PR TITLE
Introduce Localization linting action

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -100,6 +100,10 @@ module Fastlane
           # Define the shared values you are going to provide
           
         end
+
+        def self.return_type
+          :hash
+        end
   
         def self.return_value
           "Return a Hash containing the details of download and install app size, for various device models, all that for each requested version of the app"
@@ -111,7 +115,7 @@ module Fastlane
         end
   
         def self.is_supported?(platform)
-          platform == :ios
+          [:ios, :mac].include?(platform)
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -1,0 +1,105 @@
+module Fastlane
+    module Actions
+      class IosLintLocalizationsAction < Action
+        def self.run(params)
+          UI.message "Linting localizations for parameter placeholders consistency..."
+    
+          require_relative '../../helper/ios/ios_l10n_helper.rb'
+          helper = Fastlane::Helpers::IosL10nHelper.new(
+            install_path: resolve_path(params[:install_path]),
+            version: params[:version]
+          )
+          violations = helper.run(
+            input_dir: resolve_path(params[:input_dir]),
+            base_lang: params[:base_lang],
+          )
+        
+          violations.each do |lang, diff|
+            UI.error "Inconsistencies found between '#{params[:base_lang]}' and '#{lang}':\n\n#{diff}\n"
+          end
+
+          violations
+        end
+
+        def self.repo_root
+          `git rev-parse --show-toplevel`.chomp
+        end
+
+        def self.resolve_path(path)
+          if File.relative?(path)
+            File.join(repo_root, path)
+          else
+            path
+          end
+        end
+    
+        #####################################################
+        # @!group Documentation
+        #####################################################
+    
+        def self.description
+          "Lint the different *.lproj/.strings files for different locales and ensure the parameter placeholders are consistent."
+        end
+    
+        def self.details
+          "Compares the translations against a base language to find potential mismatches for the %s/%d/… parameter placeholders between locales."
+        end
+    
+        def self.available_options
+          [
+            FastlaneCore::ConfigItem.new(
+              key: :install_path,
+              env_name: "FL_IOS_LINT_TRANSLATIONS_INSTALL_PATH",
+              description: "The path where to install SwiftGen tooling needed to run the linting process. If a relative path, should be relative to your repo_root",
+              type: String,
+              optional: true,
+              default_value: "vendor/swiftgen/#{Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION}"
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :version,
+              env_name: "FL_IOS_LINT_TRANSLATIONS_SWIFTGEN_VERSION",
+              description: "The version of SwiftGen to install and use for linting",
+              type: String,
+              optional: true,
+              default_value: Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :input_dir,
+              env_name: "FL_IOS_LINT_TRANSLATIONS_INPUT_DIR",
+              description: "The path to the directory containing the .lproj folders to lint, relative to your git repo root",
+              type: String,
+              optional: false
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :base_lang,
+              env_name: "FL_IOS_LINT_TRANSLATIONS_BASE_LANG",
+              description: "The language that should be used as the base language that every other language will be compared against",
+              type: String,
+              optional: true,
+              default_value: Fastlane::Helpers::IosL10nHelper::DEFAULT_BASE_LANG
+            ),
+          ]
+        end
+    
+        def self.output
+          nil
+        end
+    
+        def self.return_type
+          :hash_of_strings
+        end
+
+        def self.return_value
+          "A hash, keyed by language code, whose values are the diff found for said language"
+        end
+    
+        def self.authors
+          ["AliSoftware"]
+        end
+    
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+      end
+    end
+  end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -23,15 +23,13 @@ module Fastlane
         end
 
         def self.repo_root
-          `git rev-parse --show-toplevel`.chomp
+          @repo_root || `git rev-parse --show-toplevel`.chomp
         end
 
+        # If the path is relative, makes the path absolute by resolving it relative to the repository's root.
+        # If the path is already absolute, it will not affect it and return it as-is.
         def self.resolve_path(path)
-          if File.relative?(path)
-            File.join(repo_root, path)
-          else
-            path
-          end
+          File.absolute_path(path, repo_root)
         end
     
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -17,7 +17,9 @@ module Fastlane
           violations.each do |lang, diff|
             UI.error "Inconsistencies found between '#{params[:base_lang]}' and '#{lang}':\n\n#{diff}\n"
           end
-          UI.abort_with_message!('Inconsistencies found during Localization linting. Aborting.') unless violations.empty?
+          if params[:abort_on_violations] && !violations.empty?
+            UI.abort_with_message!('Inconsistencies found during Localization linting. Aborting.')
+          end
           
           violations
         end
@@ -76,6 +78,14 @@ module Fastlane
               type: String,
               optional: true,
               default_value: Fastlane::Helpers::IosL10nHelper::DEFAULT_BASE_LANG
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :abort_on_violations,
+              env_name: "FL_IOS_LINT_TRANSLATIONS_ABORT",
+              description: "Should we abort the rest of the lane with a global error if any violations are found?",
+              optional: true,
+              default_value: true,
+              is_string: false # https://docs.fastlane.tools/advanced/actions/#boolean-parameters
             ),
           ]
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -37,7 +37,7 @@ module Fastlane
         #####################################################
     
         def self.description
-          "Lint the different *.lproj/.strings files for different locales and ensure the parameter placeholders are consistent."
+          "Lint the different *.lproj/.strings files for each locale and ensure the parameter placeholders are consistent."
         end
     
         def self.details
@@ -49,7 +49,7 @@ module Fastlane
             FastlaneCore::ConfigItem.new(
               key: :install_path,
               env_name: "FL_IOS_LINT_TRANSLATIONS_INSTALL_PATH",
-              description: "The path where to install SwiftGen tooling needed to run the linting process. If a relative path, should be relative to your repo_root",
+              description: "The path where to install the SwiftGen tooling needed to run the linting process. If a relative path, should be relative to your repo_root",
               type: String,
               optional: true,
               default_value: "vendor/swiftgen/#{Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION}"
@@ -97,7 +97,7 @@ module Fastlane
         end
     
         def self.is_supported?(platform)
-          platform == :ios
+          [:ios, :mac].include?(platform)
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -17,7 +17,8 @@ module Fastlane
           violations.each do |lang, diff|
             UI.error "Inconsistencies found between '#{params[:base_lang]}' and '#{lang}':\n\n#{diff}\n"
           end
-
+          UI.abort_with_message!('Inconsistencies found during Localization linting. Aborting.') unless violations.empty?
+          
           violations
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -117,7 +117,7 @@ module Fastlane
             'strings' => langs.map do |lang|
               {
                   'inputs' => ["#{lang}.lproj/Localizable.strings"],
-                  'options' => { 'separator' => "____" }, # Choose an unlikely one to avoid creating needlessly complex Stencil Context due to '.' in sentences sued as keys
+                  'options' => { 'separator' => "____" }, # Choose an unlikely one to avoid creating needlessly complex Stencil Context due to '.' in sentences used as keys
                   'outputs' => [{
                       'templatePath' => template_path,
                       'output' => output_filename(lang)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -1,0 +1,146 @@
+require 'yaml'
+require 'tmpdir'
+
+module Fastlane
+    module Helpers
+      class IosL10nHelper
+        SWIFTGEN_VERSION = '6.4.0'
+        DEFAULT_BASE_LANG = 'en'
+        CONFIG_FILE_NAME = 'swiftgen-stringtypes.yml'
+
+        attr_reader :install_path
+        attr_reader :version
+
+        # @param [String] install_path The path to install SwiftGen to. Usually something like "#{PROJECT_DIR}/vendor/swiftgen"
+        def initialize(install_path:, version: SWIFTGEN_VERSION)
+          @install_path = install_path
+          @version = version || SWIFTGEN_VERSION
+        end
+
+        def check_swiftgen_installed
+          return false unless File.exists?(swiftgen_bin)
+          vers_string = `#{swiftgen_bin} --version`
+          # SwiftGen v6.4.0 (Stencil v0.13.1, StencilSwiftKit v2.7.2, SwiftGenKit v6.4.0)
+          return vers_string.include?("SwiftGen v#{version}")
+        rescue
+          return false
+        end
+
+        def install_swiftgen
+          UI.message "Installing SwiftGen #{version} into #{install_path}"
+          Dir.mktmpdir do |tmpdir|
+            zipfile = File.join(tmpdir, "swiftgen-#{version}.zip")
+            Action.sh('curl', '--fail', '--location', '-o', zipfile, "https://github.com/SwiftGen/SwiftGen/releases/download/#{version}/swiftgen-#{version}.zip")
+            extracted_dir = File.join(tmpdir, "swiftgen-#{version}")
+            Action.sh('unzip', zipfile, '-d', extracted_dir)
+
+            FileUtils.rm_rf(install_path) if File.exists?(install_path)
+            FileUtils.mkdir_p(install_path)
+            FileUtils.cp_r("#{extracted_dir}/.", install_path)
+          end
+        end
+
+        def run(input_dir:, base_lang: DEFAULT_BASE_LANG)
+          check_swiftgen_installed || install_swiftgen
+          find_diffs(input_dir: input_dir, base_lang: base_lang)
+        end
+
+        ##################
+
+        private
+        
+        def swiftgen_bin
+          "#{install_path}/bin/swiftgen"
+        end
+
+        def output_filename(lang)
+          "L10nParamsList.#{lang}.txt"
+        end
+        
+        def template_content
+          <<~TEMPLATE
+          {% macro recursiveBlock table item %}
+            {% for string in item.strings %}
+          "{{string.key}}" => [{{string.types|join:","}}]
+            {% endfor %}
+            {% for child in item.children %}
+            {% call recursiveBlock table child %}
+            {% endfor %}
+          {% endmacro %}
+
+          {% for table in tables %}
+          {% call recursiveBlock table.name table.levels %}
+          {% endfor %}
+          TEMPLATE
+        end
+
+        # @return [(String, Array<String>)] A tuple of (config_file_absolute_path, Array<langs>)
+        #
+        def generate_swiftgen_config(input_dir, output_dir)
+          # Create the template file
+          template_path = File.absolute_path(File.join(output_dir, 'strings-types.stencil'))
+          File.write(template_path, template_content)
+
+          # Dynamically create a SwiftGen config which will cover all supported languages
+          langs = Dir.chdir(input_dir) do
+              Dir.glob('*.lproj').map { |dir| File.basename(dir, '.lproj') }
+          end.sort
+      
+          config = {
+            'input_dir' => input_dir,
+            'output_dir' => output_dir,
+            'strings' => langs.map do |lang|
+              {
+                  'inputs' => ["#{lang}.lproj/Localizable.strings"],
+                  'options' => { 'separator' => "____" }, # Choose an unlikely one to avoid creating needlessly complex Stencil Context due to '.' in sentences sued as keys
+                  'outputs' => [{
+                      'templatePath' => template_path,
+                      'output' => output_filename(lang)
+                  }]
+              }
+            end
+          }
+      
+          # Write SwiftGen config file
+          config_file = File.join(output_dir, CONFIG_FILE_NAME)
+          File.write(config_file, config.to_yaml)
+      
+          return [config_file, langs]
+        end
+
+        # Because we use English copy verbatim as key names, some keys are the same just except for the upper/lowercase.
+        # We need to sort the output again because SwiftGen only sort case-insensitively so that means keys that are
+        # the same except case might be in swapped order for different outputs
+        def sort_file_lines!(dir, lang)
+          file = File.join(dir, output_filename(lang))
+          sorted_lines = File.readlines(file).sort
+          File.write(file, sorted_lines.join)
+          return file
+        end
+
+        # @param [String] input_dir The directory where the `.lproj` folders to scan are located
+        # @param [String] base_lang The base language used as source of truth that all other languages will be compared against
+        # @return [Hash<String, String>] A hash of violations, keyed by language code, whose values are the diff result or nil if no diff
+        #
+        def find_diffs(input_dir:, base_lang:)
+          Dir.mktmpdir('a8c-lint-translations-') do |tmpdir|
+            # Run SwiftGen
+            (config_file, langs) = generate_swiftgen_config(input_dir, tmpdir)
+            Action.sh(swiftgen_bin, 'config', 'run', '--config', config_file)
+            
+            # Run diffs
+            base_file = sort_file_lines!(tmpdir, base_lang)
+            langs.delete(base_lang)
+            return Hash[langs.map do |lang|
+              file = sort_file_lines!(tmpdir, lang)
+              diff = `diff -U0 "#{base_file}" "#{file}"`
+              diff.gsub!(/^(---|\+\+\+).*\n/, '')
+              diff.empty? ? nil : [lang, diff]
+              # UI.puts "### '#{lang}' vs '#{base_lang}' base\n\n#{diff}\n" unless diff.empty?
+            end]
+          end
+        end
+
+      end
+    end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -137,7 +137,7 @@ module Fastlane
               diff.gsub!(/^(---|\+\+\+).*\n/, '')
               diff.empty? ? nil : [lang, diff]
               # UI.puts "### '#{lang}' vs '#{base_lang}' base\n\n#{diff}\n" unless diff.empty?
-            end]
+            end.compact]
           end
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -27,6 +27,8 @@ module Fastlane
         def check_swiftgen_installed
           return false unless File.exists?(swiftgen_bin)
           vers_string = `#{swiftgen_bin} --version`
+          # The SwiftGen version string has this format:
+          #
           # SwiftGen v6.4.0 (Stencil v0.13.1, StencilSwiftKit v2.7.2, SwiftGenKit v6.4.0)
           return vers_string.include?("SwiftGen v#{version}")
         rescue
@@ -133,7 +135,7 @@ module Fastlane
           return [config_file, langs]
         end
 
-        # Because we use English copy verbatim as key names, some keys are the same just except for the upper/lowercase.
+        # Because we use English copy verbatim as key names, some keys are the same except for the upper/lowercase.
         # We need to sort the output again because SwiftGen only sort case-insensitively so that means keys that are
         # the same except case might be in swapped order for different outputs
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -11,12 +11,19 @@ module Fastlane
         attr_reader :install_path
         attr_reader :version
 
-        # @param [String] install_path The path to install SwiftGen to. Usually something like "#{PROJECT_DIR}/vendor/swiftgen"
+        # @param [String] install_path The path to install SwiftGen to. Usually something like "#{PROJECT_DIR}/vendor/swiftgen/#{SWIFTGEN_VERSION}".
+        #        It's recommended to provide an absolute path here rather than a relative one, to ensure it's not dependant on where the action is run from.
+        # @param [String] version The version of SwiftGen to use. This will be used both:
+        #        - to check if the current version located in `install_path`, if it already exists, is the expected one
+        #        - to know which version to download if there is not one installed in `install_path` yet
+        #
         def initialize(install_path:, version: SWIFTGEN_VERSION)
           @install_path = install_path
           @version = version || SWIFTGEN_VERSION
         end
 
+        # Check if SwiftGen is installed in the provided `install_path` and if so if the installed version matches the expected `version`
+        #
         def check_swiftgen_installed
           return false unless File.exists?(swiftgen_bin)
           vers_string = `#{swiftgen_bin} --version`
@@ -26,7 +33,11 @@ module Fastlane
           return false
         end
 
-        def install_swiftgen
+        # Download the ZIP of SwiftGen for the requested `version` and install it in the `install_path`
+        #
+        # @warning This action nukes anything at `install_path` – if something already exists – prior to install SwiftGen there
+        #
+        def install_swiftgen!
           UI.message "Installing SwiftGen #{version} into #{install_path}"
           Dir.mktmpdir do |tmpdir|
             zipfile = File.join(tmpdir, "swiftgen-#{version}.zip")
@@ -40,8 +51,15 @@ module Fastlane
           end
         end
 
+        # Install SwiftGen if necessary (if not installed yet with the expected version), then run the checks and returns the violations found, if any
+        #
+        # @param [String] input_dir The path (ideally absolute) to the directory containing the `.lproj` folders to parse
+        # @param [String] base_lang The code name (i.e the basename of one of the `.lproj` folders) of the locale to use as the baseline
+        # @return [Hash<String, String>] A hash whose keys are the language codes (basename of `.lproj` folders) for which violations were found,
+        #         and the values are the output of the `diff` showing these violations.
+        #
         def run(input_dir:, base_lang: DEFAULT_BASE_LANG)
-          check_swiftgen_installed || install_swiftgen
+          check_swiftgen_installed || install_swiftgen!
           find_diffs(input_dir: input_dir, base_lang: base_lang)
         end
 
@@ -49,14 +67,19 @@ module Fastlane
 
         private
         
+        # Path to the swiftgen binary installed at install_path
         def swiftgen_bin
           "#{install_path}/bin/swiftgen"
         end
 
+        # Name to use for the generated files / output files of SwiftGen for each locale. Those files will be generated in the temporary directory to then diff them.
         def output_filename(lang)
           "L10nParamsList.#{lang}.txt"
         end
         
+        # The Stencil template that we want SwiftGen to use to generate the output.
+        # It iterates on every "table" (`.strings` file, in most cases there's only one, `Localizable.strings`),
+        # and for each, iterates on every entry found to print the key and the corresponding types parsed by SwiftGen from the placeholders found in that translation
         def template_content
           <<~TEMPLATE
           {% macro recursiveBlock table item %}
@@ -74,9 +97,11 @@ module Fastlane
           TEMPLATE
         end
 
+        # Create the template file and the config file, in the temp dir, to be used by SwiftGen when parsing the input files.
+        #
         # @return [(String, Array<String>)] A tuple of (config_file_absolute_path, Array<langs>)
         #
-        def generate_swiftgen_config(input_dir, output_dir)
+        def generate_swiftgen_config!(input_dir, output_dir)
           # Create the template file
           template_path = File.absolute_path(File.join(output_dir, 'strings-types.stencil'))
           File.write(template_path, template_content)
@@ -111,6 +136,10 @@ module Fastlane
         # Because we use English copy verbatim as key names, some keys are the same just except for the upper/lowercase.
         # We need to sort the output again because SwiftGen only sort case-insensitively so that means keys that are
         # the same except case might be in swapped order for different outputs
+        #
+        # @param [String] dir The temporary directory in which the file to sort lines for is located
+        # @param [String] lang The code for the locale we need to sort the output lines for
+        #
         def sort_file_lines!(dir, lang)
           file = File.join(dir, output_filename(lang))
           sorted_lines = File.readlines(file).sort
@@ -118,14 +147,18 @@ module Fastlane
           return file
         end
 
+        # Prepares the template and config files, then run SwiftGen, run `diff` on each generated output against the baseline, and returns a Hash of the violations found.
+        #
         # @param [String] input_dir The directory where the `.lproj` folders to scan are located
         # @param [String] base_lang The base language used as source of truth that all other languages will be compared against
-        # @return [Hash<String, String>] A hash of violations, keyed by language code, whose values are the diff result or nil if no diff
+        # @return [Hash<String, String>] A hash of violations, keyed by language code, whose values are the diff output.
+        #
+        # @note The returned Hash contains keys only for locales with violations. Locales parsed but without any violations found will not appear in the resulting hash.
         #
         def find_diffs(input_dir:, base_lang:)
           Dir.mktmpdir('a8c-lint-translations-') do |tmpdir|
-            # Run SwiftGen
-            (config_file, langs) = generate_swiftgen_config(input_dir, tmpdir)
+            # Run SwiftGen 
+            (config_file, langs) = generate_swiftgen_config!(input_dir, tmpdir)
             Action.sh(swiftgen_bin, 'config', 'run', '--config', config_file)
             
             # Run diffs
@@ -136,7 +169,6 @@ module Fastlane
               diff = `diff -U0 "#{base_file}" "#{file}"`
               diff.gsub!(/^(---|\+\+\+).*\n/, '')
               diff.empty? ? nil : [lang, diff]
-              # UI.puts "### '#{lang}' vs '#{base_lang}' base\n\n#{diff}\n" unless diff.empty?
             end.compact]
           end
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -119,7 +119,9 @@ module Fastlane
             'strings' => langs.map do |lang|
               {
                   'inputs' => ["#{lang}.lproj/Localizable.strings"],
-                  'options' => { 'separator' => "____" }, # Choose an unlikely one to avoid creating needlessly complex Stencil Context due to '.' in sentences used as keys
+                  # Choose an unlikely separator (instead of the default '.') to avoid creating needlessly complex Stencil Context nested
+                  # structure just because we have '.' in the English sentences we use (instead of structured reverse-dns notation) for the keys 
+                  'options' => { 'separator' => "____" },
                   'outputs' => [{
                       'templatePath' => template_path,
                       'output' => output_filename(lang)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -169,6 +169,11 @@ module Fastlane
             return Hash[langs.map do |lang|
               file = sort_file_lines!(tmpdir, lang)
               diff = `diff -U0 "#{base_file}" "#{file}"`
+              # Remove the lines starting with `---`/`+++` which contains the file names (which are temp files we don't want to expose in the final diff to users)
+              # Note: We still keep the `@@ from-file-line-numbers to-file-line-numbers @@` lines to help the user know the index of the key to find it faster,
+              #       and also to serve as a clear visual separator between diff entries in the output.
+              #       Those numbers won't be matching the original `.strings` file line numbers because they are line numbers in the SwiftGen-generated intermediate
+              #       file instead, but they can still give an indication at the index in the list of keys at which this difference is located.
               diff.gsub!(/^(---|\+\+\+).*\n/, '')
               diff.empty? ? nil : [lang, diff]
             end.compact]


### PR DESCRIPTION
# Why?

This is part of the task about linting our localized strings files.

_Internal references: [paaHJt-D6-p2] + Step 1 of [paNNhX-am-p2]_

# How?

* This action uses [SwiftGen](https://github.com/SwiftGen/SwiftGen) and a custom template to parse the various `.lproj/*.strings` files in an `input_dir` directory provided to the action.
* The custom template we use generates (in a temporary dir) an output for each locale/lproj folder found, which lists the types (`Int`, `String`, …) of the placeholder parameters (`%d`, `%@`, …) for each key.
* Then the action compares the generated output (containing lines like `{key} => [{type1}, {type2}]` e.g. `"You have %lu hidden WordPress sites." => [Int]`) of each locale to a baseline (by default, the baseline is the output of the `en` locale) to detect which keys expect different `String(format:)` parameters according to the different `%` placeholders found in their translations.

Note: Because SwiftGen already handles the complexity of parsing `String(format:)` format string (e.g. `%3$d`, `%2$.3f` and similar fun placeholder formats), it also supports when different locales uses different parameter orders in the translation and takes that into account.

# Output

For each locale (`.lproj`) where inconsistencies are found, the action prints an error with the `diff`, showing which key differs in the parameters types.

You'll see the parameter types extracted from the english translation (e.g. `[Int, Int]` for a translation that contains twho `%d` or `%li` parameters) then the types extracted for the locale where it found an inconsistency (e.g. `[]` if the translation for that key in that locale forgot to use any placeholders), allowing you to revisit the translation of that key for that locale to fix the inconsistency.

<details><summary>Extract of an example output</summary>

```
Inconsistencies found between 'en' and 'zh-Hant':

@@ -60 +60 @@
-"%li words, %li characters" => [Int,Int]
+"%li words, %li characters" => []
@@ -793,0 +794 @@
+"Great! Could you leave us a nice review?\n\nIt really helps." => []
@@ -846 +847 @@
-"If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." => [String,String]
+"If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." => []
@@ -848 +849 @@
-"If you want a site but don't want any of the posts and pages you have now, our support team can delete your posts, pages, media, and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out." => []
+"If you want a site but don't want any of the posts and pages you have now, our support team can delete your posts, pages, media, and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just cont" => []
@@ -1014 +1015 @@
-"Media uploaded (1 file)" => []
+"Media uploaded (1 file)" => [Int]
@@ -2213 +2214 @@
-"You have %lu hidden WordPress sites." => [Int]
+"You have %lu hidden WordPress sites." => []
```
</details>

# Typical Usage

You will typically add a call to `ios_lint_localizations(input_path: …)` to your `Fastfile` right after you pulled the latest translations from glotpress via the `ios_update_metadata` action.

You should provide it the path (relative to the repo root) to the directory containing all your `.lproj` folders. You can also pass it other options, see `bundle exec fastlane action ios_lint_localizations` for more documentation

For example in https://github.com/wordpress-mobile/WordPress-iOS this would likely look like this:

```diff
  lane :finalize_release do | options |
      ios_finalize_prechecks(options)
-     ios_update_metadata(options) unless ios_current_branch_is_hotfix
-     ios_bump_version_beta() unless ios_current_branch_is_hotfix
+     unless ios_current_branch_is_hotfix
+       ios_update_metadata(options)
+       ios_lint_localizations(input_dir: 'WordPress/Resources')
+       ios_bump_version_beta()
+     end
      ios_final_tag(options)
…
```

# Testing the PR

* Point your `Pluginfile` to the latest version of `fastlane-plugin-wpmreleasetoolkit` (e.g. to this branch until this PR is merged)
* Run `bundle install` to install the latest `wpmreleasetoolkit` which includes this new action
* Create a test lane `lint_l10n` and make it call the `ios_lint_localizations` action, providing it the right `input_path`
* Optionally, you can also add something like `UI.message("Continuing after lint")` at the end of that `lint_l10n` lane, especially to confirm that the message won't be printed (and the lane will abort and stop fastlane) if violations are found, and you will only see the message being printed if there are no violations found.
* Run `bundle exec fastlane lint_l10n`. The first run should install SwiftGen in `vendor/swiftgen/6.4.0`, then tell you if it found any violation in `.strings` files
* Run `bundle exec fastlane lint_l10n` again. The second run should not re-install SwiftGen as it has been already installed, but should output the same violations.

```ruby
lane :lint_l10n do | options |
  ios_lint_localizations(input_dir: 'WordPress/Resources')
  UI.message("Debug: the rest of this lane, like this message, should only execute if there were no violations found.")
end
```

Note: I've mainly tested this with WordPress-iOS in my tests, so it would be nice if testers of this PR could test it with other repos too, to ensure it works everywhere in the various configurations we might have.

# Plan about enabling the action in other repos

The next step will be to make PRs in each repo to call the action (by editing each repo's `Fastfile` to call it like explained above), but those will (1) require this PR to be merged first (2) but also for us to fix the existing violations.

Which is also why I'll only start enabling the call to this action in the various repos (i.e. doing the PRs there) next week, **after** the current release is finalized, so that we have time (before the next code freeze after that) to fix the existing violations.