### PR TITLE
[Tooling/Cleanup] Cleanup git helpers

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
 
         # Checkout develop and update
-        Fastlane::Helper::Android::GitHelper::git_checkout_and_pull("develop")
+        Fastlane::Helper::GitHelper::checkout_and_pull("develop")
 
         # Check versions
         release_version = Fastlane::Helper::Android::VersionHelper::get_release_version
@@ -19,7 +19,7 @@ module Fastlane
         
         # Check branch
         app_version = Fastlane::Helper::Android::VersionHelper::get_public_version
-        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::Android::GitHelper::git_checkout_and_pull_release_branch_for(app_version))
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::GitHelper::checkout_and_pull(release: app_version))
         
         # Check user overwrite
         if (!params[:base_version].nil?)
@@ -50,7 +50,7 @@ module Fastlane
       end
 
       def self.get_user_build_version(version, message)
-        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::Android::GitHelper::git_checkout_and_pull_release_branch_for(version)
+        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::GitHelper::checkout_and_pull(release: version)
         release_version = Fastlane::Helper::Android::VersionHelper::get_release_version
         message << "Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}.\n"
         alpha_release_version = Fastlane::Helper::Android::VersionHelper::get_alpha_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -8,7 +8,7 @@ module Fastlane
           UI.user_error!("Can't build beta and final at the same time!")
         end
 
-        Fastlane::Helper::Android::GitHelper.check_on_branch("release") unless other_action.is_ci()
+        Fastlane::Helper::GitHelper.ensure_on_branch!("release") unless other_action.is_ci()
         
         message = ""
         beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version() unless !params[:beta] and !params[:final]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -15,7 +15,7 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(@new_version_beta, @new_version_alpha)  
         UI.message "Done!"
  
-        Fastlane::Helper::Android::GitHelper.bump_version_beta()        
+        Fastlane::Helper::Android::GitHelper.commit_version_bump()        
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -7,7 +7,7 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
         require_relative '../../helper/android/android_version_helper.rb'
 
-        Fastlane::Helper::Android::GitHelper.check_on_branch("release")
+        Fastlane::Helper::GitHelper.ensure_on_branch!("release")
         create_config()
         show_config()
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -15,7 +15,7 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(@final_version, @current_version_alpha)  
         UI.message "Done!"
  
-        Fastlane::Helper::Android::GitHelper.bump_version_final()        
+        Fastlane::Helper::Android::GitHelper.commit_version_bump()        
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -7,7 +7,7 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
         require_relative '../../helper/android/android_version_helper.rb'
 
-        Fastlane::Helper::Android::GitHelper.check_on_branch("release")
+        Fastlane::Helper::GitHelper.ensure_on_branch!("release")
         create_config()
         show_config()
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -13,7 +13,7 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(@new_version, @current_version_alpha) 
         UI.message "Done!"
 
-        Fastlane::Helper::Android::GitHelper.bump_version_hotfix(params[:version_name])
+        Fastlane::Helper::Android::GitHelper.commit_version_bump()
         
         UI.message "Done."
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -5,7 +5,7 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/android/android_git_helper.rb'
-        Fastlane::Helper::Android::GitHelper.branch_for_hotfix(params[:previous_version_name], params[:version_name])
+        Fastlane::Helper::GitHelper.create_branch_for_hotfix(params[:previous_version_name], params[:version_name])
         create_config(params[:previous_version_name], params[:version_name], params[:version_code])
         show_config()
         

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -5,7 +5,7 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/android/android_git_helper.rb'
-        Fastlane::Helper::GitHelper.cut_hotfix_branch(params[:previous_version_name], params[:version_name])
+        Fastlane::Helper::GitHelper.create_branch("release/#{params[:version_name]}", from: params[:previous_version_name])
         create_config(params[:previous_version_name], params[:version_name], params[:version_code])
         show_config()
         

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -5,7 +5,7 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/android/android_git_helper.rb'
-        Fastlane::Helper::GitHelper.create_branch_for_hotfix(params[:previous_version_name], params[:version_name])
+        Fastlane::Helper::GitHelper.cut_hotfix_branch(params[:previous_version_name], params[:version_name])
         create_config(params[:previous_version_name], params[:version_name], params[:version_code])
         show_config()
         

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -17,7 +17,7 @@ module Fastlane
 
           # Update local develop and branch
           UI.message "Creating new branch..."
-          Fastlane::Helper::Android::GitHelper.do_release_branch(@new_release_branch)
+          Fastlane::Helper::GitHelper.cut_release_branch(@new_release_branch)
           UI.message "Done!"
 
           UI.message "Updating versions..."

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -22,7 +22,7 @@ module Fastlane
 
           UI.message "Updating versions..."
           Fastlane::Helper::Android::VersionHelper.update_versions(@new_version_beta, @new_version_alpha) 
-          Fastlane::Helper::Android::GitHelper.bump_version_release()         
+          Fastlane::Helper::Android::GitHelper.commit_version_bump()         
           UI.message "Done."
         end
   

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -17,7 +17,7 @@ module Fastlane
 
           # Update local develop and branch
           UI.message "Creating new branch..."
-          Fastlane::Helper::GitHelper.cut_release_branch(@new_release_branch)
+          Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: "develop")
           UI.message "Done!"
 
           UI.message "Updating versions..."

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -12,7 +12,7 @@ module Fastlane
           require_relative '../../helper/android/android_git_helper.rb'
   
           # Checkout develop and update
-          Fastlane::Helper::Android::GitHelper.git_checkout_and_pull("develop")
+          Fastlane::Helper::GitHelper.checkout_and_pull("develop")
 
           # Create versions
           current_version = Fastlane::Helper::Android::VersionHelper.get_release_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -7,7 +7,8 @@ module Fastlane
     
           release_ver = Fastlane::Helper::Android::VersionHelper.get_release_version()
           alpha_ver = Fastlane::Helper::Android::VersionHelper.get_alpha_version() unless ENV["HAS_ALPHA_VERSION"].nil?
