### PR TITLE
[Toolkit Cleanup] Yard doc: step 2 – rename module Helpers -> Helper

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -9,17 +9,17 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
 
         # Checkout develop and update
-        Fastlane::Helpers::AndroidGitHelper::git_checkout_and_pull("develop")
+        Fastlane::Helper::AndroidGitHelper::git_checkout_and_pull("develop")
 
         # Check versions
-        release_version = Fastlane::Helpers::AndroidVersionHelper::get_release_version
-        message = "The following current version has been detected: #{release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}\n"
-        alpha_release_version = Fastlane::Helpers::AndroidVersionHelper::get_alpha_version
-        message << "The following Alpha version has been detected: #{alpha_release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
+        release_version = Fastlane::Helper::AndroidVersionHelper::get_release_version
+        message = "The following current version has been detected: #{release_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}\n"
+        alpha_release_version = Fastlane::Helper::AndroidVersionHelper::get_alpha_version
+        message << "The following Alpha version has been detected: #{alpha_release_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
         
         # Check branch
-        app_version = Fastlane::Helpers::AndroidVersionHelper::get_public_version
-        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helpers::AndroidGitHelper::git_checkout_and_pull_release_branch_for(app_version))
+        app_version = Fastlane::Helper::AndroidVersionHelper::get_public_version
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::AndroidGitHelper::git_checkout_and_pull_release_branch_for(app_version))
         
         # Check user overwrite
         if (!params[:base_version].nil?)
@@ -28,12 +28,12 @@ module Fastlane
           alpha_release_version = overwrite_version[1]
         end
 
-        next_beta_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_beta_version(release_version, alpha_release_version)
-        next_alpha_version = Fastlane::Helpers::AndroidVersionHelper::calc_next_alpha_version(next_beta_version, alpha_release_version) unless alpha_release_version.nil?
+        next_beta_version = Fastlane::Helper::AndroidVersionHelper::calc_next_beta_version(release_version, alpha_release_version)
+        next_alpha_version = Fastlane::Helper::AndroidVersionHelper::calc_next_alpha_version(next_beta_version, alpha_release_version) unless alpha_release_version.nil?
 
         # Verify
-        message << "Updating branch to version: #{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) "
-        message << "and #{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n" unless alpha_release_version.nil?
+        message << "Updating branch to version: #{next_beta_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}) "
+        message << "and #{next_alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}).\n" unless alpha_release_version.nil?
         if (!params[:skip_confirm])
           if (!UI.confirm("#{message}Do you want to continue?"))
             UI.user_error!("Aborted by user request")
@@ -50,11 +50,11 @@ module Fastlane
       end
 
       def self.get_user_build_version(version, message)
-        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helpers::AndroidGitHelper::git_checkout_and_pull_release_branch_for(version)
-        release_version = Fastlane::Helpers::AndroidVersionHelper::get_release_version
-        message << "Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}.\n"
-        alpha_release_version = Fastlane::Helpers::AndroidVersionHelper::get_alpha_version
-        message << "and Alpha Version: #{alpha_release_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
+        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::AndroidGitHelper::git_checkout_and_pull_release_branch_for(version)
+        release_version = Fastlane::Helper::AndroidVersionHelper::get_release_version
+        message << "Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}.\n"
+        alpha_release_version = Fastlane::Helper::AndroidVersionHelper::get_alpha_version
+        message << "and Alpha Version: #{alpha_release_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
         [release_version, alpha_release_version]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -8,19 +8,19 @@ module Fastlane
           UI.user_error!("Can't build beta and final at the same time!")
         end
 
-        Fastlane::Helpers::AndroidGitHelper.check_on_branch("release") unless other_action.is_ci()
+        Fastlane::Helper::AndroidGitHelper.check_on_branch("release") unless other_action.is_ci()
         
         message = ""
-        beta_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version() unless !params[:beta] and !params[:final]
-        alpha_version = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version() unless !params[:alpha]
+        beta_version = Fastlane::Helper::AndroidVersionHelper.get_release_version() unless !params[:beta] and !params[:final]
+        alpha_version = Fastlane::Helper::AndroidVersionHelper.get_alpha_version() unless !params[:alpha]
         
-        if (params[:final] and Fastlane::Helpers::AndroidVersionHelper.is_beta_version?(beta_version))
+        if (params[:final] and Fastlane::Helper::AndroidVersionHelper.is_beta_version?(beta_version))
           UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!")
         end
 
-        message << "Building version #{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) (for upload to Release Channel)\n" unless !params[:final]
-        message << "Building version #{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) (for upload to Beta Channel)\n" unless !params[:beta] 
-        message << "Building version #{alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" unless !params[:alpha]
+        message << "Building version #{beta_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}) (for upload to Release Channel)\n" unless !params[:final]
+        message << "Building version #{beta_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}) (for upload to Beta Channel)\n" unless !params[:beta] 
+        message << "Building version #{alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" unless !params[:alpha]
 
         if (!params[:skip_confirm])
           if (!UI.confirm("#{message}Do you want to continue?"))

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -7,15 +7,15 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
         require_relative '../../helper/android/android_version_helper.rb'
 
-        Fastlane::Helpers::AndroidGitHelper.check_on_branch("release")
+        Fastlane::Helper::AndroidGitHelper.check_on_branch("release")
         create_config()
         show_config()
 
         UI.message "Updating build.gradle..."
-        Fastlane::Helpers::AndroidVersionHelper.update_versions(@new_version_beta, @new_version_alpha)  
+        Fastlane::Helper::AndroidVersionHelper.update_versions(@new_version_beta, @new_version_alpha)  
         UI.message "Done!"
  
