### PR TITLE
Fixing glitches in ios l10n linter action

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -12,6 +12,7 @@ module Fastlane
           violations = helper.run(
             input_dir: resolve_path(params[:input_dir]),
             base_lang: params[:base_lang],
+            only_langs: params[:only_langs]
           )
         
           violations.each do |lang, diff|
@@ -78,6 +79,13 @@ module Fastlane
               type: String,
               optional: true,
               default_value: Fastlane::Helpers::IosL10nHelper::DEFAULT_BASE_LANG
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :only_langs,
+              env_name: "FL_IOS_LINT_TRANSLATIONS_ONLY_LANGS",
+              description: "The list of languages to limit the analysis to",
+              type: Array,
+              optional: true
             ),
             FastlaneCore::ConfigItem.new(
               key: :abort_on_violations,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -170,6 +170,9 @@ module Fastlane
             langs.delete(base_lang)
             return Hash[langs.map do |lang|
               file = sort_file_lines!(tmpdir, lang)
+              # If the lang ends up not having any translation at all (e.g. a `.lproj` without any `.strings` file in it but maybe just an storyboard or assets catalog), ignore it
+              next nil if File.size(file) <= 10 && File.readlines(file).all? { |line| line.chomp.length == 0 }
+              # Compute the diff
               diff = `diff -U0 "#{base_file}" "#{file}"`
               # Remove the lines starting with `---`/`+++` which contains the file names (which are temp files we don't want to expose in the final diff to users)
               # Note: We still keep the `@@ from-file-line-numbers to-file-line-numbers @@` lines to help the user know the index of the key to find it faster,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -118,7 +118,7 @@ module Fastlane
             'output_dir' => output_dir,
             'strings' => langs.map do |lang|
               {
-                  'inputs' => ["#{lang}.lproj/Localizable.strings"],
+                  'inputs' => ["#{lang}.lproj"],
                   # Choose an unlikely separator (instead of the default '.') to avoid creating needlessly complex Stencil Context nested
                   # structure just because we have '.' in the English sentences we use (instead of structured reverse-dns notation) for the keys 
                   'options' => { 'separator' => "____" },

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -174,7 +174,10 @@ module Fastlane
             langs.delete(base_lang)
             return Hash[langs.map do |lang|
               file = sort_file_lines!(tmpdir, lang)
-              # If the lang ends up not having any translation at all (e.g. a `.lproj` without any `.strings` file in it but maybe just an storyboard or assets catalog), ignore it
+              # If the lang ends up not having any translation at all (e.g. a `.lproj` without any `.strings` file in it but maybe just a storyboard or assets catalog), ignore it
+              # Note: to check if the file is "almost" empty, i.e. only containing newlines, we only read it if it's small enough (arbitrary max length of 10 bytes) because that
+              # situation typically comes from a template having a couple of newlines at top and bottom between what's usually the content – but is empty in this case – and we don't
+              # want to waste RAM reading a big file of multiple KB for nothing, so considering only files that are "small enough to be candidates for only-newlines files" seems enough.
               next nil if file.nil? || File.size(file) <= 10 && File.readlines(file).all? { |line| line.chomp.length == 0 }
               # Compute the diff
               diff = `diff -U0 "#{base_file}" "#{file}"`


### PR DESCRIPTION
Some edge cases I found when using the linter on WC and WP:
 - `.lproj` folders not containing any .strings file (especially `Base.lproj` in WC)
 - empty diffs due to missing strings file in some translation bundles (for locales where the app strings are not translated at all despite having a lproj, so the runtime will still fallback while we were still trying to compare to empty diff file in the script)

+ Added the ability to apply the linter to only a specific set of language; very useful for debugging and focusing on one locale at a time when I was fixing the existing violations.

Note: we'll need a new release after this merge so I can push my PRs enabling those actions on WPiOS/WCiOS by pointing on the new release