-          Fastlane::Helper::Android::GitHelper.tag_build(release_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME], (ENV["HAS_ALPHA_VERSION"].nil? or (params[:tag_alpha] == false)) ? nil : alpha_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME])
+          Fastlane::Helper::GitHelper.create_tag(release_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME])
+          Fastlane::Helper::GitHelper.create_tag(alpha_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]) unless ENV["HAS_ALPHA_VERSION"].nil? || (params[:tag_alpha] == false)
         end
     
         #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper.rb'
 
         # Checkout develop and update
-        Fastlane::Helper::Ios::GitHelper::git_checkout_and_pull("develop")
+        Fastlane::Helper::GitHelper::checkout_and_pull("develop")
 
         # Check versions
         build_version = Fastlane::Helper::Ios::VersionHelper::get_build_version
@@ -17,7 +17,7 @@ module Fastlane
         
         # Check branch
         app_version = Fastlane::Helper::Ios::VersionHelper::get_public_version
-        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::Ios::GitHelper::git_checkout_and_pull_release_branch_for(app_version))
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::GitHelper::checkout_and_pull(release: app_version))
         
         # Check user overwrite
         build_version = get_user_build_version(params[:base_version], message) unless params[:base_version].nil?
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.get_user_build_version(version, message)
-        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::Ios::GitHelper::git_checkout_and_pull_release_branch_for(version)
+        UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::GitHelper::checkout_and_pull(release: version)
         build_version = Fastlane::Helper::Ios::VersionHelper::get_build_version
         message << "Looking at branch release/#{version} as requested by user. Detected version: #{build_version}.\n"
         build_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -15,7 +15,7 @@ module Fastlane
         Fastlane::Helper::Ios::VersionHelper.update_xc_configs(@new_beta_version, @short_version, @new_internal_version) 
         UI.message "Done!"
  
-        Fastlane::Helper::Ios::GitHelper.bump_version_beta        
+        Fastlane::Helper::Ios::GitHelper.commit_version_bump(include_deliverfile: false, include_metadata: false)
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -7,7 +7,7 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper.rb'
         require_relative '../../helper/ios/ios_version_helper.rb'
 
-        Fastlane::Helper::Ios::GitHelper.check_on_branch("release")
+        Fastlane::Helper::GitHelper.ensure_on_branch!("release")
         create_config()
         show_config()
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -5,7 +5,7 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/ios/ios_git_helper.rb'
-        Fastlane::Helper::GitHelper.create_branch_for_hotfix(params[:previous_version], params[:version])
+        Fastlane::Helper::GitHelper.cut_hotfix_branch(params[:previous_version], params[:version])
         create_config(params[:previous_version], params[:version])
         show_config()
         

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -5,7 +5,7 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/ios/ios_git_helper.rb'
-        Fastlane::Helper::GitHelper.cut_hotfix_branch(params[:previous_version], params[:version])
+        Fastlane::Helper::GitHelper.create_branch("release/#{params[:version]}", from: params[:previous_version])
         create_config(params[:previous_version], params[:version])
         show_config()
         

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -5,7 +5,7 @@ module Fastlane
         UI.message "Bumping app release version for hotfix..."
         
         require_relative '../../helper/ios/ios_git_helper.rb'
-        Fastlane::Helper::Ios::GitHelper.branch_for_hotfix(params[:previous_version], params[:version])
+        Fastlane::Helper::GitHelper.create_branch_for_hotfix(params[:previous_version], params[:version])
         create_config(params[:previous_version], params[:version])
         show_config()
         

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -16,7 +16,7 @@ module Fastlane
         Fastlane::Helper::Ios::VersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
         UI.message "Done!"
 
-        Fastlane::Helper::Ios::GitHelper.bump_version_hotfix(params[:version])
+        Fastlane::Helper::Ios::GitHelper.commit_version_bump(include_deliverfile: true, include_metadata: false)
         
         UI.message "Done."
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -17,7 +17,7 @@ module Fastlane
 
           # Update local develop and branch
           Fastlane::Helper::GitHelper.checkout_and_pull("develop")
-          Fastlane::Helper::GitHelper.cut_release_branch(@new_release_branch)
+          Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: "develop")
           UI.message "Done!"
 
           UI.message "Updating glotPressKeys..."  unless params[:skip_glotpress]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -32,7 +32,10 @@ module Fastlane
           Fastlane::Helper::Ios::VersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal) 
           UI.message "Done!"
 
-          Fastlane::Helper::Ios::GitHelper.bump_version_release(params[:skip_deliver], params[:skip_glotpress])
+          Fastlane::Helper::Ios::GitHelper.commit_version_bump(
+            include_deliverfile: !params[:skip_deliver],
+            include_metadata: !params[:skip_glotpress]
+          )
           
           UI.message "Done."
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -17,7 +17,7 @@ module Fastlane
 
           # Update local develop and branch
           Fastlane::Helper::GitHelper.checkout_and_pull("develop")
-          Fastlane::Helper::Ios::GitHelper.do_release_branch(@new_release_branch)
+          Fastlane::Helper::GitHelper.cut_release_branch(@new_release_branch)
           UI.message "Done!"
 
           UI.message "Updating glotPressKeys..."  unless params[:skip_glotpress]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -16,7 +16,7 @@ module Fastlane
           show_config()
 
           # Update local develop and branch
-          Fastlane::Helper::Ios::GitHelper.git_checkout_and_pull("develop")
+          Fastlane::Helper::GitHelper.checkout_and_pull("develop")
           Fastlane::Helper::Ios::GitHelper.do_release_branch(@new_release_branch)
           UI.message "Done!"
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
           require_relative '../../helper/ios/ios_git_helper.rb'
   
           # Checkout develop and update