-        Fastlane::Helpers::AndroidGitHelper.bump_version_beta()        
+        Fastlane::Helper::AndroidGitHelper.bump_version_beta()        
       end
 
       #####################################################
@@ -52,15 +52,15 @@ module Fastlane
 
       private 
       def self.create_config()
-        @current_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
-        @current_version_alpha = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
-        @new_version_beta = Fastlane::Helpers::AndroidVersionHelper.calc_next_beta_version(@current_version, @current_version_alpha)
-        @new_version_alpha = ENV["HAS_ALPHA_VERSION"].nil? ? nil : Fastlane::Helpers::AndroidVersionHelper.calc_next_alpha_version(@new_version_beta, @current_version_alpha)
+        @current_version = Fastlane::Helper::AndroidVersionHelper.get_release_version()
+        @current_version_alpha = Fastlane::Helper::AndroidVersionHelper.get_alpha_version()
+        @new_version_beta = Fastlane::Helper::AndroidVersionHelper.calc_next_beta_version(@current_version, @current_version_alpha)
+        @new_version_alpha = ENV["HAS_ALPHA_VERSION"].nil? ? nil : Fastlane::Helper::AndroidVersionHelper.calc_next_alpha_version(@new_version_beta, @current_version_alpha)
       end
 
       def self.show_config()
-        vname = Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME
-        vcode = Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE
+        vname = Fastlane::Helper::AndroidVersionHelper::VERSION_NAME
+        vcode = Fastlane::Helper::AndroidVersionHelper::VERSION_CODE
         UI.message("Current version: #{@current_version[vname]}(#{@current_version[vcode]})")
         UI.message("Current alpha version: #{@current_version_alpha[vname]}(#{@current_version_alpha[vcode]})") unless ENV["HAS_ALPHA_VERSION"].nil?
         UI.message("New beta version: #{@new_version_beta[vname]}(#{@new_version_beta[vcode]})")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -7,15 +7,15 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
         require_relative '../../helper/android/android_version_helper.rb'
 
-        Fastlane::Helpers::AndroidGitHelper.check_on_branch("release")
+        Fastlane::Helper::AndroidGitHelper.check_on_branch("release")
         create_config()
         show_config()
 
         UI.message "Updating gradle.properties..."
-        Fastlane::Helpers::AndroidVersionHelper.update_versions(@final_version, @current_version_alpha)  
+        Fastlane::Helper::AndroidVersionHelper.update_versions(@final_version, @current_version_alpha)  
         UI.message "Done!"
  
-        Fastlane::Helpers::AndroidGitHelper.bump_version_final()        
+        Fastlane::Helper::AndroidGitHelper.bump_version_final()        
       end
 
       #####################################################
@@ -40,14 +40,14 @@ module Fastlane
 
       private 
       def self.create_config()
-        @current_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
-        @current_version_alpha = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
-        @final_version = Fastlane::Helpers::AndroidVersionHelper.calc_final_release_version(@current_version, @current_version_alpha)
+        @current_version = Fastlane::Helper::AndroidVersionHelper.get_release_version()
+        @current_version_alpha = Fastlane::Helper::AndroidVersionHelper.get_alpha_version()
+        @final_version = Fastlane::Helper::AndroidVersionHelper.calc_final_release_version(@current_version, @current_version_alpha)
       end
 
       def self.show_config()
-        vname = Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME
-        vcode = Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE
+        vname = Fastlane::Helper::AndroidVersionHelper::VERSION_NAME
+        vcode = Fastlane::Helper::AndroidVersionHelper::VERSION_CODE
         UI.message("Current version: #{@current_version[vname]}(#{@current_version[vcode]})")
         UI.message("Current alpha version: #{@current_version_alpha[vname]}(#{@current_version_alpha[vcode]})") unless ENV["HAS_ALPHA_VERSION"].nil?
         UI.message("New release version: #{@final_version[vname]}(#{@final_version[vcode]})")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -5,15 +5,15 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/android/android_git_helper.rb'
-        Fastlane::Helpers::AndroidGitHelper.branch_for_hotfix(params[:previous_version_name], params[:version_name])
+        Fastlane::Helper::AndroidGitHelper.branch_for_hotfix(params[:previous_version_name], params[:version_name])
         create_config(params[:previous_version_name], params[:version_name], params[:version_code])
         show_config()
         
         UI.message "Updating build.gradle..."
-        Fastlane::Helpers::AndroidVersionHelper.update_versions(@new_version, @current_version_alpha) 
+        Fastlane::Helper::AndroidVersionHelper.update_versions(@new_version, @current_version_alpha) 
         UI.message "Done!"
 
-        Fastlane::Helpers::AndroidGitHelper.bump_version_hotfix(params[:version_name])
+        Fastlane::Helper::AndroidGitHelper.bump_version_hotfix(params[:version_name])
         
         UI.message "Done."
       end
@@ -59,16 +59,16 @@ module Fastlane
 
       private 
       def self.create_config(previous_version, new_version_name, new_version_code)
-        @current_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
-        @current_version_alpha = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
-        @new_version = Fastlane::Helpers::AndroidVersionHelper.calc_next_hotfix_version(new_version_name, new_version_code)
+        @current_version = Fastlane::Helper::AndroidVersionHelper.get_release_version()
+        @current_version_alpha = Fastlane::Helper::AndroidVersionHelper.get_alpha_version()
+        @new_version = Fastlane::Helper::AndroidVersionHelper.calc_next_hotfix_version(new_version_name, new_version_code)
         @new_short_version = new_version_name
         @new_release_branch = "release/#{@new_short_version}"
       end
 
       def self.show_config()
