### PR TITLE
Fix update_release_notes to allow pinning comment to top

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -4,11 +4,16 @@ module Fastlane
         def self.run(params)
           UI.message "Updating the release notes..."
   
-          require_relative '../../helper/android/android_git_helper.rb'
           require_relative '../../helper/android/android_version_helper.rb'
+          require_relative '../../helper/release_notes_helper.rb'
+          require_relative '../../helper/git_helper.rb'
+
+          path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
           next_version = Fastlane::Helpers::AndroidVersionHelper.calc_next_release_short_version(params[:new_version])
-          Fastlane::Helpers::AndroidGitHelper.update_release_notes(next_version)
-            
+
+          Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
+          Fastlane::Helper::GitHelper.commit(message: "Update release notes", files: path, push: true)
+
           UI.message "Done."
         end
     

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -12,7 +12,7 @@ module Fastlane
           next_version = Fastlane::Helpers::AndroidVersionHelper.calc_next_release_short_version(params[:new_version])
 
           Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
-          Fastlane::Helper::GitHelper.commit(message: "Update release notes", files: path, push: true)
+          Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path, push: true)
 
           UI.message "Done."
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -28,7 +28,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :new_version,
                                       env_name: "FL_ANDROID_UPDATE_RELEASE_NOTES_VERSION", 
-                                      description: "The new version to add to the release notes",
+                                      description: "The version we are currently freezing; An empty entry for the _next_ version after this one will be added to the release notes",
                                       is_string: true)
         ]
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -4,10 +4,15 @@ module Fastlane
       def self.run(params)
         UI.message "Updating the release notes..."
 
-        require_relative '../../helper/ios/ios_git_helper.rb'
         require_relative '../../helper/ios/ios_version_helper.rb'
+        require_relative '../../helper/release_notes_helper.rb'
+        require_relative '../../helper/git_helper.rb'
+
+        path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
         next_version = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(params[:new_version])
-        Fastlane::Helpers::IosGitHelper.update_release_notes(next_version)
+
+        Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
+        Fastlane::Helper::GitHelper.commit(message: "Update release notes", files: path, push: true)
           
         UI.message "Done."
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -12,7 +12,7 @@ module Fastlane
         next_version = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(params[:new_version])
 
         Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
