### PR TITLE
L10n Linter: allow retry after locally fixing .strings file

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -10,7 +10,7 @@ module Fastlane
           end
 
           if !violations.empty? && params[:abort_on_violations]
-            UI.abort_with_message!('Inconsistencies found during Localization linting. Aborting.')
+            UI.abort_with_message!(ABORT_MESSAGE)
           end
 
           violations
@@ -39,9 +39,9 @@ module Fastlane
 
         RETRY_MESSAGE = <<~MSG
           Inconsistencies found during Localization linting.
-          You need to fix them before continuing. From this point on, you should:
+          You need to fix them before continuing. From this point on, you should either:
 
-          - Either cancel this lane (reply 'No' below), then work with polyglots in #i18n
+          - Cancel this lane (reply 'No' below), then work with polyglots in #i18n
             to fix those directly in GlotPress – by rejecting the inconsistent
             translations, or by submitting a fixed copy. Rerun the lane when everything
             has been fixed.
@@ -55,9 +55,13 @@ module Fastlane
             This is only a workaround to allow you to submit a build if translators are
             not available to help you fix the issues in GlotPress in time. You will still
             need to let the translators know that they will need to fix those copies
-            at some point before the next build to fix the root issue.
+            at some point before the next build to fix the root of the issue.
 
           Did you fix the `.strings` files locally and want to lint them again?
+        MSG
+
+        ABORT_MESSAGE = <<~MSG
+          Inconsistencies found during Localization linting. Aborting.
         MSG
 
         def self.repo_root

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -2,6 +2,21 @@ module Fastlane
     module Actions
       class IosLintLocalizationsAction < Action
         def self.run(params)
+          violations = {}
+
+          loop do
+            violations = self.run_linter(params)
+            break unless !violations.empty? && params[:allow_retry] && UI.confirm(RETRY_MESSAGE)
+          end
+
+          if !violations.empty? && params[:abort_on_violations]
+            UI.abort_with_message!('Inconsistencies found during Localization linting. Aborting.')
+          end
+
+          violations
+        end
+
+        def self.run_linter(params)
           UI.message "Linting localizations for parameter placeholders consistency..."
     
           require_relative '../../helper/ios/ios_l10n_helper.rb'
@@ -18,12 +33,31 @@ module Fastlane
           violations.each do |lang, diff|
             UI.error "Inconsistencies found between '#{params[:base_lang]}' and '#{lang}':\n\n#{diff}\n"
           end
-          if params[:abort_on_violations] && !violations.empty?
-            UI.abort_with_message!('Inconsistencies found during Localization linting. Aborting.')
-          end
-          
+
           violations
         end
+
+        RETRY_MESSAGE = <<~MSG
+          Inconsistencies found during Localization linting.
+          You need to fix them before continuing. From this point on, you should:
+
+          - Either cancel this lane (reply 'No' below), then work with polyglots in #i18n
+            to fix those directly in GlotPress – by rejecting the inconsistent
+            translations, or by submitting a fixed copy. Then run the lane again.
+
+            This is the recommended way to go, as it will fix the issues at their source.
+
+          - Or manually edit the `Localizable.strings` files to fix the inconsistencies
+            locally, commit them, then reply 'Yes' below to re-lint and validate that all
+            inconsistencies have been fixed locally so you can continue with the build.
+
+            This is only a workaround to allow you to submit a build if translators are
+            not available to help you fix the issues in GlotPress in time. You will still
+            need to let the translators know that they will need to fix those copies
+            at some point before the next build to fix the root issue.
+
+          Did you fix the .strings files locally and want to lint them again?
+        MSG
 
         def self.repo_root
           @repo_root || `git rev-parse --show-toplevel`.chomp
@@ -93,6 +127,14 @@ module Fastlane
               description: "Should we abort the rest of the lane with a global error if any violations are found?",
               optional: true,
               default_value: true,