-        UI.message("Current version: #{@current_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{@current_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]})")
-        UI.message("New hotfix version: #{@new_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]}(#{@new_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]})")
+        UI.message("Current version: #{@current_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}(#{@current_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]})")
+        UI.message("New hotfix version: #{@new_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]}(#{@new_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]})")
         UI.message("Release branch: #{@new_release_branch}")
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -11,18 +11,18 @@ module Fastlane
           other_action.ensure_git_branch(branch: "develop")
 
           # Create new configuration
-          @new_short_version = Fastlane::Helpers::AndroidVersionHelper.bump_version_release()
+          @new_short_version = Fastlane::Helper::AndroidVersionHelper.bump_version_release()
           create_config()
           show_config()
 
           # Update local develop and branch
           UI.message "Creating new branch..."
-          Fastlane::Helpers::AndroidGitHelper.do_release_branch(@new_release_branch)
+          Fastlane::Helper::AndroidGitHelper.do_release_branch(@new_release_branch)
           UI.message "Done!"
 
           UI.message "Updating versions..."
-          Fastlane::Helpers::AndroidVersionHelper.update_versions(@new_version_beta, @new_version_alpha) 
-          Fastlane::Helpers::AndroidGitHelper.bump_version_release()         
+          Fastlane::Helper::AndroidVersionHelper.update_versions(@new_version_beta, @new_version_alpha) 
+          Fastlane::Helper::AndroidGitHelper.bump_version_release()         
           UI.message "Done."
         end
   
@@ -61,16 +61,16 @@ module Fastlane
 
         private
         def self.create_config()
-          @current_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
-          @current_version_alpha = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
-          @new_version_beta = Fastlane::Helpers::AndroidVersionHelper.calc_next_release_version(@current_version, @current_version_alpha)
-          @new_version_alpha = ENV["HAS_ALPHA_VERSION"].nil? ? nil : Fastlane::Helpers::AndroidVersionHelper.calc_next_alpha_version(@new_version_beta, @current_version_alpha)
+          @current_version = Fastlane::Helper::AndroidVersionHelper.get_release_version()
+          @current_version_alpha = Fastlane::Helper::AndroidVersionHelper.get_alpha_version()
+          @new_version_beta = Fastlane::Helper::AndroidVersionHelper.calc_next_release_version(@current_version, @current_version_alpha)
+          @new_version_alpha = ENV["HAS_ALPHA_VERSION"].nil? ? nil : Fastlane::Helper::AndroidVersionHelper.calc_next_alpha_version(@new_version_beta, @current_version_alpha)
           @new_release_branch = "release/#{@new_short_version}"
         end
 
         def self.show_config()
-          vname = Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME
-          vcode = Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE
+          vname = Fastlane::Helper::AndroidVersionHelper::VERSION_NAME
+          vcode = Fastlane::Helper::AndroidVersionHelper::VERSION_CODE
           UI.message("Current version: #{@current_version[vname]}(#{@current_version[vcode]})")
           UI.message("Current alpha version: #{@current_version_alpha[vname]}(#{@current_version_alpha[vcode]})") unless ENV["HAS_ALPHA_VERSION"].nil?
           UI.message("New beta version: #{@new_version_beta[vname]}(#{@new_version_beta[vcode]})")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -12,20 +12,20 @@ module Fastlane
           require_relative '../../helper/android/android_git_helper.rb'
   
           # Checkout develop and update
-          Fastlane::Helpers::AndroidGitHelper.git_checkout_and_pull("develop")
+          Fastlane::Helper::AndroidGitHelper.git_checkout_and_pull("develop")
 
           # Create versions
-          current_version = Fastlane::Helpers::AndroidVersionHelper.get_release_version
-          current_alpha_version = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version
-          next_version = Fastlane::Helpers::AndroidVersionHelper.calc_next_release_version(current_version, current_alpha_version)
-          next_alpha_version = ENV["HAS_ALPHA_VERSION"].nil? ? nil : Fastlane::Helpers::AndroidVersionHelper.calc_next_alpha_version(next_version, current_alpha_version)
+          current_version = Fastlane::Helper::AndroidVersionHelper.get_release_version
+          current_alpha_version = Fastlane::Helper::AndroidVersionHelper.get_alpha_version
+          next_version = Fastlane::Helper::AndroidVersionHelper.calc_next_release_version(current_version, current_alpha_version)
+          next_alpha_version = ENV["HAS_ALPHA_VERSION"].nil? ? nil : Fastlane::Helper::AndroidVersionHelper.calc_next_alpha_version(next_version, current_alpha_version)
 
           # Ask user confirmation
           if (!params[:skip_confirm])
-            confirm_message = "Building a new release branch starting from develop.\nCurrent version is #{current_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n"
-            confirm_message += ENV["HAS_ALPHA_VERSION"].nil? ? "No alpha version configured.\n" : "Current Alpha version is #{current_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]} (#{current_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n"
-            confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n"
-            confirm_message += ENV["HAS_ALPHA_VERSION"].nil? ? "" : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helpers::AndroidVersionHelper::VERSION_CODE]}).\n"
+            confirm_message = "Building a new release branch starting from develop.\nCurrent version is #{current_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}).\n"
+            confirm_message += ENV["HAS_ALPHA_VERSION"].nil? ? "No alpha version configured.\n" : "Current Alpha version is #{current_alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]} (#{current_alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}).\n"
+            confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}).\n"
+            confirm_message += ENV["HAS_ALPHA_VERSION"].nil? ? "" : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::AndroidVersionHelper::VERSION_CODE]}).\n"
             confirm_message += "Do you want to continue?"
             if (!UI.confirm(confirm_message))
               UI.user_error!("Aborted by user request")