-        Fastlane::Helper::GitHelper.commit(message: "Update release notes", files: path, push: true)
+        Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path, push: true)
           
         UI.message "Done."
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -28,7 +28,7 @@ module Fastlane
       [
         FastlaneCore::ConfigItem.new(key: :new_version,
                                     env_name: "FL_IOS_UPDATE_RELEASE_NOTES_VERSION", 
-                                    description: "The new version to add to the release notes",
+                                    description: "The version we are currently freezing; An empty entry for the _next_ version after this one will be added to the release notes",
                                     is_string: true)
       ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -36,27 +36,6 @@ module Fastlane
         !Action.sh("git branch --list #{branch_name}").empty?
       end
 
-      # Update the RELEASE-NOTES.txt to add a new entry for the new version, then commit the changes.
-      #
-      # @env [String] PROJECT_ROOT_FOLDER The env variable containing the project's root folder. Uses current folder if nil.
-      #
-      # @param [String] new_version The new version number to add an entry for
-      # 
-      def self.update_release_notes(new_version)
-        path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
-        lines = File.readlines(path)
-        # Find the index of the first non-empty line that is also NOT a comment. That way we keep commment headers as the very top of the file
-        line_idx = lines.find_index { |l| !l.start_with?('***') && !l.start_with?('//') && !l.chomp.empty? }
-        # Put back the header, then the new entry, then the rest (note: '...' excludes the higher bound of the range, unlike '..')
-        new_lines = lines[0...line_idx] + ["#{new_version}\n", "-----\n", "\n", "\n"] + lines[line_idx..]
-        File.write(path, new_lines.join)
-
-        # Commit the changes
-        Action.sh("git", "add", path)
-        Action.sh("git", "commit", "-m", "Update release notes")
-        Action.sh("git", "push", "origin", "HEAD")
-      end
-
       def self.update_metadata(validate_translation_command)
         Action.sh("./tools/update-translations.sh")
         Action.sh("./gradlew #{validate_translation_command}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -36,13 +36,25 @@ module Fastlane
         !Action.sh("git branch --list #{branch_name}").empty?
       end
 
+      # Update the RELEASE-NOTES.txt to add a new entry for the new version, then commit the changes.
+      #
+      # @env [String] PROJECT_ROOT_FOLDER The env variable containing the project's root folder. Uses current folder if nil.
+      #
+      # @param [String] new_version The new version number to add an entry for
+      # 
       def self.update_release_notes(new_version)
-        Action.sh("cp #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak")
-        Action.sh("echo \"#{new_version}\n-----\n \" > #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("cat #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak >> #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("git diff-index --quiet HEAD || git commit -m \"Update release notes\"")
-        Action.sh("git push origin HEAD")
+        path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
+        lines = File.readlines(path)
+        # Find the index of the first non-empty line that is also NOT a comment. That way we keep commment headers as the very top of the file
+        line_idx = lines.find_index { |l| !l.start_with?('***') && !l.start_with?('//') && !l.chomp.empty? }
+        # Put back the header, then the new entry, then the rest (note: '...' excludes the higher bound of the range, unlike '..')
+        new_lines = lines[0...line_idx] + ["#{new_version}\n", "-----\n", "\n", "\n"] + lines[line_idx..]
+        File.write(path, new_lines.join)
+
+        # Commit the changes
+        Action.sh("git", "add", path)
+        Action.sh("git", "commit", "-m", "Update release notes")
+        Action.sh("git", "push", "origin", "HEAD")
       end
 
       def self.update_metadata(validate_translation_command)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -12,6 +12,27 @@ module Fastlane
         return false unless is_git_repo
         `git config --get-regex lfs`.length > 0
       end
+
+      # `git add` the specified files (if any provided) then commit them using the provided message.
+      # Optionally, push the commit to the remote too.
+      #
+      # @param [String] message The commit message to use
+      # @param [String|Array<String>] files A file or array of files to git-add before creating the commit.
+      #        use `nil` or `[]` if you already added the files in a separate step and don't wan't this method to add any new file before commit.
+      #        Also accepts the special symbol `:all` to add all the files (`git commit -a -m …`).
+      # @param [Bool] push If true, will `git push` to `origin` after the commit has been created. Defaults to `false`.
+      #
+      def self.commit(message:, files: nil, push: false)
+        files = [files] if files.is_a?(String)
+        args = []
+        if files  == :all
+          args = ['-a']
+        elsif !files.nil? && !files.empty?
+          Action.sh("git", "add", *files)
+        end
+        Action.sh("git", "commit", *args, "-m", message)
+        Action.sh("git", "push", "origin", "HEAD") if push
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -78,27 +78,6 @@ module Fastlane
         end
       end
 
-      # Update the RELEASE-NOTES.txt to add a new entry for the new version, then commit the changes.
-      #
-      # @env [String] PROJECT_ROOT_FOLDER The env variable containing the project's root folder. Uses current folder if nil.
-      #
-      # @param [String] new_version The new version number to add an entry for
-      # 
-      def self.update_release_notes(new_version)
-        path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
-        lines = File.readlines(path)
-        # Find the index of the first non-empty line that is also NOT a comment. That way we keep commment headers as the very top of the file
-        line_idx = lines.find_index { |l| !l.start_with?('***') && !l.start_with?('//') && !l.chomp.empty? }
-        # Put back the header, then the new entry, then the rest (note: '...' excludes the higher bound of the range, unlike '..')
-        new_lines = lines[0...line_idx] + ["#{new_version}\n", "-----\n", "\n", "\n"] + lines[line_idx..]
-        File.write(path, new_lines.join)
-
-        # Commit the changes
-        Action.sh("git", "add", path)
-        Action.sh("git", "commit", "-m", "Update release notes")
-        Action.sh("git", "push", "origin", "HEAD")
-      end
-
       def self.tag_build(itc_version, internal_version)
         tag_and_push(itc_version)
         tag_and_push(internal_version) unless internal_version.nil?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -78,14 +78,25 @@ module Fastlane
         end
       end
 
+      # Update the RELEASE-NOTES.txt to add a new entry for the new version, then commit the changes.
+      #
+      # @env [String] PROJECT_ROOT_FOLDER The env variable containing the project's root folder. Uses current folder if nil.
+      #
+      # @param [String] new_version The new version number to add an entry for
+      # 
       def self.update_release_notes(new_version)
-        Action.sh("cp #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak")
-        Action.sh("echo \"#{new_version}\n-----\n \" > #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("cat #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak >> #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("rm #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.bak")
-        Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}RELEASE-NOTES.txt")
-        Action.sh("git commit -m \"Update release notes\"")
-        Action.sh("git push origin HEAD")
+        path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
+        lines = File.readlines(path)
+        # Find the index of the first non-empty line that is also NOT a comment. That way we keep commment headers as the very top of the file
+        line_idx = lines.find_index { |l| !l.start_with?('***') && !l.start_with?('//') && !l.chomp.empty? }
+        # Put back the header, then the new entry, then the rest (note: '...' excludes the higher bound of the range, unlike '..')
+        new_lines = lines[0...line_idx] + ["#{new_version}\n", "-----\n", "\n", "\n"] + lines[line_idx..]
+        File.write(path, new_lines.join)
+
+        # Commit the changes
+        Action.sh("git", "add", path)
+        Action.sh("git", "commit", "-m", "Update release notes")
+        Action.sh("git", "push", "origin", "HEAD")
       end
 
       def self.tag_build(itc_version, internal_version)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
@@ -4,7 +4,7 @@ module Fastlane
 
       # Update the release notes file (typycally RELEASE-NOTES.txt) to add a new entry.
       #
-      # @param [String] path The path to the relaese notes text file.
+      # @param [String] path The path to the release notes text file.
       # @param [String] section_title The title of the new section (typically the new version number) to add.
       # 
       def self.add_new_section(path:, section_title:)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
@@ -1,0 +1,23 @@
+module Fastlane
+  module Helper
+    module ReleaseNotesHelper
+
+      # Update the release notes file (typycally RELEASE-NOTES.txt) to add a new entry.
+      #
+      # @param [String] path The path to the relaese notes text file.
+      # @param [String] section_title The title of the new section (typically the new version number) to add.
+      # 
+      def self.add_new_section(path:, section_title:)
+        lines = File.readlines(path)
+
+        # Find the index of the first non-empty line that is also NOT a comment. That way we keep commment headers as the very top of the file
+        line_idx = lines.find_index { |l| !l.start_with?('***') && !l.start_with?('//') && !l.chomp.empty? }
+        # Put back the header, then the new entry, then the rest (note: '...' excludes the higher bound of the range, unlike '..')
+        new_lines = lines[0...line_idx] + ["#{section_title}\n", "-----\n", "\n", "\n"] + lines[line_idx..]
+
+        File.write(path, new_lines.join)
+      end
+    
+    end
+  end
+end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -80,7 +80,7 @@ describe Fastlane::Helper::GitHelper do
 
     it 'does not push to origin if not asked' do
       expect_shell_command('git', 'commit', '-m', @message)
-      expect_shell_command('git', 'push', 'origin', 'HEAD').never
+      expect_shell_command('git', 'push', any_args).never
       Fastlane::Helper::GitHelper.commit(message: @message)
     end
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -34,4 +34,60 @@ describe Fastlane::Helper::GitHelper do
     expect(Fastlane::Helper::GitHelper.is_git_repo).to be true
     expect(Fastlane::Helper::GitHelper.has_git_lfs).to be false
   end
+
+  context('commit(message:, files:, push:)') do
+    before(:each) do
+      allow_fastlane_action_sh()
+      @message = "Some commit message with spaces"
+    end
+  
+    it 'commits without adding any file if none are provided' do
+      expect_shell_command('git', 'add', any_args).never
+      expect_shell_command('git', 'commit', '-m', @message)
+      Fastlane::Helper::GitHelper.commit(message: @message)
+    end
+
+    it 'commits without adding any file if nil is provided' do
+      expect_shell_command('git', 'add', any_args).never
+      expect_shell_command('git', 'commit', '-m', @message)
+      Fastlane::Helper::GitHelper.commit(message: @message, files: nil)
+    end
+
+    it 'commits without adding any file if an empty list of files is provided' do
+      expect_shell_command('git', 'add', any_args).never
+      expect_shell_command('git', 'commit', '-m', @message)
+      Fastlane::Helper::GitHelper.commit(message: @message, files: [])
+    end
+
+    it 'adds a single file before commit if a single String is provided as `files`' do
+      file = 'some file'
+      expect_shell_command('git', 'add', file)
+      expect_shell_command('git', 'commit', '-m', @message)
+      Fastlane::Helper::GitHelper.commit(message: @message, files: file)
+    end
+
+    it 'adds multiple files before commit if an Array is provided as `files`' do
+      files = ['file 1', 'file 2', 'file 3']
+      expect_shell_command('git', 'add', files[0], files[1], files[2])
+      expect_shell_command('git', 'commit', '-m', @message)
+      Fastlane::Helper::GitHelper.commit(message: @message, files: files)
+    end
+
+    it 'adds all pending file changes before commit if :all is provided as `files`' do
+      expect_shell_command('git', 'commit', '-a', '-m', @message)
+      Fastlane::Helper::GitHelper.commit(message: @message, files: :all)
+    end
+
+    it 'does not push to origin if not asked' do
+      expect_shell_command('git', 'commit', '-m', @message)
+      expect_shell_command('git', 'push', 'origin', 'HEAD').never
+      Fastlane::Helper::GitHelper.commit(message: @message)
+    end
+
+    it 'does push to origin if asked' do
+      expect_shell_command('git', 'commit', '-m', @message)
+      expect_shell_command('git', 'push', 'origin', 'HEAD').once
+      Fastlane::Helper::GitHelper.commit(message: @message, push: true)
+    end
+  end
 end

--- a/spec/release_notes_helper_spec.rb
+++ b/spec/release_notes_helper_spec.rb
@@ -1,0 +1,100 @@
+require 'tmpdir'
+require_relative './spec_helper'
+
+describe Fastlane::Helper::ReleaseNotesHelper do
+  before(:each) do
+    @path = Dir.mktmpdir
+  end
+
+  after(:each) do
+    FileUtils.rm_rf(@path)
+  end
+
+  it 'adds a new section on top if there are no header comments' do
+    run_release_notes_test ''
+  end
+
+  it 'adds a new section after any `//` comments on top' do
+    run_release_notes_test <<~HEADER
+      // This is a header
+      // that we want to keep pinned on top.
+
+    HEADER
+  end
+
+  it 'adds a new section after any `***` comments on top' do
+    run_release_notes_test <<~HEADER
+      *** This is a header
+      *** that we want to keep pinned on top.
+      
+    HEADER
+  end
+
+  it 'does consider empty lines as header' do
+    run_release_notes_test("\n\n\n")
+  end
+
+  it 'adds a new section only after a mix of `//` and `***` comments and empty lines' do
+    run_release_notes_test <<~HEADER
+      // This is a header
+      // that we want to keep pinned on top.
+
+      *** It contains some mixed style of comments
+      *** with both double-slash style comment lines
+      *** and triple-star style ones.
+
+
+
+      // It also contains some empty lines we want to count as part of the pinned lines.
+      
+    HEADER
+  end
+
+  it 'does not consider # as comments' do
+    prefix = <<~NOT_HEADER
+      # This is not a comment
+    NOT_HEADER
+    run_release_notes_test('', prefix + FAKE_CONTENT)
+  end
+
+  it 'does not consider ** as comments' do
+    prefix = <<~NOT_HEADER
+      ** This is not a comment
+      *** But this is
+    NOT_HEADER
+    run_release_notes_test('', prefix + FAKE_CONTENT)
+  end
+end
+
+FAKE_CONTENT = <<~CONTENT
+  1.2.3
+  -----
+  - Item 1 for v1.2.3
+  - Item 2 for v1.2.3
+
+  // Comment in the middle 
+
+  1.2.2
+  -----
+  - Item 1 for v1.2.2
+  - Item 2 for v1.2.2
+CONTENT
+
+NEW_SECTION = <<~CONTENT
+  New Section
+  -----
+
+
+CONTENT
+
+def run_release_notes_test(header, original_content = FAKE_CONTENT)
+  Dir.mktmpdir('a8c-release-notes-test-') do |dir|
+    tmp_file = File.join(dir, 'TEST-REL-NOTES.txt')
+    File.write(tmp_file, header + original_content)
+
+    Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: tmp_file, section_title: "New Section")
+
+    new_content = File.read(tmp_file)
+    expect(new_content).to eq(header + NEW_SECTION + original_content)
+  end
+end

--- a/spec/release_notes_helper_spec.rb
+++ b/spec/release_notes_helper_spec.rb
@@ -52,7 +52,8 @@ describe Fastlane::Helper::ReleaseNotesHelper do
   it 'does not consider ** as comments' do
     prefix = <<~NOT_HEADER
       ** This is not a comment
-      *** But this is
+      *** This is; but it's after the non-comment line above, so not at the very top of the file
+      *** and should hence not be considered part of the pinned header to be skipped.
     NOT_HEADER
     run_release_notes_test('', prefix + FAKE_CONTENT)
   end
@@ -79,14 +80,14 @@ NEW_SECTION = <<~CONTENT
 
 CONTENT
 
-def run_release_notes_test(header, original_content = FAKE_CONTENT)
+def run_release_notes_test(header, post_header_content = FAKE_CONTENT)
   Dir.mktmpdir('a8c-release-notes-test-') do |dir|
     tmp_file = File.join(dir, 'TEST-REL-NOTES.txt')
-    File.write(tmp_file, header + original_content)
+    File.write(tmp_file, header + post_header_content)
 
     Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: tmp_file, section_title: "New Section")
 
     new_content = File.read(tmp_file)
-    expect(new_content).to eq(header + NEW_SECTION + original_content)
+    expect(new_content).to eq(header + NEW_SECTION + post_header_content)
   end
 end

--- a/spec/release_notes_helper_spec.rb
+++ b/spec/release_notes_helper_spec.rb
@@ -2,14 +2,6 @@ require 'tmpdir'
 require_relative './spec_helper'
 
 describe Fastlane::Helper::ReleaseNotesHelper do
-  before(:each) do
-    @path = Dir.mktmpdir
-  end
-
-  after(:each) do
-    FileUtils.rm_rf(@path)
-  end
-
   it 'adds a new section on top if there are no header comments' do
     run_release_notes_test ''
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,3 +43,27 @@ ensure
     ENV.delete 'CIRCLECI'
   end
 end
+
+# Allows Action.sh to be executed even when running in a test environment (where Fastlane's code disables it by default)
+#
+def allow_fastlane_action_sh
+  # See https://github.com/fastlane/fastlane/blob/e6bd288f17038a39cd1bfc1b70373cab1fa1e173/fastlane/lib/fastlane/helper/sh_helper.rb#L45-L85
+  allow(FastlaneCore::Helper).to receive(:sh_enabled?).and_return(true)
+end
+
+# Allows to assert if an `Action.sh` command has been triggered by the action under test.
+# Requires `allow_fastlane_action_sh` to have been called so that `Action.sh` actually calls `Open3.popen2e`
+#
+# @param [String...] *command List of the command and its parameters to run
+# @param [Int] exitstatus The exit status to expect. Defaults to 0.
+# @param [String] output The output string to expect as a result of running the command. Defaults to "".
+# @return [MessageExpectation] self, to support further chaining.
+#
+def expect_shell_command(*command, exitstatus: 0, output: "")
+  mock_input = double(:input)
+  mock_output = StringIO.new(output)
+  mock_status = double(:status, exitstatus: exitstatus)
+  mock_thread = double(:thread, value: mock_status)
+
+  expect(Open3).to receive(:popen2e).with(*command).and_yield(mock_input, mock_output, mock_thread)
+end


### PR DESCRIPTION
# Why?

In most of our iOS and Android app repos, we now added a comment at the very top of our `RELEASE-NOTES.txt` file to document to developers how the file should be used / formatted (especially, some instructions about using priority indicators).

The `update_release_notes()` fastlane action, which is used during `code_freeze` lane on all our repos, currently adds the empty section for the next version… at the very top of the `RELEASE-NOTES.txt` file, ignoring that we want this note to stay pinned on top. I got fed up of fixing this manually and moving our instructions comments back to the top myself, so here goes the fix.

# How?

This PR now makes the `update_release_notes` action skip any lines at the top of the `RELEASE-NOTES.txt` file if they start with either `***` (the marker we currently start our comment with in the release note files of most of our repos) or `//` (by convention, as it's the more common marker for comments in many languages). It will then add the new empty section only _after_ those "pinned-to-top comments" lines.

# Testing

1. In one of our iOS app's repo (WPiOS, WCiOS, …), create a new dummy git branch, and `git push -u origin <branchname>` it to the remote.
2. Point the app repo's `fastlane/Pluginfile` to this branch of the Release Toolkit and run `bundle install`.
3. _[Optional]_ Add more comment lines at the top of your `RELEASE-NOTES.txt` – some starting with `***`, some starting with `//`, and with some empty lines too, to check this will still work if we add more pinned comments in the future — and commit them.
4. Run `bundle exec fastlane run ios_update_release_notes new_version:123.4`.
   * The action will add the new entry **for `123.5`** – i.e. the version after the `123.4` that we're simulating a code freeze for.
   * It will then commit and push your branch to the remote – this is why we did `push -u` on step 1, to avoid this last step to crash on the push attempt if it was not tracking a remote branch already.
5. Run `git show HEAD` and check that the new entry for `123.5` in `RELEASE-NOTES.txt` has been added **_not_ at the very top, but _below_ the topmost instructions** in that file (and directly above the section title for the latest version entry you add in those release notes).
6. Delete the git branch you used for those tests, **both locally and on the remote**.
7. Repeat for an Android app's repo, this time running the `bundle exec fastlane run android_update_release_notes new_version:123.4` action instead of the ios one.
8. Repeat the tests on a `RELEASE-NOTES.txt` file which doesn't have a "header" / "comment-on-top" at all (i.e. first line is immediately a version number, and second line is `-----`).

#### Example

<details><summary>State of my modified release notes (as per optional step 3 above) before running the action</summary>

```
$ head -n 20 RELEASE-NOTES.txt
// This file contains the release notes for WooCommerce iOS

// Please add a new bullet point under the corresponding version every time you
// do a new PR that is worth adding a release note entry for.
//
// Thanks.

*** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]

5.9
-----
- [*] Removed fulfillment screen and moved fulfillment to the order details screen. [https://github.com/woocommerce/woocommerce-ios/pull/3453]
- [*] Fix: billing information action sheets now are presented correctly on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/3457]
- [*] fix: the rows in the product search list now don't have double separators. [https://github.com/woocommerce/woocommerce-ios/pull/3456]
- [*] fix: when adding a note to an order, the text gets no more deleted if you tap on “Email note to customer”. [https://github.com/woocommerce/woocommerce-ios/pull/3473]


5.8
-----
- [***] Products M5 features are now available to all. Products M5 features: add and edit linked products, add and edit downloadable files, product deletion. [https://github.com/woocommerce/woocommerce-ios/pull/3420]

```

</details>

<details><summary>Running the action</summary>

```
$ bundle exec fastlane run ios_update_release_notes new_version:123.4
[…]
[21:38:40]: --------------------------------------
[21:38:40]: --- Step: ios_update_release_notes ---
[21:38:40]: --------------------------------------
[21:38:40]: Updating the release notes...
[21:38:40]: $ git add ./RELEASE-NOTES.txt
[21:38:40]: $ git commit -m Update\ release\ notes
[21:38:40]: ▸ [tooling/release-notes f10ece833] Update release notes
[21:38:40]: ▸ 1 file changed, 11 insertions(+)
[21:38:40]: $ git push origin HEAD
[21:38:45]: ▸ remote:
[21:38:45]: ▸ remote: GitHub found 1 vulnerability on woocommerce/woocommerce-ios's default branch (1 low). To find out more, visit:
[21:38:45]: ▸ remote:      https://github.com/woocommerce/woocommerce-ios/security/dependabot/Gemfile.lock/nokogiri/open
[21:38:45]: ▸ remote:
[21:38:45]: ▸ To github.com:woocommerce/woocommerce-ios.git
[21:38:45]: ▸ e849a682a..f10ece833  HEAD -> tooling/release-notes
[21:38:45]: Done.
[21:38:45]: Result: true
```

</details>

<details><summary>Resulting diff, where new version's entry has properly been added <i>after</i> the header</summary>

```
$ git show HEAD
commit 00f3826f72e4ae258bb954c3a523e39728ed03fb (HEAD -> dummy/release-notes-test, origin/dummy/release-notes-test)
Author: Olivier Halligon <olivier.halligon@automattic.com>
Date:   Thu Jan 14 21:50:26 2021 +0100

    Update release notes

diff --git a/RELEASE-NOTES.txt b/RELEASE-NOTES.txt
index 8f6cbea52..33d5d770d 100644
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,10 @@
 
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 
+123.5
+-----
+
+
 5.9
 -----
 - [*] Removed fulfillment screen and moved fulfillment to the order details screen. [https://github.com/woocommerce/woocommerce-ios/pull/3453]
```
</details>
