### PR TITLE
Fix/update submodules before build

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_metadata.rb
@@ -9,7 +9,6 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
 
         Fastlane::Helpers::AndroidGitHelper.update_metadata(ENV["validate_translations"])
-        Fastlane::Action::sh("./tools/release-checks.sh")
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -47,6 +47,7 @@ module Fastlane
 
       def self.update_metadata(validate_translation_command)
         Action.sh("./tools/update-translations.sh")
+        Action.sh("git submodule update --init --recursive")
         Action.sh("./gradlew #{validate_translation_command}")
         Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/src/main/res")
         Action.sh("git diff-index --quiet HEAD || git commit -m \"Updates translations\"")


### PR DESCRIPTION
This PR makes two changes to the `android_update_metadata` action: 
- It inits the submodules in the repository before trying to run a build to check the strings. 
- It removes a call to the `release-checks.sh` script. Over the time, all the checks in that script were deprecated or moved to the `release-toolkit` and the only one which was already in place is running lint on the new strings which is actually duplicated in `update_metadata`.

# To Test
This PR can be tested as a part of the [companion PR in WordPress Android](https://github.com/wordpress-mobile/WordPress-Android/pull/13770).