@@ -36,7 +36,7 @@ module Fastlane
           other_action.ensure_git_status_clean()
   
           # Return the current version
-          Fastlane::Helpers::AndroidVersionHelper.get_public_version
+          Fastlane::Helper::AndroidVersionHelper.get_public_version
         end
   
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
   
           UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
   
-          version = Fastlane::Helpers::AndroidVersionHelper::get_public_version
+          version = Fastlane::Helper::AndroidVersionHelper::get_public_version
           message = "Completing code freeze for: #{version}\n"
           unless params[:skip_confirm]
             unless UI.confirm("#{message}Do you want to continue?")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
@@ -7,7 +7,7 @@ module Fastlane
     class AndroidCurrentBranchIsHotfixAction < Action
       def self.run(params)
         require_relative '../../helper/android/android_version_helper.rb'
-        Fastlane::Helpers::AndroidVersionHelper::is_hotfix?(Fastlane::Helpers::AndroidVersionHelper::get_release_version)
+        Fastlane::Helper::AndroidVersionHelper::is_hotfix?(Fastlane::Helper::AndroidVersionHelper::get_release_version)
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -13,7 +13,7 @@ module Fastlane
   
           UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
   
-          version = Fastlane::Helpers::AndroidVersionHelper::get_public_version
+          version = Fastlane::Helper::AndroidVersionHelper::get_public_version
           message = "Finalizing release: #{version}\n"
           if (!params[:skip_confirm])
             if (!UI.confirm("#{message}Do you want to continue?"))
@@ -26,7 +26,7 @@ module Fastlane
           # Check local repo status
           other_action.ensure_git_status_clean()
   
-          version[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME]
+          version[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME]
         end
   
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
@@ -3,7 +3,7 @@ module Fastlane
       class AndroidGetAlphaVersionAction < Action
         def self.run(params)
           require_relative '../../helper/android/android_version_helper.rb'
-          Fastlane::Helpers::AndroidVersionHelper.get_alpha_version()
+          Fastlane::Helper::AndroidVersionHelper.get_alpha_version()
         end
   
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
@@ -3,7 +3,7 @@ module Fastlane
       class AndroidGetAppVersionAction < Action
         def self.run(params)
           require_relative '../../helper/android/android_version_helper.rb'
-          Fastlane::Helpers::AndroidVersionHelper::get_public_version
+          Fastlane::Helper::AndroidVersionHelper::get_public_version
         end
   
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
@@ -3,7 +3,7 @@ module Fastlane
       class AndroidGetReleaseVersionAction < Action
         def self.run(params)
           require_relative '../../helper/android/android_version_helper.rb'
-          Fastlane::Helpers::AndroidVersionHelper.get_release_version()
+          Fastlane::Helper::AndroidVersionHelper.get_release_version()
         end
   
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
@@ -10,7 +10,7 @@ module Fastlane
 
         # Evaluate previous tag
         new_ver = params[:version_name]
-        prev_ver = Fastlane::Helpers::AndroidVersionHelper::calc_prev_hotfix_version_name(new_ver)
+        prev_ver = Fastlane::Helper::AndroidVersionHelper::calc_prev_hotfix_version_name(new_ver)
 
         # Confirm
         message = "Requested Hotfix version: #{new_ver}\n"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -5,9 +5,9 @@ module Fastlane
           require_relative '../../helper/android/android_version_helper.rb'
           require_relative '../../helper/android/android_git_helper.rb'
     
-          release_ver = Fastlane::Helpers::AndroidVersionHelper.get_release_version()
-          alpha_ver = Fastlane::Helpers::AndroidVersionHelper.get_alpha_version() unless ENV["HAS_ALPHA_VERSION"].nil?
-          Fastlane::Helpers::AndroidGitHelper.tag_build(release_ver[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME], (ENV["HAS_ALPHA_VERSION"].nil? or (params[:tag_alpha] == false)) ? nil : alpha_ver[Fastlane::Helpers::AndroidVersionHelper::VERSION_NAME])
+          release_ver = Fastlane::Helper::AndroidVersionHelper.get_release_version()
+          alpha_ver = Fastlane::Helper::AndroidVersionHelper.get_alpha_version() unless ENV["HAS_ALPHA_VERSION"].nil?
+          Fastlane::Helper::AndroidGitHelper.tag_build(release_ver[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME], (ENV["HAS_ALPHA_VERSION"].nil? or (params[:tag_alpha] == false)) ? nil : alpha_ver[Fastlane::Helper::AndroidVersionHelper::VERSION_NAME])
         end
     
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_metadata.rb
@@ -8,7 +8,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_git_helper.rb'
 
-        Fastlane::Helpers::AndroidGitHelper.update_metadata(ENV["validate_translations"])
+        Fastlane::Helper::AndroidGitHelper.update_metadata(ENV["validate_translations"])
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -9,7 +9,7 @@ module Fastlane
           require_relative '../../helper/git_helper.rb'
 
           path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