-          Fastlane::Helper::Ios::GitHelper.git_checkout_and_pull("develop")
+          Fastlane::Helper::GitHelper.checkout_and_pull("develop")
   
           # Create versions
           current_version = Fastlane::Helper::Ios::VersionHelper.get_public_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -8,7 +8,7 @@ module Fastlane
         
         UI.message("Tagging final #{version}...")
 
-        Fastlane::Helper::Ios::GitHelper.final_tag(version)
+        Fastlane::Helper::GitHelper.create_tag(version)
         
         other_action.ios_clear_intermediate_tags(version: version)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
@@ -7,7 +7,8 @@ module Fastlane
   
         itc_ver = Fastlane::Helper::Ios::VersionHelper.get_build_version()
         int_ver = Fastlane::Helper::Ios::VersionHelper.get_internal_version() unless ENV["INTERNAL_CONFIG_FILE"].nil?
-        Fastlane::Helper::Ios::GitHelper.tag_build(itc_ver, int_ver)
+        Fastlane::Helper::GitHelper.create_tag(itc_ver)
+        Fastlane::Helper::GitHelper.create_tag(int_ver) unless int_ver.nil?
       end
   
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
@@ -6,9 +6,10 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper.rb'
 
         version = Fastlane::Helper::Ios::VersionHelper::get_public_version()
-        UI.user_error!("HEAD is not on tag. Aborting!") unless Fastlane::Helper::Ios::GitHelper::is_head_on_tag()
+        head_tags = Fastlane::Helper::GitHelper.list_tags_on_current_commit()
+        UI.user_error!("HEAD is not on tag. Aborting!") if head_tags.empty?
 
-        return Fastlane::Helper::Ios::GitHelper::has_final_tag_for(version)
+        return head_tags.include?(version) # Current commit is tagged with "version" tag
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -2,16 +2,6 @@ module Fastlane
   module Helper
     module Android
       module GitHelper
-        def self.update_metadata(validate_translation_command)
-          Action.sh("./tools/update-translations.sh")
-          Action.sh("git submodule update --init --recursive")
-          Action.sh("./gradlew #{validate_translation_command}")
-          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/src/main/res")
-          Action.sh("git diff-index --quiet HEAD || git commit -m \"Updates translations\"")
-
-          Action.sh("git push origin HEAD")
-        end
-
         # Commit and push the files that are modified when we bump version numbers on an iOS project
         #
         # This typically commits and pushes the `build.gradle` file inside the project subfolder.
@@ -25,6 +15,16 @@ module Fastlane
             files: File.join(ENV["PROJECT_ROOT_FOLDER"], ENV["PROJECT_NAME"], "build.gradle"),
             push: true
           )
+        end
+
+        def self.update_metadata(validate_translation_command)
+          Action.sh("./tools/update-translations.sh")
+          Action.sh("git submodule update --init --recursive")
+          Action.sh("./gradlew #{validate_translation_command}")
+          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/src/main/res")
+          Action.sh("git diff-index --quiet HEAD || git commit -m \"Updates translations\"")
+
+          Action.sh("git push origin HEAD")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -53,11 +53,6 @@ module Fastlane
           Action.sh("git push origin HEAD")
         end
 
-        def self.tag_build(release_version, alpha_version)
-          Fastlane::Helper::GitHelper.create_tag(release_version)
-          Fastlane::Helper::GitHelper.create_tag(alpha_version) unless alpha_version.nil?
-        end
-
         def self.check_on_branch(branch_name)
           current_branch_name=Action.sh("git symbolic-ref -q HEAD")
           UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -2,23 +2,6 @@ module Fastlane
   module Helper
     module Android
       module GitHelper
-        def self.git_checkout_and_pull(branch)
-          Action.sh("git checkout #{branch}")
-          Action.sh("git pull")
-        end
-
-        def self.git_checkout_and_pull_release_branch_for(version)
-          branch_name = "release/#{version}"
-          Action.sh("git pull")
-          begin
-            Action.sh("git checkout #{branch_name}")
-            Action.sh("git pull origin #{branch_name}")
-            return true
-          rescue
-            return false
-          end
-        end
-
         def self.do_release_branch(branch_name)
           if (check_branch_exists(branch_name) == true) then
             UI.message("Branch #{branch_name} already exists. Skipping creation.")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -35,11 +35,6 @@ module Fastlane
           Action.sh("git commit -m \"Bump version number\"")
           Action.sh("git push origin HEAD")
         end
-
-        def self.check_on_branch(branch_name)
-          current_branch_name=Action.sh("git symbolic-ref -q HEAD")
-          UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
-        end
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -1,6 +1,8 @@
 module Fastlane
   module Helper
     module Android
+      # Helper methods to execute git-related operations that are specific to Android projects
+      #
       module GitHelper
         # Commit and push the files that are modified when we bump version numbers on an iOS project
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -12,28 +12,12 @@ module Fastlane
           Action.sh("git push origin HEAD")
         end
 
-        def self.bump_version_release()
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]} && git add ./build.gradle")
-          Action.sh("git commit -m \"Bump version number\"")
-          Action.sh("git push origin HEAD")
-        end
-
-        def self.bump_version_beta()
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]} && git add ./build.gradle")
-          Action.sh("git commit -m \"Bump version number\"")
-          Action.sh("git push origin HEAD")
-        end
-
-        def self.bump_version_hotfix(version)
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]} && git add ./build.gradle")
-          Action.sh("git commit -m \"Bump version number\"")
-          Action.sh("git push origin HEAD")
-        end
-
-        def self.bump_version_final()
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]} && git add ./build.gradle")
-          Action.sh("git commit -m \"Bump version number\"")
-          Action.sh("git push origin HEAD")
+        def self.commit_version_bump()
+          Fastlane::Helper::GitHelper.commit(
+            message: "Bump version number",
+            files: File.join(ENV["PROJECT_ROOT_FOLDER"], ENV["PROJECT_NAME"], "build.gradle"),
+            push: true
+          )
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -12,6 +12,13 @@ module Fastlane
           Action.sh("git push origin HEAD")
         end
 