+              is_string: false # https://docs.fastlane.tools/advanced/actions/#boolean-parameters
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :allow_retry,
+              env_name: "FL_IOS_LINT_TRANSLATIONS_ALLOW_RETRY",
+              description: "If any violations are found, show an interactive prompt allowing the user to manually fix the issues locally and retry the linting",
+              optional: true,
+              default_value: false,
               is_string: false # https://docs.fastlane.tools/advanced/actions/#boolean-parameters
             ),
           ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -43,7 +43,8 @@ module Fastlane
 
           - Either cancel this lane (reply 'No' below), then work with polyglots in #i18n
             to fix those directly in GlotPress – by rejecting the inconsistent
-            translations, or by submitting a fixed copy. Then run the lane again.
+            translations, or by submitting a fixed copy. Rerun the lane when everything
+            has been fixed.
 
             This is the recommended way to go, as it will fix the issues at their source.
 
@@ -56,7 +57,7 @@ module Fastlane
             need to let the translators know that they will need to fix those copies
             at some point before the next build to fix the root issue.
 
-          Did you fix the .strings files locally and want to lint them again?
+          Did you fix the `.strings` files locally and want to lint them again?
         MSG
 
         def self.repo_root


### PR DESCRIPTION
## What is this about?

This PR adds a new option to the `ios_lint_localizations` Fastlane action that allows interactive retry.

This new option, if set to `true`, will give the user the opportunity to manually fix the problematic `.strings` file locally then retry the linter again and again until all the violations are fixed locally. [Ref: paaHJt-1Fn-p2#comment-3524]

_This should not be the recommended course of action – as it's always better to fix the issue at its root (i.e. in GlotPress) and re-run the lane from the start to download the fixed strings from GlotPress – but this mode will still be useful in cases when we can't wait for contributors and polyglots to help us reject or fix the copies in GlotPress and when we need to still go forward with the build immediately even if the issue will only be fixed later in GlotPress._

This escape hatch will allow us to still send a build even if violations are not yet fixed in GlotPress, while ensuring said build won't crash in other locales as we'd at least have fixed those locally even if not yet in GlotPress.

## Possible Configurations

Here's how this new configuration option works in pair with the other, already existing `abort_on_violations` option, when the linter finds violations:

| `allow_retry` | `abort_on_violations` | Behavior |
|---|---|---|
| `false` (default) | `true` (default) | The default. If violations are found, the lane will stop, preventing you to go further. |
| `true` | `true` (default) | If violations are found, let you fix them locally and retry as many times as you want, until you ultimately either  have fixed all the violations in your local `.strings` files of decide to finally abort. |
| `false` (default) | `false` | If violations are found, the action WON'T abort the lane. This can be useful if you want to handle the error case yourself in your `Fastfile`, e.g. to decide what to do, what message to print, etc in case of violations instead of letting the action stop it for you. Or if you want to still allow users to create a build despite the fact that the violations will make the app crash in other locales. |
| `true` | `false` | If violations are found, allow you to locally fix them and retry until they are all ok, or until you stop retrying and ignore them. If you stop retrying, the action WON'T abort the lane, allowing the called to deal with what to do in case of violations |

## To test

* Point your `Pluginfile` to this branch of the release-toolkit
* Ensure you have a problematic string in GlotPress that will get downloaded by the `ios_update_metadata(options)` call in your `Fastfile`. Alternatively, temporarily comment out that `ios_update_metadata(options)` and instead introduce an invalid placeholder in one or more of your local `.strings` files on purpose
* Temporarily comment out the `ios_bump_version_beta()` and `ios_tag_build()` calls from your `new_beta_release` lane and replace them with some logs, e.g. `UI.message("At that point a tag would have been created and a new beta triggered")`
* Update the call to `ios_lint_localizations(…)` in your `Fastfile` to test one of the 4 combinations of `allow_retry` and `abort_on_violations` described in the table above.
* Run the modified  `new_beta_release` lane and check that the behavior matches the one described in the table above
* Redo those steps for all possible 4 combinations of those 2 boolean parameters
* Once you've checked everything, undo the temporary changes to your `new_beta_release` lane

The most important parameter set to test is `ios_lint_localizations(input_dir: …, allow_retry: true)` (which implicitly uses the default value of `abort_on_violations: true`) as it's the call that we will most likely use in all of our `Fastfile`s, both for `new_beta_release` and `finalize_release` lanes, once this PR lands and we create a new tag to point our other repos to it to be able to use this.