-          next_version = Fastlane::Helpers::AndroidVersionHelper.calc_next_release_short_version(params[:new_version])
+          next_version = Fastlane::Helper::AndroidVersionHelper.calc_next_release_short_version(params[:new_version])
 
           Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
           Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path, push: true)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -13,7 +13,7 @@ module Fastlane
         UI.message("Last detected milestone: #{last_stone[:title]} due on #{last_stone[:due_on]}.")
         milestone_duedate = last_stone[:due_on]
         newmilestone_duedate = (milestone_duedate.to_datetime.next_day(14).to_time).utc
-        newmilestone_number = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(last_stone[:title])
+        newmilestone_number = Fastlane::Helper::IosVersionHelper.calc_next_release_version(last_stone[:title])
         UI.message("Next milestone: #{newmilestone_number} due on #{newmilestone_duedate}.")
         Fastlane::Helper::GhhelperHelper.create_milestone(repository, newmilestone_number, newmilestone_duedate, params[:need_appstore_submission])
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -9,19 +9,19 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper.rb'
 
         # Checkout develop and update
-        Fastlane::Helpers::IosGitHelper::git_checkout_and_pull("develop")
+        Fastlane::Helper::IosGitHelper::git_checkout_and_pull("develop")
 
         # Check versions
-        build_version = Fastlane::Helpers::IosVersionHelper::get_build_version
+        build_version = Fastlane::Helper::IosVersionHelper::get_build_version
         message = "The following current version has been detected: #{build_version}\n"
         
         # Check branch
-        app_version = Fastlane::Helpers::IosVersionHelper::get_public_version
-        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helpers::IosGitHelper::git_checkout_and_pull_release_branch_for(app_version))
+        app_version = Fastlane::Helper::IosVersionHelper::get_public_version
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::IosGitHelper::git_checkout_and_pull_release_branch_for(app_version))
         
         # Check user overwrite
         build_version = get_user_build_version(params[:base_version], message) unless params[:base_version].nil?
-        next_version = Fastlane::Helpers::IosVersionHelper::calc_next_build_version(build_version)
+        next_version = Fastlane::Helper::IosVersionHelper::calc_next_build_version(build_version)
 
         # Verify
         message << "Updating branch to version: #{next_version}.\n"
@@ -41,8 +41,8 @@ module Fastlane
       end
 
       def self.get_user_build_version(version, message)
-        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helpers::IosGitHelper::git_checkout_and_pull_release_branch_for(version)
-        build_version = Fastlane::Helpers::IosVersionHelper::get_build_version
+        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::IosGitHelper::git_checkout_and_pull_release_branch_for(version)
+        build_version = Fastlane::Helper::IosVersionHelper::get_build_version
         message << "Looking at branch release/#{version} as requested by user. Detected version: #{build_version}.\n"
         build_version
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -5,9 +5,9 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper.rb'
 
         message = ""
-        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_internal_version()} and uploading to App Center\n" unless !params[:internal]
-        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_build_version()} and uploading to App Center\n" unless !params[:internal_on_single_version]
-        message << "Building version #{Fastlane::Helpers::IosVersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
+        message << "Building version #{Fastlane::Helper::IosVersionHelper.get_internal_version()} and uploading to App Center\n" unless !params[:internal]
+        message << "Building version #{Fastlane::Helper::IosVersionHelper.get_build_version()} and uploading to App Center\n" unless !params[:internal_on_single_version]
+        message << "Building version #{Fastlane::Helper::IosVersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
 
         if (!params[:skip_confirm])
           if (!UI.confirm("#{message}Do you want to continue?"))

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -7,15 +7,15 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper.rb'
         require_relative '../../helper/ios/ios_version_helper.rb'
 
-        Fastlane::Helpers::IosGitHelper.check_on_branch("release")
+        Fastlane::Helper::IosGitHelper.check_on_branch("release")
         create_config()
         show_config()
 
         UI.message "Updating XcConfig..."
-        Fastlane::Helpers::IosVersionHelper.update_xc_configs(@new_beta_version, @short_version, @new_internal_version) 
+        Fastlane::Helper::IosVersionHelper.update_xc_configs(@new_beta_version, @short_version, @new_internal_version) 
         UI.message "Done!"
  
-        Fastlane::Helpers::IosGitHelper.bump_version_beta        
+        Fastlane::Helper::IosGitHelper.bump_version_beta        
       end
 
       #####################################################
@@ -52,11 +52,11 @@ module Fastlane
 
       private 
       def self.create_config()