+        # Commit and push the files that are modified when we bump version numbers on an iOS project
+        #
+        # This typically commits and pushes the `build.gradle` file inside the project subfolder.
+        #
+        # @env PROJECT_ROOT_FOLDER The path to the git root of the project
+        # @env PROJECT_NAME The name of the directory containing the project code (especially containing the `build.gradle` file)
+        #
         def self.commit_version_bump()
           Fastlane::Helper::GitHelper.commit(
             message: "Bump version number",

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -2,23 +2,6 @@ module Fastlane
   module Helper
     module Android
       module GitHelper
-        def self.do_release_branch(branch_name)
-          if (check_branch_exists(branch_name) == true) then
-            UI.message("Branch #{branch_name} already exists. Skipping creation.")
-            Action.sh("git checkout #{branch_name}")
-            Action.sh("git pull origin #{branch_name}")
-          else
-            Action.sh("git checkout -b #{branch_name}")
-
-            # Push to origin
-            Action.sh("git push -u origin #{branch_name}")
-          end
-        end
-
-        def self.check_branch_exists(branch_name)
-          !Action.sh("git branch --list #{branch_name}").empty?
-        end
-
         def self.update_metadata(validate_translation_command)
           Action.sh("./tools/update-translations.sh")
           Action.sh("git submodule update --init --recursive")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -54,18 +54,13 @@ module Fastlane
         end
 
         def self.tag_build(release_version, alpha_version)
-          tag_and_push(release_version)
-          tag_and_push(alpha_version) unless alpha_version.nil?
+          Fastlane::Helper::GitHelper.create_tag(release_version)
+          Fastlane::Helper::GitHelper.create_tag(alpha_version) unless alpha_version.nil?
         end
 
         def self.check_on_branch(branch_name)
           current_branch_name=Action.sh("git symbolic-ref -q HEAD")
           UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
-        end
-
-        private
-        def self.tag_and_push(version)
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git tag #{version} && git push origin #{version}")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -26,6 +26,9 @@ module Fastlane
         #
         # @param [String] validate_translation_command The name of the gradle task to run to validate the translations
         #
+        # @todo Migrate the scripts, currently in each host repo and called by this method, to be helpers and actions
+        #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
+        #
         def self.update_metadata(validate_translation_command)
           Action.sh("./tools/update-translations.sh")
           Action.sh("git", "submodule", "update", "--init", "--recursive")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -63,12 +63,6 @@ module Fastlane
           UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
         end
 
-        def self.branch_for_hotfix(tag_version, new_version)
-          Action.sh("git checkout #{tag_version}")
-          Action.sh("git checkout -b release/#{new_version}")
-          Action.sh("git push --set-upstream origin release/#{new_version}")
-        end
-
         private
         def self.tag_and_push(version)
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git tag #{version} && git push origin #{version}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -17,14 +17,20 @@ module Fastlane
           )
         end
 
+        # Calls the `tools/update-translations.sh` script from the project repo, then lint them using the provided gradle task
+        #
+        # @env PROJECT_ROOT_FOLDER The path to the git root of the project
+        # @env PROJECT_NAME The name of the directory containing the project code (especially containing the `build.gradle` file)
+        #
+        # @param [String] validate_translation_command The name of the gradle task to run to validate the translations
+        #
         def self.update_metadata(validate_translation_command)
           Action.sh("./tools/update-translations.sh")
-          Action.sh("git submodule update --init --recursive")
-          Action.sh("./gradlew #{validate_translation_command}")
-          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/src/main/res")
-          Action.sh("git diff-index --quiet HEAD || git commit -m \"Updates translations\"")
-
-          Action.sh("git push origin HEAD")
+          Action.sh("git", "submodule", "update", "--init", "--recursive")
+          Action.sh("./gradlew", validate_translation_command)
+          
+          res_dir = File.join(ENV["PROJECT_ROOT_FOLDER"], ENV["PROJECT_NAME"], "src", "main", "res")
+          Fastlane::Helper::GitHelper.commit(message: "Update translations", files: res_dir, push: true)
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -49,7 +49,7 @@ module Fastlane
       # @param [String] tag_version The name of the tag to cut the hotfix from
       # @param [String] new_version The name of the new version, e.g. "1.2.3"
       #
