### PR TITLE
Update Nokogiri version to solve security issue

### DIFF
--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -34,31 +34,31 @@ Gem::Specification.new do |spec|
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
   spec.add_dependency 'diffy', '~> 3.3'
-  spec.add_dependency 'nokogiri', '>= 1.10.4'
+  spec.add_dependency 'nokogiri', '~> 1.11' # Needed for AndroidLocalizeHelper
   spec.add_dependency 'octokit', '~> 4.18'
   spec.add_dependency 'git', '~> 1.3'
-  spec.add_dependency 'jsonlint'
-  spec.add_dependency('rake', '~> 12.3')
-  spec.add_dependency('rake-compiler', '~> 1.0')
-  spec.add_dependency('progress_bar', '~> 1.3')
-  spec.add_dependency('parallel', '~> 1.14')
-  spec.add_dependency('chroma', '0.2.0')
-  spec.add_dependency('activesupport', '~> 5')
+  spec.add_dependency 'jsonlint', '~> 0.3'
+  spec.add_dependency 'rake', '~> 12.3'
+  spec.add_dependency 'rake-compiler', '~> 1.0'
+  spec.add_dependency 'progress_bar', '~> 1.3'
+  spec.add_dependency 'parallel', '~> 1.14'
+  spec.add_dependency 'chroma', '0.2.0'
+  spec.add_dependency 'activesupport', '~> 5'
   # Some of the upstream code uses `BigDecimal.new` which version 2.0 of the
   # `bigdecimal` gem removed. Until we'll find the time to identify the
   # dependencies and see if we can move them to something compatible with
   # modern `bigdecimal`, let's constrain the gem to a version still supporting
   # `.new` but which warns about it deprecation.
-  spec.add_dependency('bigdecimal', '~> 1.4')
+  spec.add_dependency 'bigdecimal', '~> 1.4'
 
-  spec.add_development_dependency('pry', '~> 0.12.2')
-  spec.add_development_dependency('bundler', '>= 1.17')
-  spec.add_development_dependency('rspec', '~> 3.8')
-  spec.add_development_dependency('rspec_junit_formatter', '~> 0.4.1')
-  spec.add_development_dependency('rubocop', '0.75')
-  spec.add_development_dependency('rubocop-rspec')
-  spec.add_development_dependency('rubocop-require_tools', '~> 0.1.2')
-  spec.add_development_dependency('simplecov', '~> 0.16.1')
-  spec.add_development_dependency('fastlane', '~> 2')
-  spec.add_development_dependency('rmagick', '~> 4.1')
+  spec.add_development_dependency 'pry', '~> 0.12.2'
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
+  spec.add_development_dependency 'rubocop', '0.75'
+  spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'rubocop-require_tools', '~> 0.1.2'
+  spec.add_development_dependency 'simplecov', '~> 0.16.1'
+  spec.add_development_dependency 'fastlane', '~> 2'
+  spec.add_development_dependency 'rmagick', '~> 4.1'
 end


### PR DESCRIPTION
This PR updates our `nokogiri` dependency version in order to solve [this security issue found by Dependabot](https://github.com/woocommerce/woocommerce-ios/security/dependabot/Gemfile.lock/nokogiri/open).

As a bonus, this update also brings the additional benefit of shipping `nokogiri` as precompiled native gems for Linux and MacOS: https://twitter.com/flavorjones/status/1346144159250468866 🎉 

_(The remaining changes to the `gemspec` in this PR are just stylistic to make the code style consistent)_

PS: Immediately after this PR is merged I plan to do a new tag/release of the toolkit and make our iOS apps repos adopt it, since I already need a new release to adopt the linter changes too.