-        @current_version = Fastlane::Helpers::IosVersionHelper.get_build_version()
-        @current_version_internal = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
-        @new_internal_version = Fastlane::Helpers::IosVersionHelper.create_internal_version(@current_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
-        @new_beta_version = Fastlane::Helpers::IosVersionHelper.calc_next_build_version(@current_version)
-        @short_version = Fastlane::Helpers::IosVersionHelper.get_short_version_string(@new_beta_version)
+        @current_version = Fastlane::Helper::IosVersionHelper.get_build_version()
+        @current_version_internal = Fastlane::Helper::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @new_internal_version = Fastlane::Helper::IosVersionHelper.create_internal_version(@current_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @new_beta_version = Fastlane::Helper::IosVersionHelper.calc_next_build_version(@current_version)
+        @short_version = Fastlane::Helper::IosVersionHelper.get_short_version_string(@new_beta_version)
       end
 
       def self.show_config()

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -5,18 +5,18 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/ios/ios_git_helper.rb'
-        Fastlane::Helpers::IosGitHelper.branch_for_hotfix(params[:previous_version], params[:version])
+        Fastlane::Helper::IosGitHelper.branch_for_hotfix(params[:previous_version], params[:version])
         create_config(params[:previous_version], params[:version])
         show_config()
         
         UI.message "Updating Fastlane deliver file..."
-        Fastlane::Helpers::IosVersionHelper.update_fastlane_deliver(@new_short_version)
+        Fastlane::Helper::IosVersionHelper.update_fastlane_deliver(@new_short_version)
         UI.message "Done!"
         UI.message "Updating XcConfig..."
-        Fastlane::Helpers::IosVersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
+        Fastlane::Helper::IosVersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
         UI.message "Done!"
 
-        Fastlane::Helpers::IosGitHelper.bump_version_hotfix(params[:version])
+        Fastlane::Helper::IosGitHelper.bump_version_hotfix(params[:version])
         
         UI.message "Done."
       end
@@ -68,9 +68,9 @@ module Fastlane
       private 
       def self.create_config(previous_version, new_short_version)
         @current_version = previous_version
-        @current_version_internal = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @current_version_internal = Fastlane::Helper::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
         @new_version = "#{new_short_version}.0"
-        @new_version_internal = Fastlane::Helpers::IosVersionHelper.create_internal_version(@new_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        @new_version_internal = Fastlane::Helper::IosVersionHelper.create_internal_version(@new_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
         @new_short_version = new_short_version
         @new_release_branch = "release/#{@new_short_version}"
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -11,13 +11,13 @@ module Fastlane
           other_action.ensure_git_branch(branch: "develop")
 
           # Create new configuration
-          @new_version = Fastlane::Helpers::IosVersionHelper.bump_version_release()
+          @new_version = Fastlane::Helper::IosVersionHelper.bump_version_release()
           create_config()
           show_config()
 
           # Update local develop and branch
-          Fastlane::Helpers::IosGitHelper.git_checkout_and_pull("develop")
-          Fastlane::Helpers::IosGitHelper.do_release_branch(@new_release_branch)
+          Fastlane::Helper::IosGitHelper.git_checkout_and_pull("develop")
+          Fastlane::Helper::IosGitHelper.do_release_branch(@new_release_branch)
           UI.message "Done!"
 
           UI.message "Updating glotPressKeys..."  unless params[:skip_glotpress]
@@ -25,14 +25,14 @@ module Fastlane
           UI.message "Done" unless params [:skip_glotpress]
 
           UI.message "Updating Fastlane deliver file..." unless params[:skip_deliver]
-          Fastlane::Helpers::IosVersionHelper.update_fastlane_deliver(@new_short_version) unless params[:skip_deliver]
+          Fastlane::Helper::IosVersionHelper.update_fastlane_deliver(@new_short_version) unless params[:skip_deliver]
           UI.message "Done!" unless params [:skip_deliver]
 
           UI.message "Updating XcConfig..."
-          Fastlane::Helpers::IosVersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
+          Fastlane::Helper::IosVersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
           UI.message "Done!"
 
-          Fastlane::Helpers::IosGitHelper.bump_version_release(params[:skip_deliver], params[:skip_glotpress])
+          Fastlane::Helper::IosGitHelper.bump_version_release(params[:skip_deliver], params[:skip_glotpress])
           
           UI.message "Done."
         end
@@ -84,10 +84,10 @@ module Fastlane
 
         private
         def self.create_config()
-          @current_version = Fastlane::Helpers::IosVersionHelper.get_build_version()
-          @current_version_internal = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
-          @new_version_internal = Fastlane::Helpers::IosVersionHelper.create_internal_version(@new_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
-          @new_short_version = Fastlane::Helpers::IosVersionHelper.get_short_version_string(@new_version)
+          @current_version = Fastlane::Helper::IosVersionHelper.get_build_version()
+          @current_version_internal = Fastlane::Helper::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+          @new_version_internal = Fastlane::Helper::IosVersionHelper.create_internal_version(@new_version) unless ENV["INTERNAL_CONFIG_FILE"].nil?
+          @new_short_version = Fastlane::Helper::IosVersionHelper.get_short_version_string(@new_version)
           @new_release_branch = "release/#{@new_short_version}"
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -5,7 +5,7 @@ module Fastlane
         UI.message("Deleting tags for version: #{params[:version]}")
         
         require_relative '../../helper/ios/ios_git_helper.rb'
-        Fastlane::Helpers::IosGitHelper.delete_tags(params[:version])
+        Fastlane::Helper::IosGitHelper.delete_tags(params[:version])
 
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -9,12 +9,12 @@ module Fastlane
           require_relative '../../helper/ios/ios_git_helper.rb'
   
           # Checkout develop and update
-          Fastlane::Helpers::IosGitHelper.git_checkout_and_pull("develop")
+          Fastlane::Helper::IosGitHelper.git_checkout_and_pull("develop")
   
           # Create versions
-          current_version = Fastlane::Helpers::IosVersionHelper.get_public_version
-          current_build_version = Fastlane::Helpers::IosVersionHelper.get_build_version
-          next_version = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(current_version)
+          current_version = Fastlane::Helper::IosVersionHelper.get_public_version
+          current_build_version = Fastlane::Helper::IosVersionHelper.get_build_version
+          next_version = Fastlane::Helper::IosVersionHelper.calc_next_release_version(current_version)
   
           # Ask user confirmation
           if (!params[:skip_confirm])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
   
           UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
   
-          version = Fastlane::Helpers::IosVersionHelper::get_public_version
+          version = Fastlane::Helper::IosVersionHelper::get_public_version
           message = "Completing code freeze for: #{version}\n"
           if (!params[:skip_confirm])
             if (!UI.confirm("#{message}Do you want to continue?"))

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
@@ -3,7 +3,7 @@ module Fastlane
     class IosCurrentBranchIsHotfixAction < Action
       def self.run(params)
         require_relative '../../helper/ios/ios_version_helper.rb'
-        Fastlane::Helpers::IosVersionHelper::is_hotfix?(Fastlane::Helpers::IosVersionHelper::get_public_version)
+        Fastlane::Helper::IosVersionHelper::is_hotfix?(Fastlane::Helper::IosVersionHelper::get_public_version)
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -4,11 +4,11 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/ios/ios_git_helper.rb'
         require_relative '../../helper/ios/ios_version_helper.rb'
-        version = Fastlane::Helpers::IosVersionHelper::get_public_version
+        version = Fastlane::Helper::IosVersionHelper::get_public_version
         
         UI.message("Tagging final #{version}...")
 
-        Fastlane::Helpers::IosGitHelper.final_tag(version)
+        Fastlane::Helper::IosGitHelper.final_tag(version)
         
         other_action.ios_clear_intermediate_tags(version: version)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
 
         UI.user_error!("This is not a release branch. Abort.") unless other_action.git_branch.start_with?("release/")
 
-        version = Fastlane::Helpers::IosVersionHelper::get_public_version
+        version = Fastlane::Helper::IosVersionHelper::get_public_version
         message = "Finalizing release: #{version}\n"
         if (!params[:skip_confirm])
           if (!UI.confirm("#{message}Do you want to continue?"))

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -3,7 +3,7 @@ module Fastlane
       class IosGetAppVersionAction < Action
         def self.run(params)
           require_relative '../../helper/ios/ios_version_helper.rb'
-          Fastlane::Helpers::IosVersionHelper::get_public_version
+          Fastlane::Helper::IosVersionHelper::get_public_version
         end
   
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -3,7 +3,7 @@ require_relative '../../helper/ios/ios_adc_app_sizes_helper.rb'
 module Fastlane
     module Actions
       class IosGetStoreAppSizesAction < Action
-        Helper = Fastlane::Helpers::IosADCAppSizesHelper
+        Helper = Fastlane::Helper::IosADCAppSizesHelper
 
         def self.run(params)
           app_sizes = Helper::get_adc_sizes(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
@@ -10,7 +10,7 @@ module Fastlane
 
         # Evaluate previous tag
         new_ver = params[:version]
-        prev_ver = Fastlane::Helpers::IosVersionHelper::calc_prev_hotfix_version(new_ver)
+        prev_ver = Fastlane::Helper::IosVersionHelper::calc_prev_hotfix_version(new_ver)
 
         # Confirm
         message = "Requested Hotfix version: #{new_ver}\n"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -20,7 +20,7 @@ module Fastlane
           UI.message "Linting localizations for parameter placeholders consistency..."
     
           require_relative '../../helper/ios/ios_l10n_helper.rb'
-          helper = Fastlane::Helpers::IosL10nHelper.new(
+          helper = Fastlane::Helper::IosL10nHelper.new(
             install_path: resolve_path(params[:install_path]),
             version: params[:version]
           )
@@ -94,7 +94,7 @@ module Fastlane
               description: "The path where to install the SwiftGen tooling needed to run the linting process. If a relative path, should be relative to your repo_root",
               type: String,
               optional: true,
-              default_value: "vendor/swiftgen/#{Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION}"
+              default_value: "vendor/swiftgen/#{Fastlane::Helper::IosL10nHelper::SWIFTGEN_VERSION}"
             ),
             FastlaneCore::ConfigItem.new(
               key: :version,
@@ -102,7 +102,7 @@ module Fastlane
               description: "The version of SwiftGen to install and use for linting",
               type: String,
               optional: true,
-              default_value: Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION
+              default_value: Fastlane::Helper::IosL10nHelper::SWIFTGEN_VERSION
             ),
             FastlaneCore::ConfigItem.new(
               key: :input_dir,
@@ -117,7 +117,7 @@ module Fastlane
               description: "The language that should be used as the base language that every other language will be compared against",
               type: String,
               optional: true,
-              default_value: Fastlane::Helpers::IosL10nHelper::DEFAULT_BASE_LANG
+              default_value: Fastlane::Helper::IosL10nHelper::DEFAULT_BASE_LANG
             ),
             FastlaneCore::ConfigItem.new(
               key: :only_langs,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
@@ -6,7 +6,7 @@ module Fastlane
   
         require_relative '../../helper/ios/ios_git_helper.rb'
         other_action.cocoapods()
-        Fastlane::Helpers::IosGitHelper.localize_project()
+        Fastlane::Helper::IosGitHelper.localize_project()
           
         UI.message "Done."
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
@@ -5,9 +5,9 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper.rb'
         require_relative '../../helper/ios/ios_git_helper.rb'
   
-        itc_ver = Fastlane::Helpers::IosVersionHelper.get_build_version()
-        int_ver = Fastlane::Helpers::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
-        Fastlane::Helpers::IosGitHelper.tag_build(itc_ver, int_ver)
+        itc_ver = Fastlane::Helper::IosVersionHelper.get_build_version()
+        int_ver = Fastlane::Helper::IosVersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
+        Fastlane::Helper::IosGitHelper.tag_build(itc_ver, int_ver)
       end
   
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/ios/ios_git_helper.rb'
 
-        Fastlane::Helpers::IosGitHelper.update_metadata()
+        Fastlane::Helper::IosGitHelper.update_metadata()
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -9,7 +9,7 @@ module Fastlane
         require_relative '../../helper/git_helper.rb'
 
         path = File.join(ENV["PROJECT_ROOT_FOLDER"] || '.', 'RELEASE-NOTES.txt')
-        next_version = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(params[:new_version])
+        next_version = Fastlane::Helper::IosVersionHelper.calc_next_release_version(params[:new_version])
 
         Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
         Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path, push: true)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
@@ -5,10 +5,10 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper.rb'
         require_relative '../../helper/ios/ios_version_helper.rb'
 
-        version = Fastlane::Helpers::IosVersionHelper::get_public_version()
-        UI.user_error!("HEAD is not on tag. Aborting!") unless Fastlane::Helpers::IosGitHelper::is_head_on_tag()
+        version = Fastlane::Helper::IosVersionHelper::get_public_version()
+        UI.user_error!("HEAD is not on tag. Aborting!") unless Fastlane::Helper::IosGitHelper::is_head_on_tag()
 
-        return Fastlane::Helpers::IosGitHelper::has_final_tag_for(version)
+        return Fastlane::Helper::IosGitHelper::has_final_tag_for(version)
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  module Helpers
+  module Helper
     module AndroidGitHelper
 
       def self.git_checkout_and_pull(branch)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -1,5 +1,5 @@
 module Fastlane
-    module Helpers
+    module Helper
       # A module containing helper methods to manipulate/extract/bump Android version strings in gradle files
       #
       module AndroidVersionHelper

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
@@ -1,7 +1,7 @@
 require 'spaceship'
 
 module Fastlane
-    module Helpers
+    module Helper
       module IosADCAppSizesHelper
         DEFAULT_DEVICES = ["Universal", "iPhone 8", "iPhone X"]
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  module Helpers
+  module Helper
     module IosGitHelper
 
       def self.git_checkout_and_pull(branch)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -2,7 +2,7 @@ require 'yaml'
 require 'tmpdir'
 
 module Fastlane
-    module Helpers
+    module Helper
       class IosL10nHelper
         SWIFTGEN_VERSION = '6.4.0'
         DEFAULT_BASE_LANG = 'en'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -1,5 +1,5 @@
 module Fastlane
-    module Helpers
+    module Helper
       # A module containing helper methods to manipulate/extract/bump iOS version strings in xcconfig files
       #
       module IosVersionHelper

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
 
           # First run: expect curl, unzip and cp_r to be called to install SwiftGen before running the action
           # See spec_helper.rb for documentation about `expect_shell_command`.
-          expect_shell_command("curl", any_args, /\/.*swiftgen-#{Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION}.zip/)
+          expect_shell_command("curl", any_args, /\/.*swiftgen-#{Fastlane::Helper::IosL10nHelper::SWIFTGEN_VERSION}.zip/)
           expect_shell_command("unzip", any_args)
           expect(FileUtils).to receive(:cp_r)
           expect_shell_command("#{install_dir}/bin/swiftgen", "config", "run", "--config", anything)
@@ -33,7 +33,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
           script = <<~SCRIPT
             #!/bin/sh
             if [[ "$1" == "--version" ]]; then
-              echo "SwiftGen v#{Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION} (Fake binstub)"
+              echo "SwiftGen v#{Fastlane::Helper::IosL10nHelper::SWIFTGEN_VERSION} (Fake binstub)"
             fi
           SCRIPT
           FileUtils.mkdir_p File.join(install_dir, 'bin')
@@ -101,7 +101,7 @@ def run_l10n_linter_test(data_file)
   # Note: We will install SwiftGen in vendor/swiftgen if it's not already installed yet, and intentionally won't
   #       remove this after the test ends, so that further executions of the test run faster.
   #       Only the first execution of the tests might take longer if it needs to install SwiftGen first to be able to run the tests.
-  install_dir = "vendor/swiftgen/#{Fastlane::Helpers::IosL10nHelper::SWIFTGEN_VERSION}"
+  install_dir = "vendor/swiftgen/#{Fastlane::Helper::IosL10nHelper::SWIFTGEN_VERSION}"
   result = Fastlane::Actions::IosLintLocalizationsAction.run(
     install_path: install_dir,
     input_dir: @test_data_dir,


### PR DESCRIPTION
This PR sits on top of https://github.com/wordpress-mobile/release-toolkit/pull/198 and simply renames the `module Helpers` into `module Helper` for consistency both in code and in the generated documentation.

> ⚠️  This PR is ready for review but PLEASE DO NOT MERGE it yourself. Once it's approved I will take care of merging it as it should only be merged after #198 is itself merged.

### Why?

* In fastlane's own source code, the helpers live inside `Fastlane::Helper` (singular).
* In our codebase, some helpers are named under `Fastlane::Helper` but others are named `Fastlane::Helpers`.

This discrepancy makes the code inconsistent but also makes the YARD documentation incoherent, by splitting some modules and helpers in one module and other helpers in another.

### How?

This is mainly a "Find & Replace All" on the codebase for `module Helpers` and `Fastlane::Helpers` to its singular form instead. I made it a dedicated PR for easier review because it touches many files and already makes quite a big diff all by itself.

### To Test

* Review the code changes
* Run `bundle install && bundle exec rspec` to run the existing tests and ensure they still compile and pass
* Optionally you could try running a couple of actions (`bundle exec fastlane run <action_name>` to ensure that they still work, though be careful about potential side effects triggered by those actions (we wouldn't want to cut a release or push a new beta unexpectedly)
* Run `bundle exec yard doc` to generate the documentation. Open `yard-doc/index.html` in your browser and ensure that the modules and helpers are consistently classified under a common `Fastlane` > `Helper` hierarchy