-      def self.create_branch_for_hotfix(tag_version, new_version)
+      def self.cut_hotfix_branch(tag_version, new_version)
         Action.sh("git", "checkout", tag_version)
         Action.sh("git", "checkout", "-b", "release/#{new_version}")
         Action.sh("git", "push", "--set-upstream", "origin", "release/#{new_version}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -30,6 +30,17 @@ module Fastlane
         return false
       end
 
+      def self.cut_release_branch(branch_name)
+        if branch_exists?(branch_name)
+          UI.message("Branch #{branch_name} already exists. Skipping creation.")
+          Action.sh("git", "checkout", branch_name)
+          Action.sh("git", "pull", "origin", branch_name)
+        else
+          Action.sh("git", "checkout", "-b", branch_name)
+          Action.sh("git", "push", "-u", "origin", branch_name)
+        end
+      end
+
       # Create a new branch in preparation to do a hotfix.
       #
       # - Cuts the new branch from the tag `tag_version`
@@ -81,6 +92,16 @@ module Fastlane
       #
       def self.list_tags_on_current_commit
         Action.sh("git", "tag", "--points-at", "HEAD").split("\n")
+      end
+
+      # Checks if a branch exists locally.
+      #
+      # @param [String] branch_name The name of the branch to check for
+      #
+      # @return [Bool] True if the branch exists in the local working copy, false otherwise.
+      #
+      def self.branch_exists?(branch_name)
+        !Action.sh("git", "branch", "--list", branch_name).empty?
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -92,7 +92,7 @@ module Fastlane
       # Creates a tag for the given version, and optionally push it to the remote.
       #
       # @param [String] version The name of the tag to push, e.g. "1.2"
-      # @param [Bool] push If true 9the default), the tag will also be pushed to `origin`
+      # @param [Bool] push If true (the default), the tag will also be pushed to `origin`
       #
       def self.create_tag(version, push: true)
         Action.sh("git", "tag", version)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -30,29 +30,25 @@ module Fastlane
         return false
       end
 
-      def self.cut_release_branch(branch_name)
+      # Create a new branch named `branch_name`, cutting it from branch/commit/tag `from`, and push it
+      #
+      # If the branch with that name already exists, it will instead switch to it and pull new commits.
+      #
+      # @param [String] branch_name The full name of the new branch to create, e.g "release/1.2"
+      # @param [String?] from The branch or tag from which to cut the branch from.
+      #        If `nil`, will cut the new branch from the current commit. Otherwise, will checkout that commit/branch/tag before cutting the branch.
+      # @param [Bool] push If true, will also push the branch to `origin`, tracking the upstream branch with the local one.
+      #
+      def self.create_branch(branch_name, from: nil, push: true)
         if branch_exists?(branch_name)
           UI.message("Branch #{branch_name} already exists. Skipping creation.")
           Action.sh("git", "checkout", branch_name)
           Action.sh("git", "pull", "origin", branch_name)
         else
+          Action.sh("git", "checkout", from) unless from.nil?
           Action.sh("git", "checkout", "-b", branch_name)
-          Action.sh("git", "push", "-u", "origin", branch_name)
+          Action.sh("git", "push", "-u", "origin", branch_name) if push
         end
-      end
-
-      # Create a new branch in preparation to do a hotfix.
-      #
-      # - Cuts the new branch from the tag `tag_version`
-      # - The name of the new branch will be `release/#{new_verison}`
-      #
-      # @param [String] tag_version The name of the tag to cut the hotfix from
-      # @param [String] new_version The name of the new version, e.g. "1.2.3"
-      #
-      def self.cut_hotfix_branch(tag_version, new_version)
-        Action.sh("git", "checkout", tag_version)
-        Action.sh("git", "checkout", "-b", "release/#{new_version}")
-        Action.sh("git", "push", "--set-upstream", "origin", "release/#{new_version}")
       end
 
       # `git add` the specified files (if any provided) then commit them using the provided message.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -64,6 +64,16 @@ module Fastlane
         Action.sh("git", "commit", *args, "-m", message)
         Action.sh("git", "push", "origin", "HEAD") if push
       end
+
+      # Creates a tag for the given version, and optionally push it to the remote.
+      #
+      # @param [String] version The name of the tag to push, e.g. "1.2"
+      # @param [Bool] push If true 9the default), the tag will also be pushed to `origin`
+      #
+      def self.create_tag(version, push: true)
+        Action.sh("git", "tag", version)
+        Action.sh("git", "push", "origin", version) if push
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -90,6 +90,36 @@ module Fastlane
         Action.sh("git", "tag", "--points-at", "HEAD").split("\n")
       end
 
+      # List all the tags in the local working copy, optionally filtering the list using a pattern
+      #
+      # @param [String] matching The pattern of the tag(s) to match and filter on; use "*" for wildcards.
+      #        For example, `"1.2.*"` will match every tag starting with `"1.2."`. Defaults to '*' which lists all tags.
+      #
+      # @return [Array<String>] The list of local tags matching the pattern
+      #
+      def self.list_local_tags(matching: "*")
+        Action.sh("git", "tag", "--list", matching).split("\n")
+      end
+
+      # Delete the mentioned local tags in the local working copy, and optionally delete them on the remote too.
+      #
+      # @param [Array<String>] tag_names The list of tags to delete
+      # @param [Bool] delete_on_remote If true, will also delete the tag from the remote. Otherwise, it will only be deleted locally.
+      #
+      def self.delete_tags(tag_names, delete_on_remote: false)
+        Action.sh("git", "tag", "-d", *tag_names)
+        if delete_on_remote
+          remote_refs = tag_names.map { |tag| ":refs/tags/#{tag}" }
+          Action.sh("git", "push", "origin", *remote_refs)
+        end
+      end
+
+      # Fetch all the tags from the remote.
+      #
+      def self.fetch_all_tags()
+        Action.sh("git", "fetch", "--tags")
+      end
+
       # Checks if a branch exists locally.
       #
       # @param [String] branch_name The name of the branch to check for

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -74,6 +74,14 @@ module Fastlane
         Action.sh("git", "tag", version)
         Action.sh("git", "push", "origin", version) if push
       end
+
+      # Returns the list of tags that are pointing to the current commit (HEAD)
+      #
+      # @return [Array<String>] List of tags associated with the HEAD commit
+      #
+      def self.list_tags_on_current_commit
+        Action.sh("git", "tag", "--points-at", "HEAD").split("\n")
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -13,6 +13,23 @@ module Fastlane
         `git config --get-regex lfs`.length > 0
       end
 
+      # Switch to the given branch and pull its latest commits.
+      #
+      # @param [String,Hash] branch Name of the branch to pull.
+      #        If you provide a Hash with a single key=>value pair, it will build the branch name as `"#{key}/#{value}"`,
+      #        i.e. `checkout_and_pull(release: version)` is equivalent to `checkout_and_pull("release/#{version}")`.    
+      #
+      # @return [Bool] True if it succeeded switching and pulling, false if there was an error during the switch or pull.
+      #
+      def self.checkout_and_pull(branch)
+        branch = branch.first.join('/') if branch.is_a?(Hash)
+        Action.sh("git", "checkout", branch)
+        Action.sh("git", "pull")
+        return true
+      rescue
+        return false
+      end
+
       # `git add` the specified files (if any provided) then commit them using the provided message.
       # Optionally, push the commit to the remote too.
       #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -103,6 +103,17 @@ module Fastlane
       def self.branch_exists?(branch_name)
         !Action.sh("git", "branch", "--list", branch_name).empty?
       end
+
+      # Ensure that we are on the expected branch, and abort if not.
+      #
+      # @param [String] branch_name The name of the branch we expect to be on
+      #
+      # @raise [UserError] Raises a user_error! and interrupts the lane if we are not on the expected branch.
+      #
+      def self.ensure_on_branch!(branch_name)
+        current_branch_name = Action.sh("git", "symbolic-ref", "-q", "HEAD")
+        UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -2,6 +2,8 @@ require 'git'
 
 module Fastlane
   module Helper
+    # Helper methods to execute git-related operations
+    #
     module GitHelper
 
       # Checks if the current directory is (inside) a git repo

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -4,12 +4,20 @@ module Fastlane
   module Helper
     module GitHelper
 
-      def self.is_git_repo
+      # Checks if the current directory is (inside) a git repo
+      #
+      # @return [Bool] True if the current directory is the root of a git repo (i.e. a local working copy) or a subdirectory of one.
+      #
+      def self.is_git_repo?
         system "git rev-parse --git-dir 1> /dev/null 2>/dev/null"
       end
 
-      def self.has_git_lfs
-        return false unless is_git_repo
+      # Check if the current directory has git-lfs enabled
+      #
+      # @return [Bool] True if the current directory is a git working copy and has git-lfs enabled.
+      #
+      def self.has_git_lfs?
+        return false unless is_git_repo?
         `git config --get-regex lfs`.length > 0
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -30,6 +30,20 @@ module Fastlane
         return false
       end
 
+      # Create a new branch in preparation to do a hotfix.
+      #
+      # - Cuts the new branch from the tag `tag_version`
+      # - The name of the new branch will be `release/#{new_verison}`
+      #
+      # @param [String] tag_version The name of the tag to cut the hotfix from
+      # @param [String] new_version The name of the new version, e.g. "1.2.3"
+      #
+      def self.create_branch_for_hotfix(tag_version, new_version)
+        Action.sh("git", "checkout", tag_version)
+        Action.sh("git", "checkout", "-b", "release/#{new_version}")
+        Action.sh("git", "push", "--set-upstream", "origin", "release/#{new_version}")
+      end
+
       # `git add` the specified files (if any provided) then commit them using the provided message.
       # Optionally, push the commit to the remote too.
       #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -60,6 +60,8 @@ module Fastlane
       #        Also accepts the special symbol `:all` to add all the files (`git commit -a -m …`).
       # @param [Bool] push If true, will `git push` to `origin` after the commit has been created. Defaults to `false`.
       #
+      # @return [Bool] True if commit and push were successful, false if there was an issue during commit & push (most likely being "nothing to commit").
+      #
       def self.commit(message:, files: nil, push: false)
         files = [files] if files.is_a?(String)
         args = []
@@ -68,8 +70,13 @@ module Fastlane
         elsif !files.nil? && !files.empty?
           Action.sh("git", "add", *files)
         end
-        Action.sh("git", "commit", *args, "-m", message)
-        Action.sh("git", "push", "origin", "HEAD") if push
+        begin
+          Action.sh("git", "commit", *args, "-m", message)
+          Action.sh("git", "push", "origin", "HEAD") if push
+          return true
+        rescue
+          return false
+        end
       end
 
       # Creates a tag for the given version, and optionally push it to the remote.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -2,6 +2,19 @@ module Fastlane
   module Helper
     module Ios
       module GitHelper
+        # Commit and push the files that are modified when we bump version numbers on an iOS project
+        #
+        # This typically commits and pushes:
+        #  - The files in `./config/*` – especially `Version.*.xcconfig` files
+        #  - The `fastlane/Deliverfile` file (which contains the `app_version` line)
+        #  - The `<ProjectRoot>/<ProjectName>/Resources/AppStoreStrings.pot` file, containing a key for that version's release notes
+        #
+        # @env PROJECT_ROOT_FOLDER The path to the git root of the project
+        # @env PROJECT_NAME The name of the directory containing the project code (especially containing the Resources/ subfolder)
+        #
+        # @param [Bool] include_deliverfile If true (the default), includes the `fastlane/Deliverfile` in files being commited
+        # @param [Bool] include_metadata If true (the default), includes the `fastlane/download_metadata.swift` file and the `.pot` file (which typically contains an entry or release notes for the new version)
+        #
         def self.commit_version_bump(include_deliverfile: true, include_metadata: true)
           files_list = [ File.join(ENV["PROJECT_ROOT_FOLDER"], "config", ".") ]
           if include_deliverfile

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -62,23 +62,6 @@ module Fastlane
           Action.sh("git push origin HEAD")
         end
 
-        def self.do_release_branch(branch_name)
-          if (check_branch_exists(branch_name) == true) then
-            UI.message("Branch #{branch_name} already exists. Skipping creation.")
-            Action.sh("git checkout #{branch_name}")
-            Action.sh("git pull origin #{branch_name}")
-          else
-            Action.sh("git checkout -b #{branch_name}")
-
-            # Push to origin
-            Action.sh("git push -u origin #{branch_name}")
-          end
-        end
-
-        def self.check_branch_exists(branch_name)
-          !Action.sh("git branch --list #{branch_name}").empty?
-        end
-
         def self.check_on_branch(branch_name)
           current_branch_name=Action.sh("git symbolic-ref -q HEAD")
           UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -56,8 +56,8 @@ module Fastlane
         end
 
         def self.tag_build(itc_version, internal_version)
-          tag_and_push(itc_version)
-          tag_and_push(internal_version) unless internal_version.nil?
+          Fastlane::Helper::GitHelper.create_tag(itc_version)
+          Fastlane::Helper::GitHelper.create_tag(internal_version) unless internal_version.nil?
         end
 
         def self.update_metadata()
@@ -106,11 +106,6 @@ module Fastlane
             end
           }
           return false
