### PR TITLE
Remove period from generated commit titles

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -41,7 +41,7 @@ module Fastlane
         Action.sh("echo \"#{new_version}\n-----\n \" > #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
         Action.sh("cat #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak >> #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
         Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("git diff-index --quiet HEAD || git commit -m \"Update release notes.\"")
+        Action.sh("git diff-index --quiet HEAD || git commit -m \"Update release notes\"")
         Action.sh("git push origin HEAD")
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -71,7 +71,7 @@ module Fastlane
         Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}*.lproj/*.strings")
         is_repo_clean = `git status --porcelain`.empty?
         if is_repo_clean then
-          UI.message("No new strings, skipping commit.")
+          UI.message("No new strings, skipping commit")
         else
           Action.sh("git commit -m \"Updates strings for localization\"")
           Action.sh("git push origin HEAD")
@@ -84,7 +84,7 @@ module Fastlane
         Action.sh("cat #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak >> #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
         Action.sh("rm #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak")
         Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("git commit -m \"Update release notes.\"")
+        Action.sh("git commit -m \"Update release notes\"")
         Action.sh("git push origin HEAD")
       end
 


### PR DESCRIPTION
Pedantic PR: Trailing punctuation is unnecessary in subject lines.

See:

- https://www.git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines where the example doesn't have trailing punctuation
- https://chris.beams.io/posts/git-commit/#end which makes this convention explicit