-        end
-
-        private
-        def self.tag_and_push(version)
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git tag #{version} && git push origin #{version}")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -55,11 +55,6 @@ module Fastlane
           end
         end
 
-        def self.tag_build(itc_version, internal_version)
-          Fastlane::Helper::GitHelper.create_tag(itc_version)
-          Fastlane::Helper::GitHelper.create_tag(internal_version) unless internal_version.nil?
-        end
-
         def self.update_metadata()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/update-translations.rb")
           Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/*.lproj/*.strings")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -2,23 +2,6 @@ module Fastlane
   module Helper
     module Ios
       module GitHelper
-        def self.git_checkout_and_pull(branch)
-          Action.sh("git checkout #{branch}")
-          Action.sh("git pull")
-        end
-
-        def self.git_checkout_and_pull_release_branch_for(version)
-          branch_name = "release/#{version}"
-          Action.sh("git pull")
-          begin
-            Action.sh("git checkout #{branch_name}")
-            Action.sh("git pull origin #{branch_name}")
-            return true
-          rescue
-            return false
-          end
-        end
-
         def self.branch_for_hotfix(tag_version, new_version)
           Action.sh("git checkout #{tag_version}")
           Action.sh("git checkout -b release/#{new_version}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -83,20 +83,6 @@ module Fastlane
           current_branch_name=Action.sh("git symbolic-ref -q HEAD")
           UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
         end
-
-        def self.is_head_on_tag()
-          !Action.sh("git tag --points-at HEAD").empty?
-        end
-
-        def self.has_final_tag_for(version)
-          head_tags=Action.sh("git tag --points-at HEAD").split("\n")
-          head_tags.each { | vtag |
-            if (vtag == version)
-              return true
-            end
-          }
-          return false
-        end
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -28,20 +28,6 @@ module Fastlane
           Fastlane::Helper::GitHelper.commit(message: "Bump version number", files: files_list, push: true)
         end
 
-        def self.delete_tags(version)
-          Action.sh("git tag | xargs git tag -d; git fetch --tags")
-          tags = Action.sh("git tag")
-          tags.split("\n").each do | tag |
-            if (tag.split(".").length == 4) then
-              if tag.start_with?(version) then
-                UI.message("Removing: #{tag}")
-                Action.sh("git tag -d #{tag}")
-                Action.sh("git push origin :refs/tags/#{tag}")
-              end
-            end
-          end
-        end
-
         def self.localize_project()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
           Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}*.lproj/*.strings")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -37,6 +37,9 @@ module Fastlane
         # @env PROJECT_ROOT_FOLDER The path to the git root of the project
         # @env PROJECT_NAME The name of the directory containing the project code (especially containing the `build.gradle` file)
         #
+        # @todo Migrate the scripts, currently in each host repo and called by this method, to be helpers and actions
+        #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
+        #
         def self.localize_project()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
 
@@ -50,6 +53,9 @@ module Fastlane
         #
         # @env PROJECT_ROOT_FOLDER The path to the git root of the project
         # @env PROJECT_NAME The name of the directory containing the project code (especially containing the `build.gradle` file)
+        #
+        # @todo Migrate the scripts, currently in each host repo and called by this method, to be helpers and actions
+        #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
         #
         def self.update_metadata()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/update-translations.rb")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -1,6 +1,8 @@
 module Fastlane
   module Helper
     module Ios
+      # Helper methods to execute git-related operations that are specific to iOS projects
+      #
       module GitHelper
         # Commit and push the files that are modified when we bump version numbers on an iOS project
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -2,26 +2,17 @@ module Fastlane
   module Helper
     module Ios
       module GitHelper
-        def self.bump_version_release(skip_deliver=false, skip_metadata=false)
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git add ./config/.")
-          Action.sh("git add fastlane/Deliverfile") unless skip_deliver
-          Action.sh("git add fastlane/download_metadata.swift") unless skip_metadata
-          Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}/Resources/#{ENV["APP_STORE_STRINGS_FILE_NAME"]}") unless skip_metadata
-          Action.sh("git commit -m \"Bump version number\"")
-          Action.sh("git push origin HEAD")
-        end
+        def self.commit_version_bump(include_deliverfile: true, include_metadata: true)
+          files_list = [ File.join(ENV["PROJECT_ROOT_FOLDER"], "config", ".") ]
+          if include_deliverfile
+            files_list.append File.join("fastlane", "Deliverfile")
+          end
+          if include_metadata
+            files_list.append File.join("fastlane", "download_metadata.swift")
+            files_list.append File.join(ENV["PROJECT_ROOT_FOLDER"], ENV["PROJECT_NAME"], "Resources", ENV["APP_STORE_STRINGS_FILE_NAME"])
+          end
 
-        def self.bump_version_hotfix(version)
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git add ./config/.")
-          Action.sh("git add fastlane/Deliverfile")
-          Action.sh("git commit -m \"Bump version number\"")
-          Action.sh("git push origin HEAD")
-        end
-
-        def self.bump_version_beta()
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git add ./config/.")
-          Action.sh("git commit -m \"Bump version number\"")
-          Action.sh("git push origin HEAD")
+          Fastlane::Helper::GitHelper.commit(message: "Bump version number", files: files_list, push: true)
         end
 
         def self.delete_tags(version)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -2,12 +2,6 @@ module Fastlane
   module Helper
     module Ios
       module GitHelper
-        def self.branch_for_hotfix(tag_version, new_version)
-          Action.sh("git checkout #{tag_version}")
-          Action.sh("git checkout -b release/#{new_version}")
-          Action.sh("git push --set-upstream origin release/#{new_version}")
-        end
-
         def self.bump_version_release(skip_deliver=false, skip_metadata=false)
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && git add ./config/.")
           Action.sh("git add fastlane/Deliverfile") unless skip_deliver

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -61,11 +61,6 @@ module Fastlane
 
           Action.sh("git push origin HEAD")
         end
-
-        def self.check_on_branch(branch_name)
-          current_branch_name=Action.sh("git symbolic-ref -q HEAD")
-          UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
-        end
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -38,11 +38,6 @@ module Fastlane
           end
         end
 
-        def self.final_tag(version)
-          Action.sh("git tag #{version}")
-          Action.sh("git push origin #{version}")
-        end
-
         def self.localize_project()
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
           Action.sh("git add #{ENV["PROJECT_ROOT_FOLDER"]}#{ENV["PROJECT_NAME"]}*.lproj/*.strings")

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -14,25 +14,25 @@ describe Fastlane::Helper::GitHelper do
   end
 
   it 'can detect a missing git repository' do
-    expect(Fastlane::Helper::GitHelper.is_git_repo).to be false
+    expect(Fastlane::Helper::GitHelper.is_git_repo?).to be false
   end
 
   it 'can detect a valid git repository' do
     `git init`
-    expect(Fastlane::Helper::GitHelper.is_git_repo).to be true
+    expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
   end
 
   it 'can detect a repository with Git-lfs enabled' do
     `git init`
     `git lfs install`
-    expect(Fastlane::Helper::GitHelper.has_git_lfs).to be true
+    expect(Fastlane::Helper::GitHelper.has_git_lfs?).to be true
   end
 
   it 'can detect a repository without Git-lfs enabled' do
     `git init`
     `git lfs uninstall &>/dev/null`
-    expect(Fastlane::Helper::GitHelper.is_git_repo).to be true
-    expect(Fastlane::Helper::GitHelper.has_git_lfs).to be false
+    expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
+    expect(Fastlane::Helper::GitHelper.has_git_lfs?).to be false
   end
 
   context('commit(message:, files:, push:)') do


### PR DESCRIPTION
This PR cleans up all the `ios_git_helper` + `android_git_helper` + `git_helper` methods: refactoring + YARD doc.

## Why?

 - Many were duplicated in the platform-specific helper files while there was not reason not to DRY them in one common place
 - Many methods in there were actually not really related to git. There were doing other actions then pushing the changes to git all in one place, which is probably why they ended up in those git_helpers, but most of the actions those helper were doing were something other than git in the first place
 - Many methods didn't have very explicit name, and none of them were documented

## How?

 - Refactoring all the common methods into the common `git_helper`
 - Cleaning up the calls to avoid repetition (many of those ended up just calling core methods like `commit(message:files:push:)`
 - Update the call sites, and for some of the methods which were not that much related to git, move the atomic operations directly into the actions
 - Added YARD documentation

## To Review and Test

That's the trickiest part. This is very hard to test and we don't have `rspec` for most of those methods (see "Why not TDD" below) either.

The best we can do is:
 - `bundle exec rspec` to ensure the existing tests still pass (even if there are not many tests covering the changes made there)
 - `be yard stats --list-undoc lib/fastlane/plugin/wpmreleasetoolkit/**/*git_helper.rb` to check that everything about git helpers is documented (only items that are undocumented should be the `Fastlane`, `Fastlane::Helper`, and `Fastlane::Helper::[Ios|Android]` modules)
 - `bundle exec yard doc` to generate the doc, then `open yard-doc/index.html` and inspect the documentation for the helpers
 - Review the code manually to ensure I didn't introduce typos / syntax errors in the code and didn't miss any call sites when refactoring methods… things that we can only really check by proof-reading, given that Ruby is not type-checked… 😒 
   - I split my progress in nice isolated commits, so you might prefer doing a per-commit review instead of the whole shebang.
 - Optionally, point your `Pluginfile` to this branch and run a couple of actions (ideally the ones that would not risk having any side-effects) from an app repo to ensure those still work. Unfortunately, most of the actions and helpers impacted here do have side-effects, so that might be tricky…

## Notes

### Please do thorough review 🙏

This PR should be ready to be reviewed, but I pondered about opening it as Draft or not because I didn't proof-read the whole thing after I finished everything.

* I did proof-read my individual commits and double-checked their changes, but didn't proof-read the whole PR (as I use to do) now that all the dust have settled (also because it's 11pm and my brain is nothing but a blur now…).
* I didn't actually test any of the changes either, so many of those changes were done while flying blind… which doesn't inspire me much confidence… _(That's the issue with a non-type-checked language that doesn't have unit tests 😓)_

This means that, for example, a review directly by reading diff in GitHub might not be enough to ensure that I didn't forget to update all call sites… Which is why I'd appreciate a more thorough review of those changes, especially about ensuring that the _behavior_ of helper methods are still unchanged (e.g. a parameter previously expecting just the version number for creating the release branch, but now expecting the full branch name or `release: version` instead…), there are no call sites I forgot to update, and there's no syntax error (e.g. missing comma) that slipped through…

_(At some point I'd love to add rubocop to at least catch simple things like stupid syntax errors or a missing commas… but that's whole PR on its own…)_

### Work in Progress

Things that I will probably fix in a separate incremental PR (except if I get to address those before that Draft PR gets its final review…):
* There are still a couple of methods in the platform-specific `git_helpers`, especially the helper methods around metadata+localization, and the one helper method to commit files related to version bumps (which are different set of files depending on the platforms, but are still worth DRYing in a helper rather than moving in each action because there are multiple actions using them)
* In particular, the `update_metadata` methods (iOS+Android) and the `localize_project` method (iOS) are still calling non-git-related code (invoking the script).

### Why not TDD?

I initially considered doing TDD and adding tests _first_, before refactoring. That's what tests are for after all.

Unfortunately, that ended up being very unproductive, given that the previous state of the code was really not easily testable and the amount of refactoring and thus the amount of methods (that I was gonna add tests for) that I was gonna delete, move and refactor entirely. That would have made any test written prior refactoring be obsolete by the end of it.

I know that it would have been ideal to write the tests prior to refactoring – that's the whole benefit of having tests after all – but that was too cumbersome to do, so I decided to keep the writing of the tests for a future PR addressing #193 .