### PR TITLE
[rubocop] Step 5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Lint/UnusedMethodArgument:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
 # Enabling the 'frozen_string_literal: true' comment is nice but should be done with extra care
 # because enabling it on code that accidentally mutates string literals will crash at runtime
 # (e.g. `name = 'Hello'` then later `name << ' world'` will crash if the comment is enabled)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,13 @@ Lint/UnusedMethodArgument:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+# Enabling the 'frozen_string_literal: true' comment is nice but should be done with extra care
+# because enabling it on code that accidentally mutates string literals will crash at runtime
+# (e.g. `name = 'Hello'` then later `name << ' world'` will crash if the comment is enabled)
+# So we might enable it at some point, be we will need very careful review that this doesn't break everything.
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 ########## Metrics / Max Lengths Rules
 
 Metrics/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Gemspec/OrderedDependencies:
 Lint/UnusedMethodArgument:
   Enabled: false
 
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 ########## Metrics / Max Lengths Rules
 
 Metrics/LineLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -435,20 +435,6 @@ Style/SpecialGlobalVars:
   Exclude:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb'
 
-# Offense count: 12
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiteralsInInterpolation:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: .

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,15 +228,6 @@ Style/AsciiComments:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
     - 'spec/ios_lint_localizations_spec.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SingleLineConditionsOnly, IncludeTernaryExpressions.
-# SupportedStyles: assign_to_condition, assign_inside_condition
-Style/ConditionalAssignment:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
-
 # Offense count: 22
 # Cop supports --auto-correct.
 Style/DefWithParentheses:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -323,14 +323,6 @@ Style/Next:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedOctalStyle.
-# SupportedOctalStyles: zero_with_o, zero_only
-Style/NumericLiteralPrefix:
-  Exclude:
-    - 'spec/ios_lint_localizations_spec.rb'
-
 # Offense count: 23
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, EnforcedStyle, IgnoredMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,24 +228,6 @@ Style/AsciiComments:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
     - 'spec/ios_lint_localizations_spec.rb'
 
-# Offense count: 24
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners.
-# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
-# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-# FunctionalMethods: let, let!, subject, watch
-# IgnoredMethods: lambda, proc, it
-Style/BlockDelimiters:
-  Exclude:
-    - 'bin/drawText'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
-
 # Offense count: 7
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -214,22 +214,6 @@ Security/Open:
     - 'spec/android_merge_translators_strings_spec.rb'
     - 'spec/ios_merge_translators_strings_spec.rb'
 
-# Offense count: 18
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, conditionals
-Style/AndOr:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
-
 # Offense count: 12
 # Configuration parameters: AllowedChars.
 Style/AsciiComments:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -311,13 +311,6 @@ Style/MutableConstant:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/version.rb'
     - 'spec/release_notes_helper_spec.rb'
 
-# Offense count: 27
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: both, prefix, postfix
-Style/NegatedIf:
-  Enabled: false
-
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -323,16 +323,6 @@ Style/Next:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
 
-# Offense count: 20
-# Cop supports --auto-correct.
-# Configuration parameters: IncludeSemanticChanges.
-Style/NonNilCheck:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
-
 # Offense count: 15
 # Cop supports --auto-correct.
 Style/Not:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -255,19 +255,6 @@ Style/GuardClause:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
 
-# Offense count: 20
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-Style/HashSyntax:
-  Exclude:
-    - 'Gemfile'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
-
 # Offense count: 2
 # Configuration parameters: AllowIfModifier.
 Style/IfInsideElse:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,25 +228,6 @@ Style/AsciiComments:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
     - 'spec/ios_lint_localizations_spec.rb'
 
-# Offense count: 22
-# Cop supports --auto-correct.
-Style/DefWithParentheses:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb'
-    - 'spec/android_merge_translators_strings_spec.rb'
-    - 'spec/ios_merge_translators_strings_spec.rb'
-
 # Offense count: 91
 Style/Documentation:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -342,13 +342,6 @@ Style/NumericPredicate:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: PreferredDelimiters.
-Style/PercentLiteralDelimiters:
-  Exclude:
-    - 'fastlane-plugin-wpmreleasetoolkit.gemspec'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/RedundantBegin:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -464,13 +464,6 @@ Style/TernaryParentheses:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb'
 
-# Offense count: 20
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,14 +228,6 @@ Style/AsciiComments:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
     - 'spec/ios_lint_localizations_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: percent_q, bare_percent
-Style/BarePercentLiterals:
-  Exclude:
-    - 'Dangerfile'
-
 # Offense count: 24
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -232,13 +232,6 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 104
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, never
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 # Offense count: 4
 # Configuration parameters: AllowedVariables.
 Style/GlobalVars:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -297,24 +297,6 @@ Style/MultilineBlockChain:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb'
 
-# Offense count: 28
-# Cop supports --auto-correct.
-Style/MultilineIfThen:
-  Exclude:
-    - 'bin/drawText'
-    - 'ext/drawText/extconf.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
-
 # Offense count: 15
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -421,12 +421,6 @@ Style/NumericPredicate:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb'
 
-# Offense count: 111
-# Cop supports --auto-correct.
-# Configuration parameters: AllowSafeAssignment, AllowInMultilineConditions.
-Style/ParenthesesAroundCondition:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: PreferredDelimiters.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -375,14 +375,6 @@ Style/RedundantSelf:
     - 'spec/android_merge_translators_strings_spec.rb'
     - 'spec/ios_merge_translators_strings_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, AllowInnerSlashes.
-# SupportedStyles: slashes, percent_r, mixed
-Style/RegexpLiteral:
-  Exclude:
-    - 'spec/ios_lint_localizations_spec.rb'
-
 # Offense count: 7
 # Cop supports --auto-correct.
 Style/RescueModifier:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -323,18 +323,6 @@ Style/Next:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
 
-# Offense count: 15
-# Cop supports --auto-correct.
-Style/Not:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedOctalStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,16 +228,6 @@ Style/AsciiComments:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
     - 'spec/ios_lint_localizations_spec.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: is_a?, kind_of?
-Style/ClassCheck:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SingleLineConditionsOnly, IncludeTernaryExpressions.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -232,14 +232,6 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: format, sprintf, percent
-Style/FormatString:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
-
 # Offense count: 104
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -232,12 +232,6 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/Encoding:
-  Exclude:
-    - 'fastlane-plugin-wpmreleasetoolkit.gemspec'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Style/ExpandPathArguments:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -262,11 +262,6 @@ Style/IfInsideElse:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb'
 
-# Offense count: 99
-# Cop supports --auto-correct.
-Style/IfUnlessModifier:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: InverseMethods, InverseBlocks.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -464,14 +464,6 @@ Style/TernaryParentheses:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArguments:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb'
-
 # Offense count: 20
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleForMultiline.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -232,13 +232,6 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 71
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: compact, expanded
-Style/EmptyMethod:
-  Enabled: false
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/Encoding:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -313,17 +313,6 @@ Style/MutableConstant:
 
 # Offense count: 9
 # Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: both, prefix, postfix
-Style/NegatedUnless:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb'
-
-# Offense count: 9
-# Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, MinBodyLength.
 # SupportedStyles: skip_modifier_ifs, always
 Style/Next:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -323,19 +323,6 @@ Style/Next:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
 
-# Offense count: 13
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: predicate, comparison
-Style/NilComparison:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
-
 # Offense count: 20
 # Cop supports --auto-correct.
 # Configuration parameters: IncludeSemanticChanges.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,19 +228,6 @@ Style/AsciiComments:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
     - 'spec/ios_lint_localizations_spec.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: braces, no_braces, context_dependent
-Style/BracesAroundHashParameters:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb'
-    - 'spec/android_merge_translators_strings_spec.rb'
-    - 'spec/ios_merge_translators_strings_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -464,14 +464,6 @@ Style/TernaryParentheses:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Exclude:
-    - 'spec/configuration_spec.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Style/UnlessElse:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -232,14 +232,6 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Style/ExpandPathArguments:
-  Exclude:
-    - 'Dangerfile'
-    - 'fastlane-plugin-wpmreleasetoolkit.gemspec'
-    - 'spec/spec_helper.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -228,14 +228,6 @@ Style/AsciiComments:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
     - 'spec/ios_lint_localizations_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect, EnforcedStyle.
-# SupportedStyles: nested, compact
-Style/ClassAndModuleChildren:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -419,13 +419,6 @@ Style/SelfAssignment:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: AllowAsExpressionSeparator.
-Style/Semicolon:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -264,13 +264,6 @@ Style/IfInsideElse:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-# Configuration parameters: InverseMethods, InverseBlocks.
-Style/InverseMethods:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: line_count_dependent, lambda, literal
 Style/Lambda:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -232,16 +232,6 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
-# Offense count: 7
-# Cop supports --auto-correct.
-Style/EmptyLiteral:
-  Exclude:
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb'
-
 # Offense count: 71
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,5 @@
 def version
-  lib = File.expand_path('../lib', __FILE__)
+  lib = File.expand_path('lib', __dir__)
   $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
   require 'fastlane/plugin/wpmreleasetoolkit/version'
   Fastlane::Wpmreleasetoolkit::VERSION

--- a/Dangerfile
+++ b/Dangerfile
@@ -15,7 +15,7 @@ end
 `git checkout Gemfile.lock &> /dev/null`
 
 if version.to_s != gemfile_lock_version.to_s
-  message = %Q{
+  message = %{
 The version in the `Gemfile.lock` (`#{gemfile_lock_version}`) doesn't match the one in `version.rb` (`#{version}`).
 
 Please run `bundle install` to make sure they match.

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 gem 'danger', '~> 8.0'
 
 group :test do
-  gem 'codecov', :require => false
+  gem 'codecov', require: false
   gem 'rspec'
   gem 'yard'
 end

--- a/bin/drawText
+++ b/bin/drawText
@@ -3,9 +3,7 @@
 require 'rake'
 require 'os'
 
-unless OS.mac? then
-  abort 'Fatal Error: `drawText` can only be run on macOS.'
-end
+abort 'Fatal Error: `drawText` can only be run on macOS.' unless OS.mac?
 
 plugin_path = Pathname(__FILE__).dirname.parent
 executable_path = plugin_path + 'lib/drawText'

--- a/bin/drawText
+++ b/bin/drawText
@@ -11,11 +11,11 @@ plugin_path = Pathname(__FILE__).dirname.parent
 executable_path = plugin_path + 'lib/drawText'
 
 # Run the script
-allArgs = ARGV.map { |arg|
+allArgs = ARGV.map do |arg|
   argParts = arg.split('=')
   argParts[1] = '"' + argParts[1] + '"'
 
   argParts.join('=')
-}.join(' ')
+end.join(' ')
 
 exec("#{executable_path} #{allArgs}")

--- a/ext/drawText/extconf.rb
+++ b/ext/drawText/extconf.rb
@@ -10,9 +10,7 @@ libDirectory = File.join(File.dirname(File.dirname(drawTextDirectory)), '/lib')
 FileUtils.cp(File.join(drawTextDirectory, 'makefile.example'), File.join(compilationDirectory, 'Makefile'))
 
 # Only compile drawText on macOS
-unless OS.mac? then
-  exit 0
-end
+exit 0 unless OS.mac?
 
 # Swift is needed to compile the extension
 find_executable('swift')

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/plugin/wpmreleasetoolkit/version'
 

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/plugin/wpmreleasetoolkit/version'

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/wordpress-mobile/release-toolkit'
   spec.license       = 'MIT'
 
-  spec.files         = Dir['lib/**/*'] + %w(README.md LICENSE)
+  spec.files         = Dir['lib/**/*'] + %w[README.md LICENSE]
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 
   spec.files << 'ext/drawText/extconf.rb'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -41,7 +41,7 @@ module Fastlane
                                        env_name: 'LOCALIZE_LIBS_STRINGS_PATH',
                                        description: 'The list of libs to merge',
                                        optional: false,
-                                       is_string: false)
+                                       is_string: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -13,7 +13,7 @@ module Fastlane
           (any_changes = Fastlane::Helper::AndroidLocalizeHelper.merge_lib(main_strings_path, lib)) || any_changes
         end
 
-        UI.message("Changes have been applied to #{main_strings_path}. Please, verify it!") if (any_changes)
+        UI.message("Changes have been applied to #{main_strings_path}. Please, verify it!") if any_changes
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -10,7 +10,7 @@ module Fastlane
 
         any_changes = false
         libraries_strings_path.each do |lib|
-          any_changes = Fastlane::Helper::AndroidLocalizeHelper.merge_lib(main_strings_path, lib) or any_changes
+          (any_changes = Fastlane::Helper::AndroidLocalizeHelper.merge_lib(main_strings_path, lib)) || any_changes
         end
 
         if (any_changes)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -13,9 +13,7 @@ module Fastlane
           (any_changes = Fastlane::Helper::AndroidLocalizeHelper.merge_lib(main_strings_path, lib)) || any_changes
         end
 
-        if (any_changes)
-          UI.message("Changes have been applied to #{main_strings_path}. Please, verify it!")
-        end
+        UI.message("Changes have been applied to #{main_strings_path}. Please, verify it!") if (any_changes)
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -148,7 +148,7 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                          UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (!value.empty?)
-                                       end)
+                                       end),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -98,9 +98,7 @@ module Fastlane
           end
         end
 
-        if (is_comment(line))
-          @current_block = @blocks.first
-        end
+        @current_block = @blocks.first if (is_comment(line))
 
         @current_block.handle_line(fw, line)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -68,7 +68,7 @@ module Fastlane
 
       # Creates the block instances
       def self.create_block_parsers(release_version, block_files)
-        @blocks = Array.new
+        @blocks = []
 
         # Inits default handler
         @blocks.push Fastlane::Helper::UnknownMetadataBlock.new

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -133,21 +133,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (not value.empty?)
+                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (!value.empty?)
                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (not value.empty?)
+                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (!value.empty?)
                                        end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (not value.empty?)
+                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (!value.empty?)
                                        end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -135,21 +135,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value and not value.empty?)
+                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value && (not value.empty?))
                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value and not value.empty?)
+                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value && (not value.empty?))
                                        end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value and not value.empty?)
+                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value && (not value.empty?))
                                        end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -63,7 +63,7 @@ module Fastlane
 
       # Generates the temp file path
       def self.create_target_file_path(orig_file_path)
-        "#{File.dirname(orig_file_path)}/#{File.basename(orig_file_path, ".*")}.tmp"
+        "#{File.dirname(orig_file_path)}/#{File.basename(orig_file_path, '.*')}.tmp"
       end
 
       # Creates the block instances

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -91,14 +91,14 @@ module Fastlane
 
       # Manages tags depending on the type
       def self.write_target_block(fw, line)
-        if (is_block_id(line))
+        if is_block_id(line)
           key = line.split(' ')[1].tr('\"', '')
           @blocks.each do |block|
             @current_block = block if block.is_handler_for(key)
           end
         end
 
-        @current_block = @blocks.first if (is_comment(line))
+        @current_block = @blocks.first if is_comment(line)
 
         @current_block.handle_line(fw, line)
       end
@@ -133,21 +133,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value && (not value.empty?))
+                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (not value.empty?)
                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value && (not value.empty?))
+                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (not value.empty?)
                                        end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value && (not value.empty?))
+                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (not value.empty?)
                                        end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
@@ -51,7 +51,7 @@ module Fastlane
                                        env_name: 'CHECK_LIBS_DIFF_URL',
                                        description: 'The url of the diff to check',
                                        optional: true,
-                                       is_string: true),
+                                       is_string: true)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
@@ -10,7 +10,7 @@ module Fastlane
         diff_url = params[:diff_url]
 
         source_diff = nil
-        if diff_url.nil? == false then
+        if diff_url.nil? == false
           data = open(params[:diff_url])
           source_diff = data.read()
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
@@ -51,7 +51,7 @@ module Fastlane
                                        env_name: 'CHECK_LIBS_DIFF_URL',
                                        description: 'The url of the diff to check',
                                        optional: true,
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
@@ -10,7 +10,7 @@ module Fastlane
         diff_url = params[:diff_url]
 
         source_diff = nil
-        if (diff_url.nil? == false) then
+        if diff_url.nil? == false then
           data = open(params[:diff_url])
           source_diff = data.read()
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -35,9 +35,7 @@ module Fastlane
         message << "Updating branch to version: #{next_beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) "
         message << "and #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n" unless alpha_release_version.nil?
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -19,10 +19,10 @@ module Fastlane
 
         # Check branch
         app_version = Fastlane::Helper::Android::VersionHelper.get_public_version
-        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version))
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless !params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version)
 
         # Check user overwrite
-        if (!params[:base_version].nil?)
+        if !params[:base_version].nil?
           overwrite_version = get_user_build_version(params[:base_version], message)
           release_version = overwrite_version[0]
           alpha_release_version = overwrite_version[1]
@@ -34,8 +34,8 @@ module Fastlane
         # Verify
         message << "Updating branch to version: #{next_beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) "
         message << "and #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n" unless alpha_release_version.nil?
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -79,7 +79,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_BETABUILD_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -22,7 +22,7 @@ module Fastlane
         UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless !params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version)
 
         # Check user overwrite
-        if !params[:base_version].nil?
+        unless params[:base_version].nil?
           overwrite_version = get_user_build_version(params[:base_version], message)
           release_version = overwrite_version[0]
           alpha_release_version = overwrite_version[1]
@@ -35,7 +35,7 @@ module Fastlane
         message << "Updating branch to version: #{next_beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{next_beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) "
         message << "and #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n" unless alpha_release_version.nil?
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -4,9 +4,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper.rb'
 
-        if (params[:final] && params[:beta])
-          UI.user_error!("Can't build beta and final at the same time!")
-        end
+        UI.user_error!("Can't build beta and final at the same time!") if (params[:final] && params[:beta])
 
         Fastlane::Helper::GitHelper.ensure_on_branch!('release') unless other_action.is_ci()
 
@@ -14,18 +12,14 @@ module Fastlane
         beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version() unless !params[:beta] && !params[:final]
         alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version() unless !params[:alpha]
 
-        if (params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version))
-          UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!")
-        end
+        UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if (params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version))
 
         message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Release Channel)\n" unless !params[:final]
         message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Beta Channel)\n" unless !params[:beta]
         message << "Building version #{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" unless !params[:alpha]
 
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -10,13 +10,13 @@ module Fastlane
 
         message = ''
         beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version() unless !params[:beta] && !params[:final]
-        alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version() unless !params[:alpha]
+        alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version() if params[:alpha]
 
         UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version)
 
-        message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Release Channel)\n" unless !params[:final]
-        message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Beta Channel)\n" unless !params[:beta]
-        message << "Building version #{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" unless !params[:alpha]
+        message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Release Channel)\n" if params[:final]
+        message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Beta Channel)\n" if params[:beta]
+        message << "Building version #{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" if params[:alpha]
 
         if !params[:skip_confirm]
           UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -61,7 +61,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_BUILD_PRECHECKS_FINAL_BUILD',
                                        description: 'True if this is for a final build',
                                        is_string: false,
-                                       default_value: false)
+                                       default_value: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -19,7 +19,7 @@ module Fastlane
         message << "Building version #{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" unless !params[:alpha]
 
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -61,7 +61,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_BUILD_PRECHECKS_FINAL_BUILD',
                                        description: 'True if this is for a final build',
                                        is_string: false,
-                                       default_value: false),
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -4,17 +4,17 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper.rb'
 
-        if (params[:final] and params[:beta])
+        if (params[:final] && params[:beta])
           UI.user_error!("Can't build beta and final at the same time!")
         end
 
         Fastlane::Helper::GitHelper.ensure_on_branch!('release') unless other_action.is_ci()
 
         message = ''
-        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version() unless !params[:beta] and !params[:final]
+        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version() unless !params[:beta] && !params[:final]
         alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version() unless !params[:alpha]
 
-        if (params[:final] and Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version))
+        if (params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version))
           UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!")
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -4,7 +4,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper.rb'
 
-        UI.user_error!("Can't build beta and final at the same time!") if (params[:final] && params[:beta])
+        UI.user_error!("Can't build beta and final at the same time!") if params[:final] && params[:beta]
 
         Fastlane::Helper::GitHelper.ensure_on_branch!('release') unless other_action.is_ci()
 
@@ -12,14 +12,14 @@ module Fastlane
         beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version() unless !params[:beta] && !params[:final]
         alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version() unless !params[:alpha]
 
-        UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if (params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version))
+        UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version)
 
         message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Release Channel)\n" unless !params[:final]
         message << "Building version #{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{beta_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Beta Channel)\n" unless !params[:beta]
         message << "Building version #{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}) (for upload to Alpha Channel)\n" unless !params[:alpha]
 
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -49,14 +49,14 @@ module Fastlane
 
       private
 
-      def self.create_config()
+      def self.create_config
         @current_version = Fastlane::Helper::Android::VersionHelper.get_release_version()
         @current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version()
         @new_version_beta = Fastlane::Helper::Android::VersionHelper.calc_next_beta_version(@current_version, @current_version_alpha)
         @new_version_alpha = ENV['HAS_ALPHA_VERSION'].nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(@new_version_beta, @current_version_alpha)
       end
 
-      def self.show_config()
+      def self.show_config
         vname = Fastlane::Helper::Android::VersionHelper::VERSION_NAME
         vcode = Fastlane::Helper::Android::VersionHelper::VERSION_CODE
         UI.message("Current version: #{@current_version[vname]}(#{@current_version[vcode]})")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -40,13 +40,13 @@ module Fastlane
 
       private
 
-      def self.create_config()
+      def self.create_config
         @current_version = Fastlane::Helper::Android::VersionHelper.get_release_version()
         @current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version()
         @final_version = Fastlane::Helper::Android::VersionHelper.calc_final_release_version(@current_version, @current_version_alpha)
       end
 
-      def self.show_config()
+      def self.show_config
         vname = Fastlane::Helper::Android::VersionHelper::VERSION_NAME
         vcode = Fastlane::Helper::Android::VersionHelper::VERSION_CODE
         UI.message("Current version: #{@current_version[vname]}(#{@current_version[vcode]})")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -45,7 +45,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :previous_version_name,
                                        env_name: 'FL_ANDROID_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION',
                                        description: 'The version to branch from',
-                                       is_string: true) # the default value if the user didn't provide one
+                                       is_string: true), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -67,7 +67,7 @@ module Fastlane
         @new_release_branch = "release/#{@new_short_version}"
       end
 
-      def self.show_config()
+      def self.show_config
         UI.message("Current version: #{@current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{@current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]})")
         UI.message("New hotfix version: #{@new_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{@new_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]})")
         UI.message("Release branch: #{@new_release_branch}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -78,7 +78,7 @@ module Fastlane
 
       def self.update_glotpress_key
         dm_file = ENV['DOWNLOAD_METADATA']
-        if File.exist?(dm_file) then
+        if File.exist?(dm_file)
           sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")
         else
           UI.user_error!("Can't find #{dm_file}.")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -57,7 +57,7 @@ module Fastlane
 
       private
 
-      def self.create_config()
+      def self.create_config
         @current_version = Fastlane::Helper::Android::VersionHelper.get_release_version()
         @current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version()
         @new_version_beta = Fastlane::Helper::Android::VersionHelper.calc_next_release_version(@current_version, @current_version_alpha)
@@ -65,7 +65,7 @@ module Fastlane
         @new_release_branch = "release/#{@new_short_version}"
       end
 
-      def self.show_config()
+      def self.show_config
         vname = Fastlane::Helper::Android::VersionHelper::VERSION_NAME
         vcode = Fastlane::Helper::Android::VersionHelper::VERSION_CODE
         UI.message("Current version: #{@current_version[vname]}(#{@current_version[vcode]})")
@@ -76,7 +76,7 @@ module Fastlane
         UI.message("Release branch: #{@new_release_branch}")
       end
 
-      def self.update_glotpress_key()
+      def self.update_glotpress_key
         dm_file = ENV['DOWNLOAD_METADATA']
         if (File.exist?(dm_file)) then
           sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -78,7 +78,7 @@ module Fastlane
 
       def self.update_glotpress_key
         dm_file = ENV['DOWNLOAD_METADATA']
-        if (File.exist?(dm_file)) then
+        if File.exist?(dm_file) then
           sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")
         else
           UI.user_error!("Can't find #{dm_file}.")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -27,9 +27,7 @@ module Fastlane
           confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += ENV['HAS_ALPHA_VERSION'].nil? ? '' : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += 'Do you want to continue?'
-          if (!UI.confirm(confirm_message))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm(confirm_message))
         end
 
         # Check local repo status

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -21,13 +21,13 @@ module Fastlane
         next_alpha_version = ENV['HAS_ALPHA_VERSION'].nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(next_version, current_alpha_version)
 
         # Ask user confirmation
-        if !params[:skip_confirm]
+        unless params[:skip_confirm]
           confirm_message = "Building a new release branch starting from develop.\nCurrent version is #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += ENV['HAS_ALPHA_VERSION'].nil? ? "No alpha version configured.\n" : "Current Alpha version is #{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += ENV['HAS_ALPHA_VERSION'].nil? ? '' : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += 'Do you want to continue?'
-          UI.user_error!('Aborted by user request') if !UI.confirm(confirm_message)
+          UI.user_error!('Aborted by user request') unless UI.confirm(confirm_message)
         end
 
         # Check local repo status

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -56,7 +56,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_CODEFREEZE_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation before codefreeze',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -21,13 +21,13 @@ module Fastlane
         next_alpha_version = ENV['HAS_ALPHA_VERSION'].nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(next_version, current_alpha_version)
 
         # Ask user confirmation
-        if (!params[:skip_confirm])
+        if !params[:skip_confirm]
           confirm_message = "Building a new release branch starting from develop.\nCurrent version is #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += ENV['HAS_ALPHA_VERSION'].nil? ? "No alpha version configured.\n" : "Current Alpha version is #{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += ENV['HAS_ALPHA_VERSION'].nil? ? '' : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += 'Do you want to continue?'
-          UI.user_error!('Aborted by user request') if (!UI.confirm(confirm_message))
+          UI.user_error!('Aborted by user request') if !UI.confirm(confirm_message)
         end
 
         # Check local repo status

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -12,9 +12,7 @@ module Fastlane
         version = Fastlane::Helper::Android::VersionHelper.get_public_version
         message = "Completing code freeze for: #{version}\n"
         unless params[:skip_confirm]
-          unless UI.confirm("#{message}Do you want to continue?")
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -41,7 +41,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_COMPLETECODEFREEZE_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
@@ -47,7 +47,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :locales,
                                        env_name: 'FL_DOWNLOAD_METADATA_LOCALES',
                                        description: 'The hash with the GLotPress locale and the project locale association',
-                                       is_string: false),
+                                       is_string: false)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
@@ -5,7 +5,7 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper.rb'
 
         release_notes_path = params[:download_path] + '/release_notes.xml'
-        open(release_notes_path, 'w') { |f|
+        open(release_notes_path, 'w') do |f|
           params[:locales].each do |loc|
             puts "Looking for language: #{loc[1]}"
             complete_path = "#{params[:download_path]}/#{loc[1]}/changelogs/#{params[:build_number]}.txt"
@@ -17,7 +17,7 @@ module Fastlane
               UI.message("File #{complete_path} not found. Skipping language #{loc[1]}")
             end
           end
-        }
+        end
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
@@ -9,7 +9,7 @@ module Fastlane
           params[:locales].each do |loc|
             puts "Looking for language: #{loc[1]}"
             complete_path = "#{params[:download_path]}/#{loc[1]}/changelogs/#{params[:build_number]}.txt"
-            if (File.exist?(complete_path))
+            if File.exist?(complete_path)
               f.puts("<#{loc[1]}>")
               f.puts(File.open(complete_path).read)
               f.puts("</#{loc[1]}>\n")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
@@ -47,7 +47,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :locales,
                                        env_name: 'FL_DOWNLOAD_METADATA_LOCALES',
                                        description: 'The hash with the GLotPress locale and the project locale association',
-                                       is_string: false)
+                                       is_string: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -16,9 +16,7 @@ module Fastlane
         version = Fastlane::Helper::Android::VersionHelper.get_public_version
         message = "Finalizing release: #{version}\n"
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -16,7 +16,7 @@ module Fastlane
         version = Fastlane::Helper::Android::VersionHelper.get_public_version
         message = "Finalizing release: #{version}\n"
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -48,7 +48,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_FINALIZE_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -15,8 +15,8 @@ module Fastlane
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version
         message = "Finalizing release: #{version}\n"
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
@@ -17,21 +17,15 @@ module Fastlane
         message << "Branching from: #{prev_ver}\n"
 
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end
 
         # Check tags
-        if other_action.git_tag_exists(tag: new_ver)
-          UI.crash!("Version #{new_ver} already exists! Abort!")
-        end
+        UI.crash!("Version #{new_ver} already exists! Abort!") if other_action.git_tag_exists(tag: new_ver)
 
-        if !other_action.git_tag_exists(tag: prev_ver)
-          UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!")
-        end
+        UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!") if !other_action.git_tag_exists(tag: prev_ver)
 
         # Check local repo status
         other_action.ensure_git_status_clean()

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
@@ -17,7 +17,7 @@ module Fastlane
         message << "Branching from: #{prev_ver}\n"
 
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end
@@ -25,7 +25,7 @@ module Fastlane
         # Check tags
         UI.crash!("Version #{new_ver} already exists! Abort!") if other_action.git_tag_exists(tag: new_ver)
 
-        UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!") if !other_action.git_tag_exists(tag: prev_ver)
+        UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!") unless other_action.git_tag_exists(tag: prev_ver)
 
         # Check local repo status
         other_action.ensure_git_status_clean()

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
@@ -56,7 +56,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_HOTFIX_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
@@ -16,8 +16,8 @@ module Fastlane
         message = "Requested Hotfix version: #{new_ver}\n"
         message << "Branching from: #{prev_ver}\n"
 
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
@@ -86,7 +86,7 @@ module Fastlane
                                        env_name: 'AMTS_STRING_FOLDER',
                                        description: 'The folder that contains all the translations',
                                        optional: false,
-                                       type: String)
+                                       type: String),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
@@ -32,7 +32,7 @@ module Fastlane
           my_strings.each do |string|
             if string.include?('<string name')
               string_key = string.strip.split('>').first
-              if !extra_keys.include?(string_key)
+              unless extra_keys.include?(string_key)
                 extra_strings << string
                 extra_keys << string_key
               end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
@@ -57,9 +57,7 @@ module Fastlane
 
         test_line = line.strip.split('>').first
         extra_strings.each do |overwrite_string|
-          if (overwrite_string.strip.split('>').first == test_line) then
-            return ''
-          end
+          return '' if (overwrite_string.strip.split('>').first == test_line)
         end
 
         return line

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
@@ -32,7 +32,7 @@ module Fastlane
           my_strings.each do |string|
             if string.include?('<string name')
               string_key = string.strip.split('>').first
-              if (!extra_keys.include?(string_key))
+              if !extra_keys.include?(string_key)
                 extra_strings << string
                 extra_keys << string_key
               end
@@ -44,7 +44,7 @@ module Fastlane
 
         File.open(main_file, 'w') do |f|
           File.open(tmp_main_file).each do |line|
-            f.puts(extra_strings) if (line.strip == '</resources>')
+            f.puts(extra_strings) if line.strip == '</resources>'
             f.puts(check_line(line, extra_strings))
           end
         end
@@ -53,11 +53,11 @@ module Fastlane
       end
 
       def self.check_line(line, extra_strings)
-        return line unless (line.include?('<string name'))
+        return line unless line.include?('<string name')
 
         test_line = line.strip.split('>').first
         extra_strings.each do |overwrite_string|
-          return '' if (overwrite_string.strip.split('>').first == test_line)
+          return '' if overwrite_string.strip.split('>').first == test_line
         end
 
         return line

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
@@ -25,8 +25,8 @@ module Fastlane
         FileUtils.cp(main_file, tmp_main_file)
 
         join_files = Dir.glob(File.join("#{strings_folder}", 'strings-*.xml'))
-        extra_strings = Array.new
-        extra_keys = Array.new
+        extra_strings = []
+        extra_keys = []
         join_files.each do |join_strings|
           my_strings = File.read(join_strings).split("\n")
           my_strings.each do |string|

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_merge_translators_strings.rb
@@ -86,7 +86,7 @@ module Fastlane
                                        env_name: 'AMTS_STRING_FOLDER',
                                        description: 'The folder that contains all the translations',
                                        optional: false,
-                                       type: String),
+                                       type: String)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -29,7 +29,7 @@ module Fastlane
                                        env_name: 'FL_ANDROID_TAG_BUILD_ALPHA',
                                        description: 'True to skip tagging the alpha version',
                                        is_string: false,
-                                       default_value: true)
+                                       default_value: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -34,7 +34,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :new_version,
                                        env_name: 'FL_ANDROID_UPDATE_RELEASE_NOTES_VERSION',
                                        description: 'The version we are currently freezing; An empty entry for the _next_ version after this one will be added to the release notes',
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -44,7 +44,7 @@ module Fastlane
                                        env_name: 'GHHELPER_MILESTONE',
                                        description: 'The GitHub milestone',
                                        optional: false,
-                                       type: String)
+                                       type: String),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -11,7 +11,7 @@ module Fastlane
         milestone_title = params[:milestone]
 
         milestone = Fastlane::Helper::GithubHelper.get_milestone(repository, milestone_title)
-        UI.user_error!("Milestone #{milestone_title} not found.") if (milestone.nil?)
+        UI.user_error!("Milestone #{milestone_title} not found.") if milestone.nil?
 
         Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], state: 'closed')
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -11,9 +11,7 @@ module Fastlane
         milestone_title = params[:milestone]
 
         milestone = Fastlane::Helper::GithubHelper.get_milestone(repository, milestone_title)
-        if (milestone.nil?)
-          UI.user_error!("Milestone #{milestone_title} not found.")
-        end
+        UI.user_error!("Milestone #{milestone_title} not found.") if (milestone.nil?)
 
         Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], state: 'closed')
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -15,7 +15,7 @@ module Fastlane
           UI.user_error!("Milestone #{milestone_title} not found.")
         end
 
-        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], { :state => 'closed' })
+        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], :state => 'closed')
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -15,7 +15,7 @@ module Fastlane
           UI.user_error!("Milestone #{milestone_title} not found.")
         end
 
-        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], :state => 'closed')
+        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], state: 'closed')
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -44,7 +44,7 @@ module Fastlane
                                        env_name: 'GHHELPER_MILESTONE',
                                        description: 'The GitHub milestone',
                                        optional: false,
-                                       type: String),
+                                       type: String)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -47,7 +47,7 @@ module Fastlane
                                        description: 'True if the app needs to be submitted',
                                        optional: true,
                                        is_string: false,
-                                       default_value: false),
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -47,7 +47,7 @@ module Fastlane
                                        description: 'True if the app needs to be submitted',
                                        optional: true,
                                        is_string: false,
-                                       default_value: false)
+                                       default_value: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -67,7 +67,7 @@ module Fastlane
                                        description: 'True if this is a pre-release',
                                        optional: true,
                                        default_value: false,
-                                       is_string: false),
+                                       is_string: false)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -67,7 +67,7 @@ module Fastlane
                                        description: 'True if this is a pre-release',
                                        optional: true,
                                        default_value: false,
-                                       is_string: false)
+                                       is_string: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -77,7 +77,7 @@ module Fastlane
                                        env_name: 'GHHELPER_EXTRACT_NOTES_EXTRACTED_FILE_PATH',
                                        description: 'The path to the file that will contain the extracted release notes',
                                        optional: true,
-                                       is_string: true),
+                                       is_string: true)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -25,7 +25,7 @@ module Fastlane
         File.open(release_notes_file_path).each do |line|
           case state
           when :discarding
-            if (line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/)) and (line.strip() == version)
+            if (line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/)) && (line.strip() == version)
               state = :evaluating
             end
           when :evaluating

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -25,9 +25,7 @@ module Fastlane
         File.open(release_notes_file_path).each do |line|
           case state
           when :discarding
-            if (line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/)) && (line.strip() == version)
-              state = :evaluating
-            end
+            state = :evaluating if (line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/)) && (line.strip() == version)
           when :evaluating
             state = (line.match(/-/)) ? :extracting : :discarding
           when :extracting

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -29,7 +29,7 @@ module Fastlane
           when :evaluating
             state = (line.match(/-/)) ? :extracting : :discarding
           when :extracting
-            if (line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/))
+            if line.match(/^(\d+\.)?(\d+\.)?(\*|\d+)$/)
               state = :discarding
               return
             else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -77,7 +77,7 @@ module Fastlane
                                        env_name: 'GHHELPER_EXTRACT_NOTES_EXTRACTED_FILE_PATH',
                                        description: 'The path to the file that will contain the extracted release notes',
                                        optional: true,
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -16,7 +16,7 @@ module Fastlane
         # Extract PRs
         pr_list = []
         commit_list.split("\n").each do |commit|
-          if (commit.include?('Merge pull request #'))
+          if commit.include?('Merge pull request #')
             # PR found, so extract PR number
             pr_list.push(commit.partition('#').last.split(' ')[0])
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -73,7 +73,7 @@ module Fastlane
                                        env_name: 'GHHELPER_REPORTPATH',
                                        description: 'The path of the report file',
                                        optional: false,
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -18,13 +18,13 @@ module Fastlane
         downloader = Fastlane::Helper::MetadataDownloader.new(params[:download_path], params[:target_files])
 
         params[:locales].each do |loc|
-          if loc.is_a?(Array) then
+          if loc.is_a?(Array)
             puts "Downloading language: #{loc[1]}"
             complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations?filters[status]=current&format=json"
             downloader.download(loc[1], complete_url, loc[1] == params[:source_locale])
           end
 
-          if loc.is_a?(String) then
+          if loc.is_a?(String)
             puts "Downloading language: #{loc}"
             complete_url = "#{params[:project_url]}#{loc}/default/export-translations?filters[status]=current&format=json"
             downloader.download(loc, complete_url, loc == params[:source_locale])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -18,13 +18,13 @@ module Fastlane
         downloader = Fastlane::Helper::MetadataDownloader.new(params[:download_path], params[:target_files])
 
         params[:locales].each do |loc|
-          if loc.kind_of?(Array) then
+          if loc.is_a?(Array) then
             puts "Downloading language: #{loc[1]}"
             complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations?filters[status]=current&format=json"
             downloader.download(loc[1], complete_url, loc[1] == params[:source_locale])
           end
 
-          if loc.kind_of?(String) then
+          if loc.is_a?(String) then
             puts "Downloading language: #{loc}"
             complete_url = "#{params[:project_url]}#{loc}/default/export-translations?filters[status]=current&format=json"
             downloader.download(loc, complete_url, loc == params[:source_locale])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -67,7 +67,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :download_path,
                                        env_name: 'FL_DOWNLOAD_METADATA_DOWNLOAD_PATH',
                                        description: 'The path of the target files',
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -75,9 +75,9 @@ module Fastlane
 
         # Init special handlers
         block_files.each do |key, file_path|
-          if (key == :release_note)
+          if key == :release_note
             @blocks.push Fastlane::Helper::ReleaseNoteMetadataBlock.new(key, file_path, release_version)
-          elsif (key == :whats_new)
+          elsif key == :whats_new
             @blocks.push Fastlane::Helper::WhatsNewMetadataBlock.new(key, file_path, release_version)
           else
             @blocks.push Fastlane::Helper::StandardMetadataBlock.new(key, file_path)
@@ -90,14 +90,14 @@ module Fastlane
 
       # Manages tags depending on the type
       def self.write_target_block(fw, line)
-        if (is_block_id(line))
+        if is_block_id(line)
           key = line.split(' ')[1].tr('\"', '')
           @blocks.each do |block|
             @current_block = block if block.is_handler_for(key)
           end
         end
 
-        @current_block = @blocks.first if (is_comment(line))
+        @current_block = @blocks.first if is_comment(line)
 
         @current_block.handle_line(fw, line)
       end
@@ -132,21 +132,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value && (not value.empty?))
+                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (not value.empty?)
                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value && (not value.empty?))
+                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (not value.empty?)
                                        end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value && (not value.empty?))
+                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (not value.empty?)
                                        end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -68,7 +68,7 @@ module Fastlane
 
       # Creates the block instances
       def self.create_block_parsers(release_version, block_files)
-        @blocks = Array.new
+        @blocks = []
 
         # Inits default handler
         @blocks.push Fastlane::Helper::UnknownMetadataBlock.new

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -147,7 +147,7 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                          UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (!value.empty?)
-                                       end)
+                                       end),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -134,21 +134,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value and not value.empty?)
+                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value && (not value.empty?))
                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value and not value.empty?)
+                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value && (not value.empty?))
                                        end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value and not value.empty?)
+                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value && (not value.empty?))
                                        end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -97,9 +97,7 @@ module Fastlane
           end
         end
 
-        if (is_comment(line))
-          @current_block = @blocks.first
-        end
+        @current_block = @blocks.first if (is_comment(line))
 
         @current_block.handle_line(fw, line)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -132,21 +132,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (not value.empty?)
+                                         UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (!value.empty?)
                                          UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (not value.empty?)
+                                         UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (!value.empty?)
                                        end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (not value.empty?)
+                                         UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (!value.empty?)
                                        end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -63,7 +63,7 @@ module Fastlane
 
       # Generates the temp file path
       def self.create_target_file_path(orig_file_path)
-        "#{File.dirname(orig_file_path)}/#{File.basename(orig_file_path, ".*")}.tmp"
+        "#{File.dirname(orig_file_path)}/#{File.basename(orig_file_path, '.*')}.tmp"
       end
 
       # Creates the block instances

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -47,7 +47,7 @@ module Fastlane
 
         stylesheet_path = config['stylesheet']
 
-        entries = build_entries(config, languages, outputDirectory, params)
+        entries = build_entries(config['entries'], languages, outputDirectory, params)
 
         bar = ProgressBar.new(entries.count, :bar, :counter, :eta, :rate)
 
@@ -174,8 +174,8 @@ module Fastlane
         true
       end
 
-      def self.build_entries(config, languages, output_directory, params)
-        config['entries']
+      def self.build_entries(config_entries, languages, output_directory, params)
+        config_entries
           .flat_map do |entry|
           languages.map do |language|
             newEntry = entry.deep_dup

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -50,8 +50,8 @@ module Fastlane
         stylesheet_path = config['stylesheet']
 
         entries = config['entries']
-                  .flat_map { |entry|
-                    languages.map { |language|
+                  .flat_map do |entry|
+                    languages.map do |language|
                       newEntry = entry.deep_dup
 
                       # Not every output file will have a screenshot, so handle cases where no
@@ -81,7 +81,7 @@ module Fastlane
                         newEntry['attachments'] = []
                       end
 
-                      newEntry['attachments'].each { |attachment|
+                      newEntry['attachments'].each do |attachment|
                         if attachment['file'] != nil
                           attachment['file'].sub!('{locale}', language.dup)
                         end
@@ -89,14 +89,14 @@ module Fastlane
                         if attachment['text'] != nil
                           attachment['text'].sub!('{locale}', language.dup)
                         end
-                      }
+                      end
 
                       newEntry
-                    }
-                  }
-                  .sort { |x, y|
+                    end
+                  end
+                  .sort do |x, y|
           x['filename'] <=> y['filename']
-        }
+        end
 
         bar = ProgressBar.new(entries.count, :bar, :counter, :eta, :rate)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -39,9 +39,7 @@ module Fastlane
 
         UI.message("💙 Creating Promo Screenshots for: #{languages.join(", ")}")
 
-        unless params[:force] then
-          confirm_directory_overwrite(params[:output_folder], 'the existing promo screenshots')
-        end
+        confirm_directory_overwrite(params[:output_folder], 'the existing promo screenshots') unless params[:force]
 
         # Create a hash of devices, keyed by device name
         devices = config['devices']
@@ -72,23 +70,15 @@ module Fastlane
                       newEntry['locale'] = language
 
                       # Localize file paths for text
-                      if entry['text'] != nil
-                        newEntry['text'].sub!('{locale}', language.dup)
-                      end
+                      newEntry['text'].sub!('{locale}', language.dup) if entry['text'] != nil
 
                       # Map attachments paths to their localized versions
-                      if newEntry['attachments'] == nil
-                        newEntry['attachments'] = []
-                      end
+                      newEntry['attachments'] = [] if newEntry['attachments'] == nil
 
                       newEntry['attachments'].each do |attachment|
-                        if attachment['file'] != nil
-                          attachment['file'].sub!('{locale}', language.dup)
-                        end
+                        attachment['file'].sub!('{locale}', language.dup) if attachment['file'] != nil
 
-                        if attachment['text'] != nil
-                          attachment['text'].sub!('{locale}', language.dup)
-                        end
+                        attachment['text'].sub!('{locale}', language.dup) if attachment['text'] != nil
                       end
 
                       newEntry
@@ -105,9 +95,7 @@ module Fastlane
         }) do |entry|
           device = devices[entry['device']]
 
-          if device == nil
-            UI.message("Unable to find device #{entry["device"]}.")
-          end
+          UI.message("Unable to find device #{entry["device"]}.") if device == nil
 
           width = device['canvas_size'][0]
           height = device['canvas_size'][1]
@@ -124,9 +112,7 @@ module Fastlane
           output_filename = entry['filename']
           dirname = File.dirname(output_filename)
 
-          unless File.directory?(dirname)
-            FileUtils.mkdir_p(dirname)
-          end
+          FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
 
           canvas.write(output_filename)
           canvas.destroy!
@@ -152,9 +138,7 @@ module Fastlane
       def self.subdirectories_for_path(path)
         subdirectories = []
 
-        unless helper.can_resolve_path(path) then
-          return []
-        end
+        return [] unless helper.can_resolve_path(path)
 
         resolved_path = helper.resolve_path(path)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -166,7 +166,7 @@ module Fastlane
                                        description: 'Overwrite existing promo screenshots without asking first?',
                                        optional: true,
                                        is_string: false,
-                                       default_value: false)
+                                       default_value: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -57,10 +57,10 @@ module Fastlane
                       if entry['screenshot'] != nil && entry['filename'] != nil
                         newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
                         newEntry['filename'] =  outputDirectory + language + entry['filename']
-                      elsif entry['screenshot'] != nil && entry['filename'] == nil
+                      elsif entry['screenshot'] != nil && entry['filename'].nil?
                         newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
                         newEntry['filename'] =  outputDirectory + language + entry['screenshot']
-                      elsif entry['screenshot'] == nil && entry['filename'] != nil
+                      elsif entry['screenshot'].nil? && entry['filename'] != nil
                         newEntry['filename'] =  outputDirectory + language + entry['filename']
                       else
                         puts newEntry
@@ -73,7 +73,7 @@ module Fastlane
                       newEntry['text'].sub!('{locale}', language.dup) if entry['text'] != nil
 
                       # Map attachments paths to their localized versions
-                      newEntry['attachments'] = [] if newEntry['attachments'] == nil
+                      newEntry['attachments'] = [] if newEntry['attachments'].nil?
 
                       newEntry['attachments'].each do |attachment|
                         attachment['file'].sub!('{locale}', language.dup) if attachment['file'] != nil
@@ -95,7 +95,7 @@ module Fastlane
         }) do |entry|
           device = devices[entry['device']]
 
-          UI.message("Unable to find device #{entry["device"]}.") if device == nil
+          UI.message("Unable to find device #{entry["device"]}.") if device.nil?
 
           width = device['canvas_size'][0]
           height = device['canvas_size'][1]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -16,7 +16,7 @@ module Fastlane
         translationDirectories = subdirectories_for_path(params[:metadata_folder])
         imageDirectories = subdirectories_for_path(params[:orig_folder])
 
-        unless helper.can_resolve_path(params[:output_folder]) then
+        unless helper.can_resolve_path(params[:output_folder])
           UI.message "✅ Created Output Folder: #{params[:output_folder]}"
           FileUtils.mkdir_p(params[:output_folder])
         else
@@ -123,8 +123,8 @@ module Fastlane
       end
 
       def self.confirm_directory_overwrite(path, description)
-        if File.exist?(path) then
-          if UI.confirm("Do you want to overwrite #{description}?") then
+        if File.exist?(path)
+          if UI.confirm("Do you want to overwrite #{description}?")
             FileUtils.rm_rf(path)
             Dir.mkdir(path)
           else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -47,72 +47,7 @@ module Fastlane
 
         stylesheet_path = config['stylesheet']
 
-        entries = config['entries']
-                  .flat_map do |entry|
-                    languages.map do |language|
-                      newEntry = entry.deep_dup
-
-                      # Not every output file will have a screenshot, so handle cases where no
-                      # screenshot file is defined
-                      if !entry['screenshot'].nil? && !entry['filename'].nil?
-                        newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
-                        newEntry['filename'] = outputDirectory + language + entry['filename']
-                      elsif !entry['screenshot'].nil? && entry['filename'].nil?
-                        newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
-                        newEntry['filename'] =  outputDirectory + language + entry['screenshot']
-                      elsif entry['screenshot'].nil? && !entry['filename'].nil?
-                        newEntry['filename'] =  outputDirectory + language + entry['filename']
-                      else
-                        puts newEntry
-                        abort 'Unable to find output file names'
-                      end
-
-                      newEntry['locale'] = language
-
-                      # Localize file paths for text
-                      newEntry['text'].sub!('{locale}', language.dup) unless entry['text'].nil?
-
-                      # Map attachments paths to their localized versions
-                      newEntry['attachments'] = [] if newEntry['attachments'].nil?
-
-                      newEntry['attachments'].each do |attachment|
-                        ## If there are no translated screenshot images (whether it's because they haven't been generated yet,
-                        ##   or because we aren't using them), just use the translated directories.
-                        ## And vice-versa.
-                        ## If there are original screenshots and translations available, use only locales that exist in both.
-                        # Create a hash of devices, keyed by device name
-                        # Not every output file will have a screenshot, so handle cases where no
-                        # screenshot file is defined
-                        # Localize file paths for text
-                        # Map attachments paths to their localized versions
-                        # Automatically create intermediate directories for output
-                        # Run the GC in the same thread to clean up after RMagick
-                        # If your method provides a return value, you can describe here what it does
-                        # Optional:
-                        attachment['file']&.sub!('{locale}', language.dup)
-
-                        ## If there are no translated screenshot images (whether it's because they haven't been generated yet,
-                        ##   or because we aren't using them), just use the translated directories.
-                        ## And vice-versa.
-                        ## If there are original screenshots and translations available, use only locales that exist in both.
-                        # Create a hash of devices, keyed by device name
-                        # Not every output file will have a screenshot, so handle cases where no
-                        # screenshot file is defined
-                        # Localize file paths for text
-                        # Map attachments paths to their localized versions
-                        # Automatically create intermediate directories for output
-                        # Run the GC in the same thread to clean up after RMagick
-                        # If your method provides a return value, you can describe here what it does
-                        # Optional:
-                        attachment['text']&.sub!('{locale}', language.dup)
-                      end
-
-                      newEntry
-                    end
-                  end
-                  .sort do |x, y|
-          x['filename'] <=> y['filename']
-        end
+        entries = build_entries(config, languages, outputDirectory, params)
 
         bar = ProgressBar.new(entries.count, :bar, :counter, :eta, :rate)
 
@@ -237,6 +172,75 @@ module Fastlane
 
       def self.is_supported?(platform)
         true
+      end
+
+      def self.build_entries(config, languages, output_directory, params)
+        config['entries']
+          .flat_map do |entry|
+          languages.map do |language|
+            newEntry = entry.deep_dup
+
+            # Not every output file will have a screenshot, so handle cases where no
+            # screenshot file is defined
+            if !entry['screenshot'].nil? && !entry['filename'].nil?
+              newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
+              newEntry['filename'] = output_directory + language + entry['filename']
+            elsif !entry['screenshot'].nil? && entry['filename'].nil?
+              newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
+              newEntry['filename'] = output_directory + language + entry['screenshot']
+            elsif entry['screenshot'].nil? && !entry['filename'].nil?
+              newEntry['filename'] = output_directory + language + entry['filename']
+            else
+              puts newEntry
+              abort 'Unable to find output file names'
+            end
+
+            newEntry['locale'] = language
+
+            # Localize file paths for text
+            newEntry['text'].sub!('{locale}', language.dup) unless entry['text'].nil?
+
+            # Map attachments paths to their localized versions
+            newEntry['attachments'] = [] if newEntry['attachments'].nil?
+
+            newEntry['attachments'].each do |attachment|
+              ## If there are no translated screenshot images (whether it's because they haven't been generated yet,
+              ##   or because we aren't using them), just use the translated directories.
+              ## And vice-versa.
+              ## If there are original screenshots and translations available, use only locales that exist in both.
+              # Create a hash of devices, keyed by device name
+              # Not every output file will have a screenshot, so handle cases where no
+              # screenshot file is defined
+              # Localize file paths for text
+              # Map attachments paths to their localized versions
+              # Automatically create intermediate directories for output
+              # Run the GC in the same thread to clean up after RMagick
+              # If your method provides a return value, you can describe here what it does
+              # Optional:
+              attachment['file']&.sub!('{locale}', language.dup)
+
+              ## If there are no translated screenshot images (whether it's because they haven't been generated yet,
+              ##   or because we aren't using them), just use the translated directories.
+              ## And vice-versa.
+              ## If there are original screenshots and translations available, use only locales that exist in both.
+              # Create a hash of devices, keyed by device name
+              # Not every output file will have a screenshot, so handle cases where no
+              # screenshot file is defined
+              # Localize file paths for text
+              # Map attachments paths to their localized versions
+              # Automatically create intermediate directories for output
+              # Run the GC in the same thread to clean up after RMagick
+              # If your method provides a return value, you can describe here what it does
+              # Optional:
+              attachment['text']&.sub!('{locale}', language.dup)
+            end
+
+            newEntry
+          end
+        end
+          .sort do |x, y|
+          x['filename'] <=> y['filename']
+        end
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -54,13 +54,13 @@ module Fastlane
 
                       # Not every output file will have a screenshot, so handle cases where no
                       # screenshot file is defined
-                      if entry['screenshot'] != nil && entry['filename'] != nil
+                      if !entry['screenshot'].nil? && !entry['filename'].nil?
                         newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
-                        newEntry['filename'] =  outputDirectory + language + entry['filename']
-                      elsif entry['screenshot'] != nil && entry['filename'].nil?
+                        newEntry['filename'] = outputDirectory + language + entry['filename']
+                      elsif !entry['screenshot'].nil? && entry['filename'].nil?
                         newEntry['screenshot'] = helper.resolve_path(params[:orig_folder]) + language + entry['screenshot']
                         newEntry['filename'] =  outputDirectory + language + entry['screenshot']
-                      elsif entry['screenshot'].nil? && entry['filename'] != nil
+                      elsif entry['screenshot'].nil? && !entry['filename'].nil?
                         newEntry['filename'] =  outputDirectory + language + entry['filename']
                       else
                         puts newEntry
@@ -70,15 +70,41 @@ module Fastlane
                       newEntry['locale'] = language
 
                       # Localize file paths for text
-                      newEntry['text'].sub!('{locale}', language.dup) if entry['text'] != nil
+                      newEntry['text'].sub!('{locale}', language.dup) unless entry['text'].nil?
 
                       # Map attachments paths to their localized versions
                       newEntry['attachments'] = [] if newEntry['attachments'].nil?
 
                       newEntry['attachments'].each do |attachment|
-                        attachment['file'].sub!('{locale}', language.dup) if attachment['file'] != nil
+                        ## If there are no translated screenshot images (whether it's because they haven't been generated yet,
+                        ##   or because we aren't using them), just use the translated directories.
+                        ## And vice-versa.
+                        ## If there are original screenshots and translations available, use only locales that exist in both.
+                        # Create a hash of devices, keyed by device name
+                        # Not every output file will have a screenshot, so handle cases where no
+                        # screenshot file is defined
+                        # Localize file paths for text
+                        # Map attachments paths to their localized versions
+                        # Automatically create intermediate directories for output
+                        # Run the GC in the same thread to clean up after RMagick
+                        # If your method provides a return value, you can describe here what it does
+                        # Optional:
+                        attachment['file']&.sub!('{locale}', language.dup)
 
-                        attachment['text'].sub!('{locale}', language.dup) if attachment['text'] != nil
+                        ## If there are no translated screenshot images (whether it's because they haven't been generated yet,
+                        ##   or because we aren't using them), just use the translated directories.
+                        ## And vice-versa.
+                        ## If there are original screenshots and translations available, use only locales that exist in both.
+                        # Create a hash of devices, keyed by device name
+                        # Not every output file will have a screenshot, so handle cases where no
+                        # screenshot file is defined
+                        # Localize file paths for text
+                        # Map attachments paths to their localized versions
+                        # Automatically create intermediate directories for output
+                        # Run the GC in the same thread to clean up after RMagick
+                        # If your method provides a return value, you can describe here what it does
+                        # Optional:
+                        attachment['text']&.sub!('{locale}', language.dup)
                       end
 
                       newEntry

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -123,7 +123,7 @@ module Fastlane
       end
 
       def self.confirm_directory_overwrite(path, description)
-        if (File.exist?(path)) then
+        if File.exist?(path) then
           if UI.confirm("Do you want to overwrite #{description}?") then
             FileUtils.rm_rf(path)
             Dir.mkdir(path)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -166,7 +166,7 @@ module Fastlane
                                        description: 'Overwrite existing promo screenshots without asking first?',
                                        optional: true,
                                        is_string: false,
-                                       default_value: false),
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -27,15 +27,15 @@ module Fastlane
 
         ## If there are no translated screenshot images (whether it's because they haven't been generated yet,
         ##   or because we aren't using them), just use the translated directories.
-        if imageDirectories == []
-          languages = translationDirectories
-        ## And vice-versa.
-        elsif translationDirectories == []
-          languages = imageDirectories
-        ## If there are original screenshots and translations available, use only locales that exist in both.
-        else
-          languages = imageDirectories & translationDirectories
-        end
+        languages = if imageDirectories == []
+                      translationDirectories
+                    ## And vice-versa.
+                    elsif translationDirectories == []
+                      imageDirectories
+                    ## If there are original screenshots and translations available, use only locales that exist in both.
+                    else
+                      imageDirectories & translationDirectories
+                    end
 
         UI.message("💙 Creating Promo Screenshots for: #{languages.join(", ")}")
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -143,7 +143,7 @@ module Fastlane
         resolved_path = helper.resolve_path(path)
 
         Dir.chdir(resolved_path) do
-          subdirectories = Dir['*'].reject { |o| not File.directory?(o) }.sort
+          subdirectories = Dir['*'].select { |o| File.directory?(o) }.sort
         end
 
         subdirectories

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -37,7 +37,7 @@ module Fastlane
                       imageDirectories & translationDirectories
                     end
 
-        UI.message("💙 Creating Promo Screenshots for: #{languages.join(", ")}")
+        UI.message("💙 Creating Promo Screenshots for: #{languages.join(', ')}")
 
         confirm_directory_overwrite(params[:output_folder], 'the existing promo screenshots') unless params[:force]
 
@@ -56,7 +56,7 @@ module Fastlane
         }) do |entry|
           device = devices[entry['device']]
 
-          UI.message("Unable to find device #{entry["device"]}.") if device.nil?
+          UI.message("Unable to find device #{entry['device']}.") if device.nil?
 
           width = device['canvas_size'][0]
           height = device['canvas_size'][1]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
@@ -10,9 +10,9 @@ module Fastlane
         branch_prot = {}
 
         branch_url = "https://api.github.com/repos/#{repository}/branches/" + branch_name
-        branch_prot[:restrictions] = { :url => branch_url + '/protection/restrictions', :users_url => branch_url + '/protection/restrictions/users', :teams_url => branch_url + '/protection/restrictions/teams', :users => [], :teams => [] }
+        branch_prot[:restrictions] = { url: branch_url + '/protection/restrictions', users_url: branch_url + '/protection/restrictions/users', teams_url: branch_url + '/protection/restrictions/teams', users: [], teams: [] }
         branch_prot[:enforce_admins] = nil
-        branch_prot[:required_pull_request_reviews] = { :url => branch_url + '/protection/required_pull_request_reviews', :dismiss_stale_reviews => false, :require_code_owner_reviews => false }
+        branch_prot[:required_pull_request_reviews] = { url: branch_url + '/protection/required_pull_request_reviews', dismiss_stale_reviews: false, require_code_owner_reviews: false }
 
         Fastlane::Helper::GithubHelper.github_client().unprotect_branch(repository, branch_name, branch_prot)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
@@ -45,7 +45,7 @@ module Fastlane
                                        env_name: 'GHHELPER_BRANCH',
                                        description: 'The branch to unprotect',
                                        optional: false,
-                                       type: String)
+                                       type: String),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
@@ -10,9 +10,9 @@ module Fastlane
         branch_prot = {}
 
         branch_url = "https://api.github.com/repos/#{repository}/branches/" + branch_name
-        branch_prot[:restrictions] = { :url => branch_url + '/protection/restrictions', :users_url => branch_url + '/protection/restrictions/users', :teams_url => branch_url + '/protection/restrictions/teams', :users => [], :teams => [] }
+        branch_prot[:restrictions] = { url: branch_url + '/protection/restrictions', users_url: branch_url + '/protection/restrictions/users', teams_url: branch_url + '/protection/restrictions/teams', users: [], teams: [] }
         branch_prot[:enforce_admins] = nil
-        branch_prot[:required_pull_request_reviews] = { :url => branch_url + '/protection/required_pull_request_reviews', :dismiss_stale_reviews => false, :require_code_owner_reviews => false }
+        branch_prot[:required_pull_request_reviews] = { url: branch_url + '/protection/required_pull_request_reviews', dismiss_stale_reviews: false, require_code_owner_reviews: false }
         Fastlane::Helper::GithubHelper.github_client().protect_branch(repository, branch_name, branch_prot)
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
@@ -44,7 +44,7 @@ module Fastlane
                                        env_name: 'GHHELPER_BRANCH',
                                        description: 'The branch to protect',
                                        optional: false,
-                                       type: String)
+                                       type: String),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -29,7 +29,7 @@ module Fastlane
         end
 
         UI.message("New milestone: #{mile_title}")
-        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], { :title => mile_title })
+        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], :title => mile_title)
       end
 
       def self.is_frozen(milestone)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -10,13 +10,13 @@ module Fastlane
         freeze = params[:freeze]
 
         milestone = Fastlane::Helper::GithubHelper.get_milestone(repository, milestone_title)
-        UI.user_error!("Milestone #{milestone_title} not found.") if (milestone.nil?)
+        UI.user_error!("Milestone #{milestone_title} not found.") if milestone.nil?
 
         mile_title = milestone[:title]
         puts freeze
         if freeze
           # Check if the state needs changes
-          if (is_frozen(milestone))
+          if is_frozen(milestone)
             UI.message("Milestone #{mile_title} is already frozen. Nothing to do")
             return # Already frozen: nothing to do
           end
@@ -31,7 +31,7 @@ module Fastlane
       end
 
       def self.is_frozen(milestone)
-        return milestone[:title].include?('❄️') unless (milestone.nil?)
+        return milestone[:title].include?('❄️') unless milestone.nil?
 
         return false
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -29,7 +29,7 @@ module Fastlane
         end
 
         UI.message("New milestone: #{mile_title}")
-        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], :title => mile_title)
+        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], title: mile_title)
       end
 
       def self.is_frozen(milestone)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -69,7 +69,7 @@ module Fastlane
                                        description: 'The GitHub milestone',
                                        optional: false,
                                        default_value: true,
-                                       is_string: false)
+                                       is_string: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -10,9 +10,7 @@ module Fastlane
         freeze = params[:freeze]
 
         milestone = Fastlane::Helper::GithubHelper.get_milestone(repository, milestone_title)
-        if (milestone.nil?)
-          UI.user_error!("Milestone #{milestone_title} not found.")
-        end
+        UI.user_error!("Milestone #{milestone_title} not found.") if (milestone.nil?)
 
         mile_title = milestone[:title]
         puts freeze
@@ -33,9 +31,7 @@ module Fastlane
       end
 
       def self.is_frozen(milestone)
-        unless (milestone.nil?)
-          return milestone[:title].include?('❄️')
-        end
+        return milestone[:title].include?('❄️') unless (milestone.nil?)
 
         return false
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
@@ -12,7 +12,7 @@ module Fastlane
       def self.run(params = {})
         continue = true
 
-        while (continue)
+        while continue
 
           confirmation = 'Do you want to specify a file that should be copied from the secrets repository into your project?'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
@@ -16,9 +16,7 @@ module Fastlane
 
           confirmation = 'Do you want to specify a file that should be copied from the secrets repository into your project?'
 
-          if Fastlane::Helper::ConfigureHelper.has_files
-            confirmation = 'Do you want to specify additional files that should be copied from the secrets repository into your project?'
-          end
+          confirmation = 'Do you want to specify additional files that should be copied from the secrets repository into your project?' if Fastlane::Helper::ConfigureHelper.has_files
 
           if UI.confirm(confirmation)
             add_file

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -41,9 +41,7 @@ module Fastlane
         original_repo_ref = Fastlane::Helper::ConfigureHelper.repo_branch_name
         original_repo_ref = repo_hash if original_repo_ref.nil?
 
-        unless repo_hash == file_hash
-          other_action.sh(command: "cd #{repository_path} && git fetch && git checkout #{file_hash}", log: false)
-        end
+        other_action.sh(command: "cd #{repository_path} && git fetch && git checkout #{file_hash}", log: false) unless repo_hash == file_hash
 
         # Run the provided block
         yield
@@ -66,9 +64,7 @@ module Fastlane
           return # Nothing to do if the files are identical
         end
 
-        if UI.confirm("#{file_reference.destination} has changes that need to be merged. Would you like to see a diff?")
-          puts Diffy::Diff.new(file_reference.destination_contents, file_reference.source_contents)
-        end
+        puts Diffy::Diff.new(file_reference.destination_contents, file_reference.source_contents) if UI.confirm("#{file_reference.destination} has changes that need to be merged. Would you like to see a diff?")
 
         if UI.confirm("Would you like to make a backup of #{file_reference.destination}?")
           extension = File.extname(file_reference.destination)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -125,7 +125,7 @@ module Fastlane
                                        description: 'Overwrite copied files without confirmation',
                                        optional: true,
                                        default_value: false,
-                                       is_string: false)
+                                       is_string: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -125,7 +125,7 @@ module Fastlane
                                        description: 'Overwrite copied files without confirmation',
                                        optional: true,
                                        default_value: false,
-                                       is_string: false),
+                                       is_string: false)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -22,9 +22,7 @@ module Fastlane
       def self.update_repository
         secrets_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
 
-        unless secrets_repo_branch == nil
-          sh("cd #{secrets_dir} && git pull")
-        end
+        sh("cd #{secrets_dir} && git pull") unless secrets_repo_branch == nil
       end
 
       def self.secrets_dir

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -22,7 +22,7 @@ module Fastlane
       def self.update_repository
         secrets_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
 
-        sh("cd #{secrets_dir} && git pull") unless secrets_repo_branch == nil
+        sh("cd #{secrets_dir} && git pull") unless secrets_repo_branch.nil?
       end
 
       def self.secrets_dir

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
@@ -11,9 +11,7 @@ module Fastlane
     class ConfigureSetupAction < Action
       def self.run(params = {})
         # Check to see if the local secret storage is set up at ~/.mobile-secrets.
-        unless File.directory?(repository_path)
-          UI.user_error!('The local secrets store does not exist. Please clone it to ~/.mobile-secrets before continuing.')
-        end
+        UI.user_error!('The local secrets store does not exist. Please clone it to ~/.mobile-secrets before continuing.') unless File.directory?(repository_path)
 
         # Checks to see if .configure exists. If so, exit – there’s no need to continue as everything is set up.
         if configuration_file_exists
@@ -22,9 +20,7 @@ module Fastlane
         end
 
         # The mobile secrets repo must be up to date in order to generate and save the encryption key
-        if Fastlane::Helper::ConfigureHelper.repo_is_behind_remote
-          prompt_to_update_to_most_recent_version
-        end
+        prompt_to_update_to_most_recent_version if Fastlane::Helper::ConfigureHelper.repo_is_behind_remote
 
         # Generate an encryption key for the new project, if needed
         Fastlane::Helper::ConfigureHelper.update_project_encryption_key if Fastlane::Helper::ConfigureHelper.project_encryption_key.nil?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -15,9 +15,7 @@ module Fastlane
             Please fix this issue before continuing")
         end
 
-        if repo_is_behind_remote
-          prompt_to_update_to_most_recent_version
-        end
+        prompt_to_update_to_most_recent_version if repo_is_behind_remote
 
         if configure_file_is_behind_repo
           prompt_to_update_configure_file_to_most_recent_hash
@@ -30,9 +28,7 @@ module Fastlane
         # If there is no encryption key for the project, generate one
         if Fastlane::Helper::ConfigureHelper.project_encryption_key.nil?
           # If the user chose not to update the repo but there is no encryption key, throw an error
-          if repo_is_behind_remote
-            UI.user_error!('The local secrets behind the remote but it is missing a keys.json entry for this project. Please update it to the latest commit.')
-          end
+          UI.user_error!('The local secrets behind the remote but it is missing a keys.json entry for this project. Please update it to the latest commit.') if repo_is_behind_remote
           Fastlane::Helper::ConfigureHelper.update_project_encryption_key
           # Update the configure file to the new hash
           update_configure_file
@@ -55,9 +51,7 @@ module Fastlane
           checkout_branch(new_branch)
           update_configure_file
         else
-          if current_branch == nil
-            UI.user_error!('The local secrets store is in a deatched HEAD state.  Please check out a branch and try again.')
-          end
+          UI.user_error!('The local secrets store is in a deatched HEAD state.  Please check out a branch and try again.') if current_branch == nil
         end
       end
 
@@ -69,9 +63,7 @@ module Fastlane
       end
 
       def self.prompt_to_update_configure_file_to_most_recent_hash
-        if UI.confirm("The `.configure` file is #{configure_file_commits_behind_repo} commit hash(es) behind the repo. Would you like to update it?")
-          update_configure_file
-        end
+        update_configure_file if UI.confirm("The `.configure` file is #{configure_file_commits_behind_repo} commit hash(es) behind the repo. Would you like to update it?")
       end
 
       def self.current_branch

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -45,13 +45,13 @@ module Fastlane
       end
 
       def self.prompt_to_switch_branches
-        branch_name_to_display = current_branch == nil ? current_hash : current_branch
+        branch_name_to_display = current_branch.nil? ? current_hash : current_branch
         if UI.confirm("The current branch is `#{branch_name_to_display}`. Would you like to switch branches?")
           new_branch = UI.select("Select the branch you'd like to switch to: ", get_branches)
           checkout_branch(new_branch)
           update_configure_file
         else
-          UI.user_error!('The local secrets store is in a deatched HEAD state.  Please check out a branch and try again.') if current_branch == nil
+          UI.user_error!('The local secrets store is in a deatched HEAD state.  Please check out a branch and try again.') if current_branch.nil?
         end
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -93,7 +93,7 @@ module Fastlane
       end
 
       def self.validate_that_all_copied_files_match
-        Fastlane::Helper::ConfigureHelper.files_to_copy.each { |x|
+        Fastlane::Helper::ConfigureHelper.files_to_copy.each do |x|
           source = absolute_secret_store_path(x.file)
           destination = absolute_project_path(x.destination)
 
@@ -103,7 +103,7 @@ module Fastlane
           unless sourceHash == destinationHash
             UI.user_error!("`#{x.destination} doesn't match the file in the secrets repository (#{x.file}) – unable to continue")
           end
-        }
+        end
       end
 
       def self.validate_that_configure_file_exists

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -76,20 +76,14 @@ module Fastlane
 
         changed_dependencies = changed_files & dependencies # calculate array intersection
 
-        unless changed_dependencies.empty?
-          UI.user_error!("The following files are out of date. Please run `bundle exec fastlane run configure_update` before continuing:\n\n#{changed_dependencies}")
-        end
+        UI.user_error!("The following files are out of date. Please run `bundle exec fastlane run configure_update` before continuing:\n\n#{changed_dependencies}") unless changed_dependencies.empty?
 
-        unless new_files.empty?
-          UI.user_error!("The following files are in the secrets repository, but aren't available for your project. Please run `bundle exec fastlane run configure_update` before continuing:\n\n#{new_files}")
-        end
+        UI.user_error!("The following files are in the secrets repository, but aren't available for your project. Please run `bundle exec fastlane run configure_update` before continuing:\n\n#{new_files}") unless new_files.empty?
       end
 
       ### Validate that the secrets repo doesn't have any local changes
       def self.validate_that_secrets_repo_is_clean
-        unless Fastlane::Helper::ConfigureHelper.repo_has_changes
-          UI.user_error!('The secrets repository has uncommitted changes. Please commit or discard them before continuing.')
-        end
+        UI.user_error!('The secrets repository has uncommitted changes. Please commit or discard them before continuing.') unless Fastlane::Helper::ConfigureHelper.repo_has_changes
       end
 
       def self.validate_that_all_copied_files_match
@@ -100,16 +94,12 @@ module Fastlane
           sourceHash = file_hash(source)
           destinationHash = file_hash(destination)
 
-          unless sourceHash == destinationHash
-            UI.user_error!("`#{x.destination} doesn't match the file in the secrets repository (#{x.file}) – unable to continue")
-          end
+          UI.user_error!("`#{x.destination} doesn't match the file in the secrets repository (#{x.file}) – unable to continue") unless sourceHash == destinationHash
         end
       end
 
       def self.validate_that_configure_file_exists
-        unless Fastlane::Helper::ConfigureHelper.configuration_path_exists
-          UI.user_error!("Couldn't find `.configure` file. Please set up this project for `configure` by running `bundle exec fastlane run configure_setup`")
-        end
+        UI.user_error!("Couldn't find `.configure` file. Please set up this project for `configure` by running `bundle exec fastlane run configure_setup`") unless Fastlane::Helper::ConfigureHelper.configuration_path_exists
       end
 
       def self.absolute_project_path(relative_path)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -44,7 +44,7 @@ module Fastlane
 
           UI.user_error!([
             'The branch specified in `.configure` is not the currently checked out branch in the secrets repository.',
-            "To fix this issue, switch back to the `#{file_branch_name}` branch in the mobile secrets repository."
+            "To fix this issue, switch back to the `#{file_branch_name}` branch in the mobile secrets repository.",
           ].join("\n"))
         end
       end
@@ -59,7 +59,7 @@ module Fastlane
 
           UI.user_error!([
             'The pinned_hash specified in `.configure` is not the currently checked out hash in the secrets repository.',
-            "To fix this issue, check out the `#{file_hash}` hash in the mobile secrets repository."
+            "To fix this issue, check out the `#{file_hash}` hash in the mobile secrets repository.",
           ].join("\n"))
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -44,7 +44,7 @@ module Fastlane
 
           UI.user_error!([
             'The branch specified in `.configure` is not the currently checked out branch in the secrets repository.',
-            "To fix this issue, switch back to the `#{file_branch_name}` branch in the mobile secrets repository.",
+            "To fix this issue, switch back to the `#{file_branch_name}` branch in the mobile secrets repository."
           ].join("\n"))
         end
       end
@@ -59,7 +59,7 @@ module Fastlane
 
           UI.user_error!([
             'The pinned_hash specified in `.configure` is not the currently checked out hash in the secrets repository.',
-            "To fix this issue, check out the `#{file_hash}` hash in the mobile secrets repository.",
+            "To fix this issue, check out the `#{file_hash}` hash in the mobile secrets repository."
           ].join("\n"))
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -51,7 +51,7 @@ module Fastlane
                                        description: 'The team_id for the provisioning profiles',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                                       UI.user_error!('You must provide a team ID in `team_id`') unless (value && (not value.empty?))
+                                                       UI.user_error!('You must provide a team ID in `team_id`') unless value && (not value.empty?)
                                                      end),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -51,7 +51,7 @@ module Fastlane
                                        description: 'The team_id for the provisioning profiles',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                                       UI.user_error!('You must provide a team ID in `team_id`') unless (value and not value.empty?)
+                                                       UI.user_error!('You must provide a team ID in `team_id`') unless (value && (not value.empty?))
                                                      end),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -7,24 +7,24 @@ module Fastlane
         Spaceship.login
         Spaceship.select_team(team_id: params[:team_id])
 
-        all_certificates = Spaceship.certificate.all(mac: false).select { |certificate|
+        all_certificates = Spaceship.certificate.all(mac: false).select do |certificate|
           certificate.owner_type == 'teamMember'
-        }
+        end
 
-        params[:app_identifier].each { |identifier|
+        params[:app_identifier].each do |identifier|
           Spaceship.provisioning_profile.find_by_bundle_id(bundle_id: identifier)
-                   .select { |profile|
+                   .select do |profile|
             profile.kind_of? Spaceship::Portal::ProvisioningProfile::Development
-          }
-                   .tap { |profiles|
+          end
+                   .tap do |profiles|
             UI.important "Warning: Unable to find any profiles associated with #{identifier}" unless profiles.length > 0
-          }
-                   .each { |profile|
+          end
+                   .each do |profile|
             profile.certificates = all_certificates
             profile.update!
             UI.success "Applied #{all_certificates.length} certificates to #{profile.name}"
-          }
-        }
+          end
+        end
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -52,7 +52,7 @@ module Fastlane
                                        is_string: true,
                                        verify_block: proc do |value|
                                                        UI.user_error!('You must provide a team ID in `team_id`') unless value && (!value.empty?)
-                                                     end),
+                                                     end)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -45,7 +45,7 @@ module Fastlane
                                        description: 'List of App Identifiers that should contain the new device identifier',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                                       UI.user_error!('You must provide an array of bundle identifiers in `app_identifier`') unless not value.empty?
+                                                       UI.user_error!('You must provide an array of bundle identifiers in `app_identifier`') if value.empty?
                                                      end),
           FastlaneCore::ConfigItem.new(key: :team_id,
                                        description: 'The team_id for the provisioning profiles',

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -51,7 +51,7 @@ module Fastlane
                                        description: 'The team_id for the provisioning profiles',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                                       UI.user_error!('You must provide a team ID in `team_id`') unless value && (not value.empty?)
+                                                       UI.user_error!('You must provide a team ID in `team_id`') unless value && (!value.empty?)
                                                      end),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -14,7 +14,7 @@ module Fastlane
         params[:app_identifier].each do |identifier|
           Spaceship.provisioning_profile.find_by_bundle_id(bundle_id: identifier)
                    .select do |profile|
-            profile.kind_of? Spaceship::Portal::ProvisioningProfile::Development
+            profile.is_a? Spaceship::Portal::ProvisioningProfile::Development
           end
                    .tap do |profiles|
             UI.important "Warning: Unable to find any profiles associated with #{identifier}" unless profiles.length > 0

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -52,7 +52,7 @@ module Fastlane
                                        is_string: true,
                                        verify_block: proc do |value|
                                                        UI.user_error!('You must provide a team ID in `team_id`') unless value && (!value.empty?)
-                                                     end)
+                                                     end),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -54,7 +54,7 @@ module Fastlane
             verify_block: proc do |value|
               UI.user_error!('You must provide a team ID in `team_id`') unless value && (!value.empty?)
             end
-          ),
+          )
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -54,7 +54,7 @@ module Fastlane
             verify_block: proc do |value|
               UI.user_error!('You must provide a team ID in `team_id`') unless value && (!value.empty?)
             end
-          )
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -52,7 +52,7 @@ module Fastlane
             description: 'The team_id for the provisioning profiles',
             is_string: true,
             verify_block: proc do |value|
-              UI.user_error!('You must provide a team ID in `team_id`') unless (value && (not value.empty?))
+              UI.user_error!('You must provide a team ID in `team_id`') unless value && (not value.empty?)
             end
           ),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -52,7 +52,7 @@ module Fastlane
             description: 'The team_id for the provisioning profiles',
             is_string: true,
             verify_block: proc do |value|
-              UI.user_error!('You must provide a team ID in `team_id`') unless (value and not value.empty?)
+              UI.user_error!('You must provide a team ID in `team_id`') unless (value && (not value.empty?))
             end
           ),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -44,7 +44,7 @@ module Fastlane
             description: 'List of App Identifiers that should contain the new device identifier',
             is_string: false,
             verify_block: proc do |value|
-              UI.user_error!('You must provide an array of bundle identifiers in `app_identifier`') unless not value.empty?
+              UI.user_error!('You must provide an array of bundle identifiers in `app_identifier`') if value.empty?
             end
           ),
           FastlaneCore::ConfigItem.new(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -9,20 +9,20 @@ module Fastlane
 
         devices = Spaceship.device.all_ios_profile_devices
 
-        params[:app_identifier].each { |identifier|
+        params[:app_identifier].each do |identifier|
           Spaceship.provisioning_profile.find_by_bundle_id(bundle_id: identifier)
-                   .select { |profile|
+                   .select do |profile|
             profile.kind_of? Spaceship::Portal::ProvisioningProfile::Development
-          }
-                   .tap { |profiles|
+          end
+                   .tap do |profiles|
             UI.important "Warning: Unable to find any profiles associated with #{identifier}" unless profiles.length > 0
-          }
-                   .each { |profile|
+          end
+                   .each do |profile|
             profile.devices = devices
             profile.update!
             UI.success "Applied #{devices.length} devices to #{profile.name}"
-          }
-        }
+          end
+        end
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -12,7 +12,7 @@ module Fastlane
         params[:app_identifier].each do |identifier|
           Spaceship.provisioning_profile.find_by_bundle_id(bundle_id: identifier)
                    .select do |profile|
-            profile.kind_of? Spaceship::Portal::ProvisioningProfile::Development
+            profile.is_a? Spaceship::Portal::ProvisioningProfile::Development
           end
                    .tap do |profiles|
             UI.important "Warning: Unable to find any profiles associated with #{identifier}" unless profiles.length > 0

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -52,7 +52,7 @@ module Fastlane
             description: 'The team_id for the provisioning profiles',
             is_string: true,
             verify_block: proc do |value|
-              UI.user_error!('You must provide a team ID in `team_id`') unless value && (not value.empty?)
+              UI.user_error!('You must provide a team ID in `team_id`') unless value && (!value.empty?)
             end
           ),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -17,7 +17,7 @@ module Fastlane
 
         # Check branch
         app_version = Fastlane::Helper::Ios::VersionHelper.get_public_version
-        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless (!params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version))
+        UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless !params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version)
 
         # Check user overwrite
         build_version = get_user_build_version(params[:base_version], message) unless params[:base_version].nil?
@@ -25,8 +25,8 @@ module Fastlane
 
         # Verify
         message << "Updating branch to version: #{next_version}.\n"
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -68,7 +68,7 @@ module Fastlane
                                        env_name: 'FL_IOS_BETABUILD_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -26,7 +26,7 @@ module Fastlane
         # Verify
         message << "Updating branch to version: #{next_version}.\n"
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -26,9 +26,7 @@ module Fastlane
         # Verify
         message << "Updating branch to version: #{next_version}.\n"
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -9,8 +9,8 @@ module Fastlane
         message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to App Center\n" unless !params[:internal_on_single_version]
         message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
 
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -10,9 +10,7 @@ module Fastlane
         message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
 
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -5,9 +5,9 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper.rb'
 
         message = ''
-        message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_internal_version()} and uploading to App Center\n" unless !params[:internal]
-        message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to App Center\n" unless !params[:internal_on_single_version]
-        message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
+        message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_internal_version()} and uploading to App Center\n" if params[:internal]
+        message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to App Center\n" if params[:internal_on_single_version]
+        message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to TestFlight\n" if params[:external]
 
         if !params[:skip_confirm]
           UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -10,7 +10,7 @@ module Fastlane
         message << "Building version #{Fastlane::Helper::Ios::VersionHelper.get_build_version()} and uploading to TestFlight\n" unless !params[:external]
 
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -52,7 +52,7 @@ module Fastlane
                                        env_name: 'FL_IOS_BUILD_PRECHECKS_INTERNAL_SV_BUILD',
                                        description: 'True if this is for an internal build that follows the same versioning of the external',
                                        is_string: false,
-                                       default_value: false)
+                                       default_value: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -56,7 +56,7 @@ module Fastlane
             description: "The path to the DerivedData directory for the project. Should match what's used in the `gym` action",
             is_string: true,
             default_value: '~/Library/Developer/Xcode/DerivedData'
-          )
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -49,7 +49,7 @@ module Fastlane
 
       private
 
-      def self.create_config()
+      def self.create_config
         @current_version = Fastlane::Helper::Ios::VersionHelper.get_build_version()
         @current_version_internal = Fastlane::Helper::Ios::VersionHelper.get_internal_version() unless ENV['INTERNAL_CONFIG_FILE'].nil?
         @new_internal_version = Fastlane::Helper::Ios::VersionHelper.create_internal_version(@current_version) unless ENV['INTERNAL_CONFIG_FILE'].nil?
@@ -57,7 +57,7 @@ module Fastlane
         @short_version = Fastlane::Helper::Ios::VersionHelper.get_short_version_string(@new_beta_version)
       end
 
-      def self.show_config()
+      def self.show_config
         UI.message("Current build version: #{@current_version}")
         UI.message("Current internal version: #{@current_version_internal}") unless ENV['INTERNAL_CONFIG_FILE'].nil?
         UI.message("New beta version: #{@new_beta_version}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -74,7 +74,7 @@ module Fastlane
         @new_release_branch = "release/#{@new_short_version}"
       end
 
-      def self.show_config()
+      def self.show_config
         UI.message("Current build version: #{@current_version}")
         UI.message("Current internal version: #{@current_version_internal}") unless ENV['INTERNAL_CONFIG_FILE'].nil?
         UI.message("New build version: #{@new_version}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -45,7 +45,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :previous_version,
                                        env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION',
                                        description: 'The version to branch from',
-                                       is_string: true) # the default value if the user didn't provide one
+                                       is_string: true), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -84,7 +84,7 @@ module Fastlane
 
       private
 
-      def self.create_config()
+      def self.create_config
         @current_version = Fastlane::Helper::Ios::VersionHelper.get_build_version()
         @current_version_internal = Fastlane::Helper::Ios::VersionHelper.get_internal_version() unless ENV['INTERNAL_CONFIG_FILE'].nil?
         @new_version_internal = Fastlane::Helper::Ios::VersionHelper.create_internal_version(@new_version) unless ENV['INTERNAL_CONFIG_FILE'].nil?
@@ -92,7 +92,7 @@ module Fastlane
         @new_release_branch = "release/#{@new_short_version}"
       end
 
-      def self.show_config()
+      def self.show_config
         UI.message("Current build version: #{@current_version}")
         UI.message("Current internal version: #{@current_version_internal}") unless ENV['INTERNAL_CONFIG_FILE'].nil?
         UI.message("New build version: #{@new_version}")
@@ -101,7 +101,7 @@ module Fastlane
         UI.message("Release branch: #{@new_release_branch}")
       end
 
-      def self.update_glotpress_key()
+      def self.update_glotpress_key
         dm_file = ENV['DOWNLOAD_METADATA']
         if (File.exist?(dm_file)) then
           sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -63,7 +63,7 @@ module Fastlane
                                        env_name: 'FL_IOS_CODEFREEZE_BUMP_SKIPDELIVER',
                                        description: 'Skips Deliver key update',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
 
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -103,7 +103,7 @@ module Fastlane
 
       def self.update_glotpress_key
         dm_file = ENV['DOWNLOAD_METADATA']
-        if (File.exist?(dm_file)) then
+        if File.exist?(dm_file) then
           sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")
         else
           UI.user_error!("Can't find #{dm_file}.")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -103,7 +103,7 @@ module Fastlane
 
       def self.update_glotpress_key
         dm_file = ENV['DOWNLOAD_METADATA']
-        if File.exist?(dm_file) then
+        if File.exist?(dm_file)
           sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")
         else
           UI.user_error!("Can't find #{dm_file}.")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -63,7 +63,7 @@ module Fastlane
                                        env_name: 'FL_IOS_CODEFREEZE_BUMP_SKIPDELIVER',
                                        description: 'Skips Deliver key update',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false), # the default value if the user didn't provide one
+                                       default_value: false) # the default value if the user didn't provide one
 
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -7,7 +7,7 @@ module Fastlane
 
         beta_pods = []
         File.open(params[:podfile]).each do |li|
-          beta_pods << li if (li.match('^\s*\t*pod.*beta'))
+          beta_pods << li if li.match('^\s*\t*pod.*beta')
         end
 
         if beta_pods.count == 0

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -39,7 +39,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :podfile,
                                        env_name: 'FL_IOS_CHECKBETADEPS_PODFILE',
                                        description: 'Path to the Podfile to analyse',
-                                       is_string: true),
+                                       is_string: true)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -39,7 +39,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :podfile,
                                        env_name: 'FL_IOS_CHECKBETADEPS_PODFILE',
                                        description: 'Path to the Podfile to analyse',
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -36,7 +36,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: 'FL_IOS_CLEAN_INTERMEDIATE_TAGS_VERSION',
                                        description: 'The version of the tags to clear',
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -47,7 +47,7 @@ module Fastlane
                                        env_name: 'FL_IOS_CODEFREEZE_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation before codefreeze',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -17,8 +17,8 @@ module Fastlane
         next_version = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(current_version)
 
         # Ask user confirmation
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
         end
 
         # Check local repo status

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -17,8 +17,8 @@ module Fastlane
         next_version = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(current_version)
 
         # Ask user confirmation
-        if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
+        unless params[:skip_confirm]
+          UI.user_error!('Aborted by user request') unless UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
         end
 
         # Check local repo status

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -18,9 +18,7 @@ module Fastlane
 
         # Ask user confirmation
         if (!params[:skip_confirm])
-          if (!UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?"))
         end
 
         # Check local repo status

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -41,7 +41,7 @@ module Fastlane
                                        env_name: 'FL_IOS_COMPLETECODEFREEZE_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -12,7 +12,7 @@ module Fastlane
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
         message = "Completing code freeze for: #{version}\n"
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -12,9 +12,7 @@ module Fastlane
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
         message = "Completing code freeze for: #{version}\n"
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -11,8 +11,8 @@ module Fastlane
 
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
         message = "Completing code freeze for: #{version}\n"
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -30,7 +30,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: 'FL_IOS_FINAL_TAG_VERSION',
                                        description: 'The version of the release to finalize',
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -11,8 +11,8 @@ module Fastlane
 
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
         message = "Finalizing release: #{version}\n"
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -41,7 +41,7 @@ module Fastlane
                                        env_name: 'FL_IOS_FINALIZE_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -12,7 +12,7 @@ module Fastlane
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
         message = "Finalizing release: #{version}\n"
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -12,9 +12,7 @@ module Fastlane
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
         message = "Finalizing release: #{version}\n"
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -92,7 +92,7 @@ module Fastlane
             description: "The output format used to print the result. Can be one of 'csv' or 'markdown', or nil to print nothing (raw data will always be available as the the action's return value)",
             type: String,
             optional: true
-          )
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -92,7 +92,7 @@ module Fastlane
             description: "The output format used to print the result. Can be one of 'csv' or 'markdown', or nil to print nothing (raw data will always be available as the the action's return value)",
             type: String,
             optional: true
-          ),
+          )
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -91,7 +91,7 @@ module Fastlane
             env_name: 'FL_IOS_STOREAPPSIZES_FORMAT',
             description: "The output format used to print the result. Can be one of 'csv' or 'markdown', or nil to print nothing (raw data will always be available as the the action's return value)",
             type: String,
-            optional: true,
+            optional: true
           ),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
@@ -17,21 +17,15 @@ module Fastlane
         message << "Branching from: #{prev_ver}\n"
 
         if (!params[:skip_confirm])
-          if (!UI.confirm("#{message}Do you want to continue?"))
-            UI.user_error!('Aborted by user request')
-          end
+          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
         else
           UI.message(message)
         end
 
         # Check tags
-        if other_action.git_tag_exists(tag: new_ver)
-          UI.crash!("Version #{new_ver} already exists! Abort!")
-        end
+        UI.crash!("Version #{new_ver} already exists! Abort!") if other_action.git_tag_exists(tag: new_ver)
 
-        if !other_action.git_tag_exists(tag: prev_ver)
-          UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!")
-        end
+        UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!") if !other_action.git_tag_exists(tag: prev_ver)
 
         # Check local repo status
         other_action.ensure_git_status_clean()

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
@@ -17,7 +17,7 @@ module Fastlane
         message << "Branching from: #{prev_ver}\n"
 
         if !params[:skip_confirm]
-          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
+          UI.user_error!('Aborted by user request') unless UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end
@@ -25,7 +25,7 @@ module Fastlane
         # Check tags
         UI.crash!("Version #{new_ver} already exists! Abort!") if other_action.git_tag_exists(tag: new_ver)
 
-        UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!") if !other_action.git_tag_exists(tag: prev_ver)
+        UI.crash!("Version #{prev_ver} is not tagged! Can't branch. Abort!") unless other_action.git_tag_exists(tag: prev_ver)
 
         # Check local repo status
         other_action.ensure_git_status_clean()

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
@@ -16,8 +16,8 @@ module Fastlane
         message = "Requested Hotfix version: #{new_ver}\n"
         message << "Branching from: #{prev_ver}\n"
 
-        if (!params[:skip_confirm])
-          UI.user_error!('Aborted by user request') if (!UI.confirm("#{message}Do you want to continue?"))
+        if !params[:skip_confirm]
+          UI.user_error!('Aborted by user request') if !UI.confirm("#{message}Do you want to continue?")
         else
           UI.message(message)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotifx_prechecks.rb
@@ -56,7 +56,7 @@ module Fastlane
                                        env_name: 'FL_IOS_HOTFIX_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false) # the default value if the user didn't provide one
+                                       default_value: false), # the default value if the user didn't provide one
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -139,7 +139,7 @@ module Fastlane
             optional: true,
             default_value: false,
             is_string: false # https://docs.fastlane.tools/advanced/actions/#boolean-parameters
-          )
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -9,9 +9,7 @@ module Fastlane
           break unless !violations.empty? && params[:allow_retry] && UI.confirm(RETRY_MESSAGE)
         end
 
-        if !violations.empty? && params[:abort_on_violations]
-          UI.abort_with_message!(ABORT_MESSAGE)
-        end
+        UI.abort_with_message!(ABORT_MESSAGE) if !violations.empty? && params[:abort_on_violations]
 
         violations
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -139,7 +139,7 @@ module Fastlane
             optional: true,
             default_value: false,
             is_string: false # https://docs.fastlane.tools/advanced/actions/#boolean-parameters
-          ),
+          )
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
@@ -81,7 +81,7 @@ module Fastlane
                                        env_name: 'IMTS_STRING_FOLDER',
                                        description: 'The folder that contains all the translations',
                                        optional: false,
-                                       type: String)
+                                       type: String),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
@@ -17,7 +17,7 @@ module Fastlane
       def self.merge_folder(strings_folder)
         main_file = File.join(strings_folder, 'Localizable.strings')
         tmp_main_file = File.join(strings_folder, 'Localizable_current.strings')
-        return unless (File.exist?(main_file) && File.exist?(tmp_main_file))
+        return unless File.exist?(main_file) && File.exist?(tmp_main_file)
 
         UI.message("Merging in: #{strings_folder}")
 
@@ -29,7 +29,7 @@ module Fastlane
           my_strings.each do |string|
             if string[/^\"(.*)\" = \"(.*)\";$/]
               /^\"(?<string_key>.*)\" = \"/i =~ string
-              if (!extra_keys.include?(string_key))
+              if !extra_keys.include?(string_key)
                 extra_strings << string
                 extra_keys << string_key
               end
@@ -50,10 +50,10 @@ module Fastlane
       end
 
       def self.check_line(line, extra_keys)
-        return line unless (line[/^\"(.*)\" = \"(.*)\";$/])
+        return line unless line[/^\"(.*)\" = \"(.*)\";$/]
 
         /^\"(?<line_key>.*)\" = \"/i =~ line
-        return '' if (extra_keys.include?(line_key))
+        return '' if extra_keys.include?(line_key)
 
         return line
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
@@ -22,8 +22,8 @@ module Fastlane
         UI.message("Merging in: #{strings_folder}")
 
         join_files = Dir.glob(File.join("#{strings_folder}", 'Localizable_*.strings')) - [tmp_main_file]
-        extra_strings = Array.new
-        extra_keys = Array.new
+        extra_strings = []
+        extra_keys = []
         join_files.each do |join_strings|
           my_strings = File.read(join_strings).split("\n")
           my_strings.each do |string|

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
@@ -81,7 +81,7 @@ module Fastlane
                                        env_name: 'IMTS_STRING_FOLDER',
                                        description: 'The folder that contains all the translations',
                                        optional: false,
-                                       type: String),
+                                       type: String)
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_translators_strings.rb
@@ -29,7 +29,7 @@ module Fastlane
           my_strings.each do |string|
             if string[/^\"(.*)\" = \"(.*)\";$/]
               /^\"(?<string_key>.*)\" = \"/i =~ string
-              if !extra_keys.include?(string_key)
+              unless extra_keys.include?(string_key)
                 extra_strings << string
                 extra_keys << string_key
               end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -44,21 +44,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value and not value.empty?)
+                                                       UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value && (not value.empty?))
                                                        UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                                      end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_IOS_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value and not value.empty?)
+                                                       UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value && (not value.empty?))
                                                      end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_IOS_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value and not value.empty?)
+                                                       UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value && (not value.empty?))
                                                      end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -59,7 +59,7 @@ module Fastlane
                                        is_string: false,
                                        verify_block: proc do |value|
                                                        UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (!value.empty?)
-                                                     end)
+                                                     end),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -16,7 +16,7 @@ module Fastlane
 
         repo_status = Actions.sh('git status --porcelain')
         repo_clean = repo_status.empty?
-        if !repo_clean then
+        if !repo_clean
           Action.sh('git commit -m "Update metadata strings"')
           Action.sh('git push')
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -16,7 +16,7 @@ module Fastlane
 
         repo_status = Actions.sh('git status --porcelain')
         repo_clean = repo_status.empty?
-        if (!repo_clean) then
+        if !repo_clean then
           Action.sh('git commit -m "Update metadata strings"')
           Action.sh('git push')
         end
@@ -44,21 +44,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless (value && (not value.empty?))
+                                                       UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (not value.empty?)
                                                        UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                                      end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_IOS_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless (value && (not value.empty?))
+                                                       UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (not value.empty?)
                                                      end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_IOS_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless (value && (not value.empty?))
+                                                       UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (not value.empty?)
                                                      end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -44,21 +44,21 @@ module Fastlane
                                        description: 'The path of the .po file to update',
                                        is_string: true,
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (not value.empty?)
+                                                       UI.user_error!("No .po file path for UpdateMetadataSourceAction given, pass using `po_file_path: 'file path'`") unless value && (!value.empty?)
                                                        UI.user_error!("Couldn't find file at path '#{value}'") unless File.exist?(value)
                                                      end),
           FastlaneCore::ConfigItem.new(key: :release_version,
                                        env_name: 'FL_IOS_UPDATE_METADATA_SOURCE_RELEASE_VERSION',
                                        description: 'The release version of the app (to use to mark the release notes)',
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (not value.empty?)
+                                                       UI.user_error!("No relase version for UpdateMetadataSourceAction given, pass using `release_version: 'version'`") unless value && (!value.empty?)
                                                      end),
           FastlaneCore::ConfigItem.new(key: :source_files,
                                        env_name: 'FL_IOS_UPDATE_METADATA_SOURCE_SOURCE_FILES',
                                        description: 'The hash with the path to the source files and the key to use to include their content',
                                        is_string: false,
                                        verify_block: proc do |value|
-                                                       UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (not value.empty?)
+                                                       UI.user_error!("No source file hash for UpdateMetadataSourceAction given, pass using `source_files: 'source file hash'`") unless value && (!value.empty?)
                                                      end)
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -16,7 +16,7 @@ module Fastlane
 
         repo_status = Actions.sh('git status --porcelain')
         repo_clean = repo_status.empty?
-        if !repo_clean
+        unless repo_clean
           Action.sh('git commit -m "Update metadata strings"')
           Action.sh('git push')
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -34,7 +34,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :new_version,
                                        env_name: 'FL_IOS_UPDATE_RELEASE_NOTES_VERSION',
                                        description: 'The version we are currently freezing; An empty entry for the _next_ version after this one will be added to the release notes',
-                                       is_string: true)
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -48,7 +48,7 @@ module Fastlane
         fw.puts("msgctxt \"#{@block_key}\"")
         line_count = File.foreach(@content_file_path).inject(0) { |c, _line| c + 1 }
 
-        if (line_count <= 1)
+        if line_count <= 1
           # Single line output
           fw.puts("msgid \"#{File.open(@content_file_path, "r").read}\"")
         else
@@ -100,10 +100,10 @@ module Fastlane
         if line.start_with?('msgctxt')
           key = extract_key(line)
           @is_copying = (key == @keep_key)
-          generate_block(fw) if (@is_copying)
+          generate_block(fw) if @is_copying
         end
 
-        fw.puts(line) if (@is_copying)
+        fw.puts(line) if @is_copying
       end
 
       def generate_block(fw)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -40,9 +40,7 @@ module Fastlane
       def handle_line(fw, line)
         # put the new content on block start
         # and skip all the other content
-        if line.start_with?('msgctxt')
-          generate_block(fw)
-        end
+        generate_block(fw) if line.start_with?('msgctxt')
       end
 
       def generate_block(fw)
@@ -102,14 +100,10 @@ module Fastlane
         if line.start_with?('msgctxt')
           key = extract_key(line)
           @is_copying = (key == @keep_key)
-          if (@is_copying)
-            generate_block(fw)
-          end
+          generate_block(fw) if (@is_copying)
         end
 
-        if (@is_copying)
-          fw.puts(line)
-        end
+        fw.puts(line) if (@is_copying)
       end
 
       def generate_block(fw)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -20,7 +20,7 @@ module Fastlane
     class UnknownMetadataBlock < MetadataBlock
       attr_reader :content_file_path
 
-      def initialize()
+      def initialize
         super(nil)
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -91,7 +91,7 @@ module Fastlane
 
       def is_handler_for(key)
         values = key.split('_')
-        key.start_with?(@rel_note_key) && values.length == 3 && (Integer(values[2].sub(/^[0]*/, '')) != nil rescue false)
+        key.start_with?(@rel_note_key) && values.length == 3 && is_int?(values[2].sub(/^[0]*/, ''))
       end
 
       def handle_line(fw, line)
@@ -137,11 +137,15 @@ module Fastlane
 
       def is_handler_for(key)
         values = key.split('_')
-        key.start_with?(@rel_note_key) && values.length == 4 && (Integer(values[3].sub(/^[0]*/, '')) != nil rescue false)
+        key.start_with?(@rel_note_key) && values.length == 4 && is_int?(values[3].sub(/^[0]*/, ''))
       end
 
       def generate_block(fw)
         super(fw) unless File.zero?(@content_file_path)
+      end
+
+      def is_int?(value)
+        true if Integer(string) rescue false
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -50,7 +50,7 @@ module Fastlane
 
         if line_count <= 1
           # Single line output
-          fw.puts("msgid \"#{File.open(@content_file_path, "r").read}\"")
+          fw.puts("msgid \"#{File.open(@content_file_path, 'r').read}\"")
         else
           # Multiple line output
           fw.puts('msgid ""')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -11,7 +11,7 @@ module Fastlane
         # @env PROJECT_ROOT_FOLDER The path to the git root of the project
         # @env PROJECT_NAME The name of the directory containing the project code (especially containing the `build.gradle` file)
         #
-        def self.commit_version_bump()
+        def self.commit_version_bump
           Fastlane::Helper::GitHelper.commit(
             message: 'Bump version number',
             files: File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], 'build.gradle'),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -182,30 +182,34 @@ end
 
 # Source: https://stackoverflow.com/questions/7825258/determine-if-two-nokogiri-nodes-are-equivalent?rq=1
 # There may be better solutions now that Ruby supports canonicalization.
-class Nokogiri::XML::Node
-  # Return true if this node is content-equivalent to other, false otherwise
-  def =~(other)
-    return true if self == other
-    return false unless name == other.name
+module Nokogiri
+  module XML
+    class Node
+      # Return true if this node is content-equivalent to other, false otherwise
+      def =~(other)
+        return true if self == other
+        return false unless name == other.name
 
-    stype = node_type; otype = other.node_type
-    return false unless stype == otype
+        stype = node_type; otype = other.node_type
+        return false unless stype == otype
 
-    sa = attributes; oa = other.attributes
-    return false unless sa.length == oa.length
+        sa = attributes; oa = other.attributes
+        return false unless sa.length == oa.length
 
-    sa = sa.sort.map { |n, a| [n, a.value, a.namespace && a.namespace.href] }
-    oa = oa.sort.map { |n, a| [n, a.value, a.namespace && a.namespace.href] }
-    return false unless sa == oa
+        sa = sa.sort.map { |n, a| [n, a.value, a.namespace && a.namespace.href] }
+        oa = oa.sort.map { |n, a| [n, a.value, a.namespace && a.namespace.href] }
+        return false unless sa == oa
 
-    skids = children; okids = other.children
-    return false unless skids.length == okids.length
-    return false if stype == TEXT_NODE && (content != other.content)
+        skids = children; okids = other.children
+        return false unless skids.length == okids.length
+        return false if stype == TEXT_NODE && (content != other.content)
 
-    sns = namespace; ons = other.namespace
-    return false if !sns ^ !ons
-    return false if sns && (sns.href != ons.href)
+        sns = namespace; ons = other.namespace
+        return false if !sns ^ !ons
+        return false if sns && (sns.href != ons.href)
 
-    skids.to_enum.with_index.all? { |ski, i| ski =~ okids[i] }
+        skids.to_enum.with_index.all? { |ski, i| ski =~ okids[i] }
+      end
+    end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -11,7 +11,7 @@ module Fastlane
         # Checks if string_line has the content_override flag set
         def self.skip_string_by_tag(string_line)
           skip = string_line.attr('content_override') == 'true' unless string_line.attr('content_override').nil?
-          if (skip)
+          if skip
             puts " - Skipping #{string_line.attr("name")} string"
             return true
           end
@@ -21,10 +21,10 @@ module Fastlane
 
         # Checks if string_name is in the excluesion list
         def self.skip_string_by_exclusion_list(library, string_name)
-          return false if (!library.key?(:exclusions))
+          return false if !library.key?(:exclusions)
 
           skip = library[:exclusions].include?(string_name)
-          if (skip)
+          if skip
             puts " - Skipping #{string_name} string"
             return true
           end
@@ -41,16 +41,16 @@ module Fastlane
           # Search for the string in the main file
           result = :added
           main_strings.xpath('//string').each do |this_string|
-            if (this_string.attr('name') == string_name) then
+            if this_string.attr('name') == string_name then
               # Skip if the string has the content_override tag
               return :skipped if skip_string_by_tag(this_string)
 
               # If nodes are equivalent, skip
-              return :found if (string_line =~ this_string)
+              return :found if string_line =~ this_string
 
               # The string needs an update
               result = :updated
-              if (this_string.attr('tools:ignore').nil?)
+              if this_string.attr('tools:ignore').nil?
                 # It can be updated, so remove the current one and move ahead
                 this_string.remove
                 break
@@ -77,12 +77,12 @@ module Fastlane
 
           # Search for the string in the main file
           main_strings.xpath('//string').each do |this_string|
-            if (this_string.attr('name') == string_name) then
+            if this_string.attr('name') == string_name then
               # Skip if the string has the content_override tag
               return if skip_string_by_tag(this_string)
 
               # Update if needed
-              UI.user_error!("String #{string_name} [#{string_content}] has been updated in the main file but not in the library #{library[:library]}.") if (this_string.content != string_content)
+              UI.user_error!("String #{string_name} [#{string_content}] has been updated in the main file but not in the library #{library[:library]}.") if this_string.content != string_content
               return
             end
           end
@@ -136,7 +136,7 @@ module Fastlane
             diff_string = diff_string.slice(0..(end_index - 1))
 
             lib_strings.xpath('//string').each do |string_line|
-              res = verify_string(main_strings, library, string_line) if (string_line.attr('name') == diff_string)
+              res = verify_string(main_strings, library, string_line) if string_line.attr('name') == diff_string
             end
           end
         end
@@ -152,7 +152,7 @@ module Fastlane
 
         def self.verify_local_diff(main, library, main_strings, lib_strings)
           `git diff #{main}`.each_line do |line|
-            if (line.start_with?('+ ') || line.start_with?('- ')) then
+            if line.start_with?('+ ') || line.start_with?('- ') then
               diffs = line.gsub(/\s+/m, ' ').strip.split(' ')
               diffs.each do |diff|
                 verify_diff(diff, main_strings, lib_strings, library)
@@ -163,7 +163,7 @@ module Fastlane
 
         def self.verify_pr_diff(main, library, main_strings, lib_strings, source_diff)
           source_diff.each_line do |line|
-            if (line.start_with?('+ ') || line.start_with?('- ')) then
+            if line.start_with?('+ ') || line.start_with?('- ') then
               diffs = line.gsub(/\s+/m, ' ').strip.split(' ')
               diffs.each do |diff|
                 verify_diff(diff, main_strings, lib_strings, library)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -186,21 +186,25 @@ module Nokogiri
         return true if self == other
         return false unless name == other.name
 
-        stype = node_type; otype = other.node_type
+        stype = node_type
+        otype = other.node_type
         return false unless stype == otype
 
-        sa = attributes; oa = other.attributes
+        sa = attributes
+        oa = other.attributes
         return false unless sa.length == oa.length
 
         sa = sa.sort.map { |n, a| [n, a.value, a.namespace && a.namespace.href] }
         oa = oa.sort.map { |n, a| [n, a.value, a.namespace && a.namespace.href] }
         return false unless sa == oa
 
-        skids = children; okids = other.children
+        skids = children
+        okids = other.children
         return false unless skids.length == okids.length
         return false if stype == TEXT_NODE && (content != other.content)
 
-        sns = namespace; ons = other.namespace
+        sns = namespace
+        ons = other.namespace
         return false if !sns ^ !ons
         return false if sns && (sns.href != ons.href)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -21,7 +21,7 @@ module Fastlane
 
         # Checks if string_name is in the excluesion list
         def self.skip_string_by_exclusion_list(library, string_name)
-          return false if !library.key?(:exclusions)
+          return false unless library.key?(:exclusions)
 
           skip = library[:exclusions].include?(string_name)
           if skip

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -156,7 +156,7 @@ module Fastlane
 
         def self.verify_local_diff(main, library, main_strings, lib_strings)
           `git diff #{main}`.each_line do |line|
-            if (line.start_with?('+ ') or line.start_with?('- ')) then
+            if (line.start_with?('+ ') || line.start_with?('- ')) then
               diffs = line.gsub(/\s+/m, ' ').strip.split(' ')
               diffs.each do |diff|
                 verify_diff(diff, main_strings, lib_strings, library)
@@ -167,7 +167,7 @@ module Fastlane
 
         def self.verify_pr_diff(main, library, main_strings, lib_strings, source_diff)
           source_diff.each_line do |line|
-            if (line.start_with?('+ ') or line.start_with?('- ')) then
+            if (line.start_with?('+ ') || line.start_with?('- ')) then
               diffs = line.gsub(/\s+/m, ' ').strip.split(' ')
               diffs.each do |diff|
                 verify_diff(diff, main_strings, lib_strings, library)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -21,9 +21,7 @@ module Fastlane
 
         # Checks if string_name is in the excluesion list
         def self.skip_string_by_exclusion_list(library, string_name)
-          if (!library.key?(:exclusions))
-            return false
-          end
+          return false if (!library.key?(:exclusions))
 
           skip = library[:exclusions].include?(string_name)
           if (skip)
@@ -138,9 +136,7 @@ module Fastlane
             diff_string = diff_string.slice(0..(end_index - 1))
 
             lib_strings.xpath('//string').each do |string_line|
-              if (string_line.attr('name') == diff_string) then
-                res = verify_string(main_strings, library, string_line)
-              end
+              res = verify_string(main_strings, library, string_line) if (string_line.attr('name') == diff_string)
             end
           end
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -121,7 +121,7 @@ module Fastlane
           end
 
           File.open(main, 'w:UTF-8') do |f|
-            f.write(main_strings.to_xml(:indent => 4))
+            f.write(main_strings.to_xml(indent: 4))
           end
 
           UI.message("Done (#{added_count} added, #{updated_count} updated, #{untouched_count} untouched, #{skipped_count} skipped).")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -41,7 +41,7 @@ module Fastlane
           # Search for the string in the main file
           result = :added
           main_strings.xpath('//string').each do |this_string|
-            if this_string.attr('name') == string_name then
+            if this_string.attr('name') == string_name
               # Skip if the string has the content_override tag
               return :skipped if skip_string_by_tag(this_string)
 
@@ -77,7 +77,7 @@ module Fastlane
 
           # Search for the string in the main file
           main_strings.xpath('//string').each do |this_string|
-            if this_string.attr('name') == string_name then
+            if this_string.attr('name') == string_name
               # Skip if the string has the content_override tag
               return if skip_string_by_tag(this_string)
 
@@ -127,7 +127,7 @@ module Fastlane
         end
 
         def self.verify_diff(diff_string, main_strings, lib_strings, library)
-          if diff_string.start_with?('name=') then
+          if diff_string.start_with?('name=')
             diff_string.slice!('name="')
 
             end_index = diff_string.index('"')
@@ -152,7 +152,7 @@ module Fastlane
 
         def self.verify_local_diff(main, library, main_strings, lib_strings)
           `git diff #{main}`.each_line do |line|
-            if line.start_with?('+ ') || line.start_with?('- ') then
+            if line.start_with?('+ ') || line.start_with?('- ')
               diffs = line.gsub(/\s+/m, ' ').strip.split(' ')
               diffs.each do |diff|
                 verify_diff(diff, main_strings, lib_strings, library)
@@ -163,7 +163,7 @@ module Fastlane
 
         def self.verify_pr_diff(main, library, main_strings, lib_strings, source_diff)
           source_diff.each_line do |line|
-            if line.start_with?('+ ') || line.start_with?('- ') then
+            if line.start_with?('+ ') || line.start_with?('- ')
               diffs = line.gsub(/\s+/m, ' ').strip.split(' ')
               diffs.each do |diff|
                 verify_diff(diff, main_strings, lib_strings, library)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
         def self.skip_string_by_tag(string_line)
           skip = string_line.attr('content_override') == 'true' unless string_line.attr('content_override').nil?
           if skip
-            puts " - Skipping #{string_line.attr("name")} string"
+            puts " - Skipping #{string_line.attr('name')} string"
             return true
           end
 
@@ -63,7 +63,7 @@ module Fastlane
           end
 
           # String not found, or removed because needing update and not in the exclusion list: add to the main file
-          main_strings.xpath('//string').last().add_next_sibling("\n#{" " * 4}#{string_line.to_xml().strip}")
+          main_strings.xpath('//string').last().add_next_sibling("\n#{' ' * 4}#{string_line.to_xml().strip}")
           return result
         end
 
@@ -104,12 +104,12 @@ module Fastlane
             res = merge_string(main_strings, library, string_line)
             case res
             when :updated
-              puts "#{string_line.attr("name")} updated."
+              puts "#{string_line.attr('name')} updated."
               updated_count = updated_count + 1
             when :found
               untouched_count = untouched_count + 1
             when :added
-              puts "#{string_line.attr("name")} added."
+              puts "#{string_line.attr('name')} added."
               added_count = added_count + 1
             when :skipped
               skipped_count = skipped_count + 1

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -180,7 +180,7 @@ module Fastlane
           version_name = remove_beta_suffix(version[VERSION_NAME])
           vp = get_version_parts(version_name)
           vp[MINOR_NUMBER] += 1
-          if (vp[MINOR_NUMBER] == 10)
+          if vp[MINOR_NUMBER] == 10
             vp[MAJOR_NUMBER] += 1
             vp[MINOR_NUMBER] = 0
           end
@@ -229,7 +229,7 @@ module Fastlane
         #
         def self.calc_prev_release_version(version)
           vp = get_version_parts(version)
-          if (vp[MINOR_NUMBER] == 0)
+          if vp[MINOR_NUMBER] == 0
             vp[MAJOR_NUMBER] -= 1
             vp[MINOR_NUMBER] = 9
           else
@@ -382,7 +382,7 @@ module Fastlane
           v_parts = get_version_parts(version)
 
           v_parts.each do |part|
-            UI.user_error!('Version value can only contains numbers.') if (!is_int?(part))
+            UI.user_error!('Version value can only contains numbers.') if !is_int?(part)
           end
 
           "#{v_parts[MAJOR_NUMBER]}.#{v_parts[MINOR_NUMBER]}"
@@ -428,16 +428,16 @@ module Fastlane
             file.each_line do |line|
               if !found_section
                 temp_file.puts line
-                found_section = true if (line.include? section)
+                found_section = true if line.include? section
               else
-                if (version_updated < 2)
+                if version_updated < 2
                   if line.include?('versionName') && !line.include?('"versionName"') && !line.include?('PversionName')
                     version_name = line.split(' ')[1].tr('\"', '')
                     line.sub!(version_name, version[VERSION_NAME].to_s)
                     version_updated = version_updated + 1
                   end
 
-                  if (line.include? 'versionCode')
+                  if line.include? 'versionCode'
                     version_code = line.split(' ')[1]
                     line.sub!(version_code, version[VERSION_CODE].to_s)
                     version_updated = version_updated + 1

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -382,7 +382,7 @@ module Fastlane
           v_parts = get_version_parts(version)
 
           v_parts.each do |part|
-            UI.user_error!('Version value can only contains numbers.') if !is_int?(part)
+            UI.user_error!('Version value can only contains numbers.') unless is_int?(part)
           end
 
           "#{v_parts[MAJOR_NUMBER]}.#{v_parts[MINOR_NUMBER]}"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -362,13 +362,9 @@ module Fastlane
           File.open(file_path, 'r') do |file|
             file.each_line do |line|
               if !found_section
-                if line.include?(section)
-                  found_section = true
-                end
+                found_section = true if line.include?(section)
               else
-                if line.include?(keyword) && !line.include?("\"#{keyword}\"") && !line.include?("P#{keyword}")
-                  return line.split(' ')[1]
-                end
+                return line.split(' ')[1] if line.include?(keyword) && !line.include?("\"#{keyword}\"") && !line.include?("P#{keyword}")
               end
             end
           end
@@ -386,9 +382,7 @@ module Fastlane
           v_parts = get_version_parts(version)
 
           v_parts.each do |part|
-            if (!is_int?(part)) then
-              UI.user_error!('Version value can only contains numbers.')
-            end
+            UI.user_error!('Version value can only contains numbers.') if (!is_int?(part))
           end
 
           "#{v_parts[MAJOR_NUMBER]}.#{v_parts[MINOR_NUMBER]}"
@@ -434,9 +428,7 @@ module Fastlane
             file.each_line do |line|
               if !found_section
                 temp_file.puts line
-                if (line.include? section)
-                  found_section = true
-                end
+                found_section = true if (line.include? section)
               else
                 if (version_updated < 2)
                   if line.include?('versionName') && !line.include?('"versionName"') && !line.include?('PversionName')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -163,7 +163,7 @@ module Fastlane
         # @return [String] The version name for the next release
         #
         def self.calc_next_release_short_version(version)
-          v = self.calc_next_release_base_version({ VERSION_NAME => version, VERSION_CODE => nil })
+          v = self.calc_next_release_base_version(VERSION_NAME => version, VERSION_CODE => nil)
           return v[VERSION_NAME]
         end
 
@@ -201,7 +201,7 @@ module Fastlane
         # @return [Hash] The hash containing the version name and code to use after release cut
         #
         def self.calc_next_release_version(version, alpha_version = nil)
-          nv = calc_next_release_base_version({ VERSION_NAME => version[VERSION_NAME], VERSION_CODE => alpha_version.nil? ? version[VERSION_CODE] : [version[VERSION_CODE], alpha_version[VERSION_CODE]].max })
+          nv = calc_next_release_base_version(VERSION_NAME => version[VERSION_NAME], VERSION_CODE => alpha_version.nil? ? version[VERSION_CODE] : [version[VERSION_CODE], alpha_version[VERSION_CODE]].max)
           calc_next_beta_version(nv)
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -221,9 +221,9 @@ module Fastlane
       # Adds a file to the `.configure` file's `files_to_copy` hash.
       # The hash for this method must contain the `source` and `destination` keys
       def self.add_file(params)
-        UI.user_error!('You must pass a `source` to `add_file`') unless (params[:source])
+        UI.user_error!('You must pass a `source` to `add_file`') unless params[:source]
 
-        UI.user_error!('You must pass a `destination` to `add_file`') unless (params[:destination])
+        UI.user_error!('You must pass a `destination` to `add_file`') unless params[:destination]
 
         new_config = self.configuration
         new_config.add_file_to_copy(params[:source], params[:destination], params[:encrypt])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -127,7 +127,7 @@ module Fastlane
       def self.repo_commits_behind_remote
         matches = repo_status.match(/behind \d+/)
 
-        return 0 if matches == nil
+        return 0 if matches.nil?
 
         parse_distance(matches[0])
       end
@@ -142,7 +142,7 @@ module Fastlane
       def self.repo_commits_ahead_of_remote
         matches = repo_status.match(/ahead \d+/)
 
-        return 0 if matches == nil
+        return 0 if matches.nil?
 
         parse_distance(matches[0])
       end
@@ -152,7 +152,7 @@ module Fastlane
       def self.parse_distance(match)
         distance = match.to_s.scan(/\d+/).first
 
-        return 0 if distance == nil
+        return 0 if distance.nil?
 
         distance.to_i
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -190,17 +190,17 @@ module Fastlane
         file_dependencies ||= []
 
         # Allows support for specifying directories – they'll be expanded recursively
-        expanded_file_dependencies = file_dependencies.map { |path|
+        expanded_file_dependencies = file_dependencies.map do |path|
           abs_path = self.mobile_secrets_path(path)
 
           if File.directory?(abs_path)
-            Dir.glob("#{abs_path}**/*").map { |sub_path|
+            Dir.glob("#{abs_path}**/*").map do |sub_path|
               sub_path.gsub(repository_path + '/', '')
-            }
+            end
           else
             return path
           end
-        }
+        end
 
         self.files_to_copy.map { |o| o.file } + expanded_file_dependencies
       end
@@ -211,9 +211,9 @@ module Fastlane
         file_dependencies = self.configuration.file_dependencies
         file_dependencies ||= []
 
-        directory_dependencies = file_dependencies.select { |path|
+        directory_dependencies = file_dependencies.select do |path|
           File.directory?(self.mobile_secrets_path(path))
-        }
+        end
 
         new_files = []
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -106,9 +106,7 @@ module Fastlane
         index_of_configure_hash = hashes.find_index(configure_file_commit_hash)
         index_of_repo_commit_hash = hashes.find_index(repo_commit_hash)
 
-        if index_of_configure_hash >= index_of_repo_commit_hash
-          return 0
-        end
+        return 0 if index_of_configure_hash >= index_of_repo_commit_hash
 
         index_of_repo_commit_hash - index_of_configure_hash
       end
@@ -129,9 +127,7 @@ module Fastlane
       def self.repo_commits_behind_remote
         matches = repo_status.match(/behind \d+/)
 
-        if matches == nil
-          return 0
-        end
+        return 0 if matches == nil
 
         parse_distance(matches[0])
       end
@@ -146,9 +142,7 @@ module Fastlane
       def self.repo_commits_ahead_of_remote
         matches = repo_status.match(/ahead \d+/)
 
-        if matches == nil
-          return 0
-        end
+        return 0 if matches == nil
 
         parse_distance(matches[0])
       end
@@ -158,9 +152,7 @@ module Fastlane
       def self.parse_distance(match)
         distance = match.to_s.scan(/\d+/).first
 
-        if distance == nil
-          return 0
-        end
+        return 0 if distance == nil
 
         distance.to_i
       end
@@ -219,9 +211,7 @@ module Fastlane
 
         files.each do |path|
           directory_dependencies.each do |directory_name|
-            if path.start_with?(directory_name)
-              new_files << path
-            end
+            new_files << path if path.start_with?(directory_name)
           end
         end
 
@@ -231,13 +221,9 @@ module Fastlane
       # Adds a file to the `.configure` file's `files_to_copy` hash.
       # The hash for this method must contain the `source` and `destination` keys
       def self.add_file(params)
-        unless (params[:source])
-          UI.user_error!('You must pass a `source` to `add_file`')
-        end
+        UI.user_error!('You must pass a `source` to `add_file`') unless (params[:source])
 
-        unless (params[:destination])
-          UI.user_error!('You must pass a `destination` to `add_file`')
-        end
+        UI.user_error!('You must pass a `destination` to `add_file`') unless (params[:destination])
 
         new_config = self.configuration
         new_config.add_file_to_copy(params[:source], params[:destination], params[:encrypt])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -23,9 +23,7 @@ module Fastlane
             dir = dir.parent
           end
 
-          if dir.root?
-            UI.user_error!("Unable to determine the project root directory – #{Dir.pwd} doesn't appear to reside within a git repository.")
-          end
+          UI.user_error!("Unable to determine the project root directory – #{Dir.pwd} doesn't appear to reside within a git repository.") if dir.root?
         end
 
         dir
@@ -44,9 +42,7 @@ module Fastlane
             dir = dir.parent
           end
 
-          if dir.root?
-            UI.user_error!('Unable to determine the plugin root directory.')
-          end
+          UI.user_error!('Unable to determine the plugin root directory.') if dir.root?
         end
 
         dir
@@ -88,9 +84,7 @@ module Fastlane
 
       ### Returns the `sha1` hash of a file, given the absolute path.
       def self.file_hash(absolute_path)
-        unless File.file?(absolute_path)
-          UI.user_error!("Unable to hash #{absolute_path} – the file does not exist")
-        end
+        UI.user_error!("Unable to hash #{absolute_path} – the file does not exist") unless File.file?(absolute_path)
 
         Digest::SHA1.file absolute_path
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -133,7 +133,7 @@ module Fastlane
 
       # Fetch all the tags from the remote.
       #
-      def self.fetch_all_tags()
+      def self.fetch_all_tags
         Action.sh('git', 'fetch', '--tags')
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -32,17 +32,17 @@ module Fastlane
         options[:state] = 'open'
 
         milestones = github_client().list_milestones(repository, options)
-        return nil if (milestones.nil?)
+        return nil if milestones.nil?
 
         last_stone = nil
         milestones.each do |mile|
-          if (last_stone.nil?)
+          if last_stone.nil?
             last_stone = mile unless mile[:title].split(' ')[0].split('.').length < 2
           else
             begin
-              if (mile[:title].split(' ')[0].split('.')[0] > last_stone[:title].split(' ')[0].split('.')[0])
+              if mile[:title].split(' ')[0].split('.')[0] > last_stone[:title].split(' ')[0].split('.')[0]
                 last_stone = mile
-              elsif (mile[:title].split(' ')[0].split('.')[1] > last_stone[:title].split(' ')[0].split('.')[1])
+              elsif mile[:title].split(' ')[0].split('.')[1] > last_stone[:title].split(' ')[0].split('.')[1]
                 last_stone = mile
               end
             rescue StandardError

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -21,9 +21,7 @@ module Fastlane
         mile = nil
 
         miles&.each do |mm|
-          if mm[:title].start_with?(release)
-            mile = mm
-          end
+          mile = mm if mm[:title].start_with?(release)
         end
 
         return mile
@@ -34,9 +32,7 @@ module Fastlane
         options[:state] = 'open'
 
         milestones = github_client().list_milestones(repository, options)
-        if (milestones.nil?)
-          return nil
-        end
+        return nil if (milestones.nil?)
 
         last_stone = nil
         milestones.each do |mile|

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
@@ -20,9 +20,7 @@ module Fastlane
 
           UI.message 'Fetching the list of versions...'
           versions = app.app_store_versions.select { |v| v.version_string == only_version && !v.build.nil? }
-          if versions.empty?
-            versions = app.get_app_store_versions.reject { |v| v.build.nil? }
-          end
+          versions = app.get_app_store_versions.reject { |v| v.build.nil? } if versions.empty?
           UI.message "Found #{versions.count} versions." + (limit == 0 ? '' : " Limiting to last #{limit}")
           versions = versions.first(limit) unless limit == 0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -39,7 +39,7 @@ module Fastlane
         #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
         #
         def self.localize_project
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
+          Action.sh("cd #{ENV['PROJECT_ROOT_FOLDER']} && ./Scripts/localize.py")
 
           strings_files = Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do
             Dir.glob('*.lproj/*.strings')
@@ -56,7 +56,7 @@ module Fastlane
         #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
         #
         def self.update_metadata
-          Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/update-translations.rb")
+          Action.sh("cd #{ENV['PROJECT_ROOT_FOLDER']} && ./Scripts/update-translations.rb")
 
           strings_files = Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do
             Dir.glob('*.lproj/*.strings')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -19,9 +19,7 @@ module Fastlane
         #
         def self.commit_version_bump(include_deliverfile: true, include_metadata: true)
           files_list = [File.join(ENV['PROJECT_ROOT_FOLDER'], 'config', '.')]
-          if include_deliverfile
-            files_list.append File.join('fastlane', 'Deliverfile')
-          end
+          files_list.append File.join('fastlane', 'Deliverfile') if include_deliverfile
           if include_metadata
             files_list.append File.join('fastlane', 'download_metadata.swift')
             files_list.append File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], 'Resources', ENV['APP_STORE_STRINGS_FILE_NAME'])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -40,7 +40,7 @@ module Fastlane
         # @todo Migrate the scripts, currently in each host repo and called by this method, to be helpers and actions
         #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
         #
-        def self.localize_project()
+        def self.localize_project
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/localize.py")
 
           strings_files = Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do
@@ -57,7 +57,7 @@ module Fastlane
         # @todo Migrate the scripts, currently in each host repo and called by this method, to be helpers and actions
         #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
         #
-        def self.update_metadata()
+        def self.update_metadata
           Action.sh("cd #{ENV["PROJECT_ROOT_FOLDER"]} && ./Scripts/update-translations.rb")
 
           strings_files = Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -197,7 +197,7 @@ module Fastlane
         def only_empty_lines?(file)
           File.open(file) do |f|
             while (line = f.gets)
-              return false if not line.strip.empty?
+              return false unless line.strip.empty?
             end
           end
           return true

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -327,7 +327,7 @@ module Fastlane
           v_parts = get_version_parts(version)
 
           v_parts.each do |part|
-            UI.user_error!('Version value can only contains numbers.') if !is_int?(part)
+            UI.user_error!('Version value can only contains numbers.') unless is_int?(part)
           end
 
           "#{v_parts[MAJOR_NUMBER]}.#{v_parts[MINOR_NUMBER]}.#{v_parts[HOTFIX_NUMBER]}.#{v_parts[BUILD_NUMBER]}"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -314,7 +314,7 @@ module Fastlane
         #         The first element is always present and contains the version extracted from the public config file
         #         The second element is the version extracted from the internal config file, only present if one was provided.
         def self.get_version_strings
-          version_strings = Array.new
+          version_strings = []
           version_strings << read_long_version_from_config_file(ENV['PUBLIC_CONFIG_FILE'])
           version_strings << read_long_version_from_config_file(ENV['INTERNAL_CONFIG_FILE']) unless ENV['INTERNAL_CONFIG_FILE'].nil?
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -202,7 +202,7 @@ module Fastlane
         #
         def self.update_fastlane_deliver(new_version)
           fd_file = './fastlane/Deliverfile'
-          if File.exist?(fd_file) then
+          if File.exist?(fd_file)
             Action.sh("sed -i '' \"s/app_version.*/app_version \\\"#{new_version}\\\"/\" #{fd_file}")
           else
             UI.user_error!("Can't find #{fd_file}.")
@@ -232,7 +232,7 @@ module Fastlane
         # @raise [UserError] If the xcconfig file was not found
         #
         def self.update_xc_config(file_path, new_version, new_version_short)
-          if File.exist?(file_path) then
+          if File.exist?(file_path)
             UI.message("Updating #{file_path} to version #{new_version_short}/#{new_version}")
             Action.sh("sed -i '' \"$(awk '/^VERSION_SHORT/{ print NR; exit }' \"#{file_path}\")s/=.*/=#{new_version_short}/\" \"#{file_path}\"")
             Action.sh("sed -i '' \"$(awk '/^VERSION_LONG/{ print NR; exit }' \"#{file_path}\")s/=.*/=#{new_version}/\" \"#{file_path}\"")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -260,9 +260,7 @@ module Fastlane
         def self.get_version_parts(version)
           parts = version.split('.')
           parts = parts.fill('0', parts.length...4).map { |chr| chr.to_i }
-          if (parts.length > 4) then
-            UI.user_error!("Bad version string: #{version}")
-          end
+          UI.user_error!("Bad version string: #{version}") if (parts.length > 4)
 
           return parts
         end
@@ -296,9 +294,7 @@ module Fastlane
           File.open(filePath, 'r') do |f|
             f.each_line do |line|
               line = line.strip()
-              if line.start_with?("#{key}=")
-                return line.split('=')[1]
-              end
+              return line.split('=')[1] if line.start_with?("#{key}=")
             end
           end
 
@@ -331,9 +327,7 @@ module Fastlane
           v_parts = get_version_parts(version)
 
           v_parts.each do |part|
-            if (!is_int?(part)) then
-              UI.user_error!('Version value can only contains numbers.')
-            end
+            UI.user_error!('Version value can only contains numbers.') if (!is_int?(part))
           end
 
           "#{v_parts[MAJOR_NUMBER]}.#{v_parts[MINOR_NUMBER]}.#{v_parts[HOTFIX_NUMBER]}.#{v_parts[BUILD_NUMBER]}"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -38,7 +38,7 @@ module Fastlane
         def self.calc_next_release_version(version)
           vp = get_version_parts(version)
           vp[MINOR_NUMBER] += 1
-          if (vp[MINOR_NUMBER] == 10)
+          if vp[MINOR_NUMBER] == 10
             vp[MAJOR_NUMBER] += 1
             vp[MINOR_NUMBER] = 0
           end
@@ -66,7 +66,7 @@ module Fastlane
         #
         def self.calc_prev_release_version(version)
           vp = get_version_parts(version)
-          if (vp[MINOR_NUMBER] == 0)
+          if vp[MINOR_NUMBER] == 0
             vp[MAJOR_NUMBER] -= 1
             vp[MINOR_NUMBER] = 9
           else
@@ -202,7 +202,7 @@ module Fastlane
         #
         def self.update_fastlane_deliver(new_version)
           fd_file = './fastlane/Deliverfile'
-          if (File.exist?(fd_file)) then
+          if File.exist?(fd_file) then
             Action.sh("sed -i '' \"s/app_version.*/app_version \\\"#{new_version}\\\"/\" #{fd_file}")
           else
             UI.user_error!("Can't find #{fd_file}.")
@@ -238,7 +238,7 @@ module Fastlane
             Action.sh("sed -i '' \"$(awk '/^VERSION_LONG/{ print NR; exit }' \"#{file_path}\")s/=.*/=#{new_version}/\" \"#{file_path}\"")
 
             build_number = read_build_number_from_config_file(file_path)
-            unless (build_number.nil?)
+            unless build_number.nil?
               new_build_number = bump_build_number(build_number)
               Action.sh("sed -i '' \"$(awk '/^BUILD_NUMBER/{ print NR; exit }' \"#{file_path}\")s/=.*/=#{new_build_number}/\" \"#{file_path}\"")
             end
@@ -260,7 +260,7 @@ module Fastlane
         def self.get_version_parts(version)
           parts = version.split('.')
           parts = parts.fill('0', parts.length...4).map { |chr| chr.to_i }
-          UI.user_error!("Bad version string: #{version}") if (parts.length > 4)
+          UI.user_error!("Bad version string: #{version}") if parts.length > 4
 
           return parts
         end
@@ -327,7 +327,7 @@ module Fastlane
           v_parts = get_version_parts(version)
 
           v_parts.each do |part|
-            UI.user_error!('Version value can only contains numbers.') if (!is_int?(part))
+            UI.user_error!('Version value can only contains numbers.') if !is_int?(part)
           end
 
           "#{v_parts[MAJOR_NUMBER]}.#{v_parts[MINOR_NUMBER]}.#{v_parts[HOTFIX_NUMBER]}.#{v_parts[BUILD_NUMBER]}"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -22,14 +22,14 @@ module Fastlane
         @alternates.clear
         loc_data = JSON.parse(response.body) rescue loc_data = nil
         parse_data(target_locale, loc_data, is_source)
-        reparse_alternates(target_locale, loc_data, is_source) unless (@alternates.length == 0)
+        reparse_alternates(target_locale, loc_data, is_source) unless @alternates.length == 0
       end
 
       # Parse JSON data and update the local files
       def parse_data(target_locale, loc_data, is_source)
         delete_existing_metadata(target_locale)
 
-        if (loc_data == nil)
+        if loc_data == nil
           UI.message "No translation available for #{target_locale}"
           return
         end
@@ -39,7 +39,7 @@ module Fastlane
           source = d[0].split(/\u0004/).last
 
           target_files.each do |file|
-            if (file[0].to_s == key)
+            if file[0].to_s == key
               data = file[1]
               msg = is_source ? source : d[1]
               update_key(target_locale, key, file, data, msg)
@@ -56,7 +56,7 @@ module Fastlane
 
           @alternates.each do |file|
             puts "Data: #{file[0]} - key: #{key}"
-            if (file[0].to_s == key)
+            if file[0].to_s == key
               puts "Alternate: #{key}"
               data = file[1]
               msg = is_source ? source : d[1]
@@ -69,7 +69,7 @@ module Fastlane
       def update_key(target_locale, key, file, data, msg)
         message_len = msg.to_s.length - 4 # Don't count JSON delimiters.
         if (data.key?(:max_size)) && (data[:max_size] != 0) && ((message_len) > data[:max_size]) then
-          if (data.key?(:alternate_key)) then
+          if data.key?(:alternate_key) then
             UI.message("#{target_locale} translation for #{key} exceeds maximum length (#{message_len}). Switching to the alternate translation.")
             @alternates[data[:alternate_key]] = { desc: data[:desc], max_size: 0 }
           else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -17,9 +17,7 @@ module Fastlane
       def download(target_locale, glotpress_url, is_source)
         uri = URI(glotpress_url)
         response = Net::HTTP.get_response(uri)
-        if response.code == '301'
-          response = Net::HTTP.get_response(URI.parse(response.header['location']))
-        end
+        response = Net::HTTP.get_response(URI.parse(response.header['location'])) if response.code == '301'
 
         @alternates.clear
         loc_data = JSON.parse(response.body) rescue loc_data = nil

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -68,8 +68,8 @@ module Fastlane
 
       def update_key(target_locale, key, file, data, msg)
         message_len = msg.to_s.length - 4 # Don't count JSON delimiters.
-        if (data.key?(:max_size)) && (data[:max_size] != 0) && ((message_len) > data[:max_size]) then
-          if data.key?(:alternate_key) then
+        if (data.key?(:max_size)) && (data[:max_size] != 0) && ((message_len) > data[:max_size])
+          if data.key?(:alternate_key)
             UI.message("#{target_locale} translation for #{key} exceeds maximum length (#{message_len}). Switching to the alternate translation.")
             @alternates[data[:alternate_key]] = { desc: data[:desc], max_size: 0 }
           else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -29,7 +29,7 @@ module Fastlane
       def parse_data(target_locale, loc_data, is_source)
         delete_existing_metadata(target_locale)
 
-        if loc_data == nil
+        if loc_data.nil?
           UI.message "No translation available for #{target_locale}"
           return
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
@@ -95,7 +95,7 @@ module Fastlane
 
       def is_handler_for(key)
         values = key.split('_')
-        key.start_with?(@rel_note_key) && values.length == 3 && (Integer(values[2]) != nil rescue false)
+        key.start_with?(@rel_note_key) && values.length == 3 && (!Integer(values[2]).nil? rescue false)
       end
 
       def handle_line(fw, line)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
@@ -40,9 +40,7 @@ module Fastlane
       def handle_line(fw, line)
         # put the new content on block start
         # and skip all the other content
-        if line.start_with?('msgctxt')
-          generate_block(fw)
-        end
+        generate_block(fw) if line.start_with?('msgctxt')
       end
 
       def generate_block(fw)
@@ -106,14 +104,10 @@ module Fastlane
         if line.start_with?('msgctxt')
           key = extract_key(line)
           @is_copying = (key == @keep_key)
-          if (@is_copying)
-            generate_block(fw)
-          end
+          generate_block(fw) if (@is_copying)
         end
 
-        if (@is_copying)
-          fw.puts(line)
-        end
+        fw.puts(line) if (@is_copying)
       end
 
       def generate_block(fw)
@@ -166,9 +160,7 @@ module Fastlane
       def handle_line(fw, line)
         # put content on block start or if copying the latest one
         # and skip all the other content
-        if line.start_with?('msgctxt')
-          generate_block(fw)
-        end
+        generate_block(fw) if line.start_with?('msgctxt')
       end
 
       def generate_block(fw)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
@@ -20,7 +20,7 @@ module Fastlane
     class UnknownMetadataBlock < MetadataBlock
       attr_reader :content_file_path
 
-      def initialize()
+      def initialize
         super(nil)
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
@@ -48,7 +48,7 @@ module Fastlane
         fw.puts("msgctxt \"#{@block_key}\"")
         line_count = File.foreach(@content_file_path).inject(0) { |c, _line| c + 1 }
 
-        if (line_count <= 1)
+        if line_count <= 1
           # Single line output
           fw.puts("msgid \"#{File.open(@content_file_path, "r").read}\"")
         else
@@ -104,10 +104,10 @@ module Fastlane
         if line.start_with?('msgctxt')
           key = extract_key(line)
           @is_copying = (key == @keep_key)
-          generate_block(fw) if (@is_copying)
+          generate_block(fw) if @is_copying
         end
 
-        fw.puts(line) if (@is_copying)
+        fw.puts(line) if @is_copying
       end
 
       def generate_block(fw)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb
@@ -50,7 +50,7 @@ module Fastlane
 
         if line_count <= 1
           # Single line output
-          fw.puts("msgid \"#{File.open(@content_file_path, "r").read}\"")
+          fw.puts("msgid \"#{File.open(@content_file_path, 'r').read}\"")
         else
           # Multiple line output
           fw.puts('msgid ""')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -46,9 +46,7 @@ module Fastlane
 
       def draw_caption_to_canvas(entry, canvas, device, stylesheet_path = '')
         # If no caption is provided, it's ok to skip the body of this method
-        if entry['text'] == nil
-          return canvas
-        end
+        return canvas if entry['text'] == nil
 
         text = entry['text']
         text_size = device['text_size']
@@ -57,9 +55,7 @@ module Fastlane
 
         text = resolve_text_into_path(text, locale)
 
-        if can_resolve_path(stylesheet_path)
-          stylesheet_path = resolve_path(stylesheet_path)
-        end
+        stylesheet_path = resolve_path(stylesheet_path) if can_resolve_path(stylesheet_path)
 
         width = text_size[0]
         height = text_size[1]
@@ -100,9 +96,7 @@ module Fastlane
 
       def draw_device_frame_to_canvas(device, canvas)
         # Apply the device frame to the canvas, but only if one is provided
-        unless device['device_frame_size'] != nil
-          return canvas
-        end
+        return canvas unless device['device_frame_size'] != nil
 
         w = device['device_frame_size'][0]
         h = device['device_frame_size'][1]
@@ -123,9 +117,7 @@ module Fastlane
       def draw_screenshot_to_canvas(entry, canvas, device)
         # Don't require a screenshot to be present – we can just skip
         # this function if one doesn't exist.
-        unless entry['screenshot'] != nil
-          return canvas
-        end
+        return canvas unless entry['screenshot'] != nil
 
         device_mask = device['screenshot_mask']
         screenshot_size = device['screenshot_size']
@@ -135,9 +127,7 @@ module Fastlane
 
         screenshot = open_image(screenshot)
 
-        if device_mask != nil
-          screenshot = mask_image(screenshot, open_image(device_mask))
-        end
+        screenshot = mask_image(screenshot, open_image(device_mask)) if device_mask != nil
 
         screenshot = resize_image(screenshot, screenshot_size[0], screenshot_size[1])
         composite_image(canvas, screenshot, screenshot_offset[0], screenshot_offset[1])
@@ -193,9 +183,7 @@ module Fastlane
         y_position = attachment['position'][1] ||= 0
 
         stylesheet_path = attachment['stylesheet']
-        if can_resolve_path(stylesheet_path)
-          stylesheet_path = resolve_path(stylesheet_path)
-        end
+        stylesheet_path = resolve_path(stylesheet_path) if can_resolve_path(stylesheet_path)
 
         alignment = attachment['alignment'] ||= 'center'
 
@@ -247,9 +235,7 @@ module Fastlane
 
           command = "bundle exec drawText html=\"#{text}\" maxWidth=#{width} maxHeight=#{height} output=#{tempTextFile.path} fontSize=#{font_size} stylesheet=\"#{stylesheet_path}\" alignment=\"#{position}\""
 
-          unless system(command)
-            UI.crash!('Unable to draw text')
-          end
+          UI.crash!('Unable to draw text') unless system(command)
 
           text_content = open_image(tempTextFile.path).trim
           text_frame = create_image(width, height)
@@ -296,9 +282,7 @@ module Fastlane
       #
       # @return [Magick::Image] The resized image
       def resize_image(original, width, height)
-        if !original.is_a?(Magick::Image)
-          UI.user_error!('You must pass an image object to `resize_image`.')
-        end
+        UI.user_error!('You must pass an image object to `resize_image`.') if !original.is_a?(Magick::Image)
 
         original.adaptive_resize(width, height)
       end
@@ -318,13 +302,9 @@ module Fastlane
       #
       # @return [Magick::Image] The resized image
       def composite_image(original, child, x_position, y_position, starting_position = NorthWestGravity)
-        if !original.is_a?(Magick::Image)
-          UI.user_error!('You must pass an image object as the first argument to `composite_image`.')
-        end
+        UI.user_error!('You must pass an image object as the first argument to `composite_image`.') if !original.is_a?(Magick::Image)
 
-        if !child.is_a?(Magick::Image)
-          UI.user_error!('You must pass an image object as the second argument to `composite_image`.')
-        end
+        UI.user_error!('You must pass an image object as the second argument to `composite_image`.') if !child.is_a?(Magick::Image)
 
         original.composite(child, starting_position, x_position, y_position, Magick::OverCompositeOp)
       end
@@ -356,9 +336,7 @@ module Fastlane
       #
       # @return [Magick::Image] The resized image
       def crop_image(original, x_position, y_position, width, height)
-        if !original.is_a?(Magick::Image)
-          UI.user_error!('You must pass an image object to `crop_image`.')
-        end
+        UI.user_error!('You must pass an image object to `crop_image`.') if !original.is_a?(Magick::Image)
 
         original.crop(x_position, y_position, width, height)
       end
@@ -389,9 +367,7 @@ module Fastlane
       end
 
       def resolve_path(path)
-        if path == nil
-          UI.crash!('Path not provided – you must provide one to continue')
-        end
+        UI.crash!('Path not provided – you must provide one to continue') if path == nil
 
         [
           Pathname.new(path),                                                           # Absolute Path
@@ -400,9 +376,7 @@ module Fastlane
           Fastlane::Helper::FilesystemHelper.plugin_root + 'spec/test-data/' + path,    # Path Relative to the test data
         ]
           .each do |resolved_path|
-          if resolved_path != nil && resolved_path.exist?
-            return resolved_path
-          end
+          return resolved_path if resolved_path != nil && resolved_path.exist?
         end
 
         message = "Unable to locate #{path}"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -373,7 +373,7 @@ module Fastlane
           Pathname.new(path),                                                           # Absolute Path
           Pathname.new(FastlaneCore::FastlaneFolder.fastfile_path).dirname + path,      # Path Relative to the fastfile
           Fastlane::Helper::FilesystemHelper.plugin_root + path,                        # Path Relative to the plugin
-          Fastlane::Helper::FilesystemHelper.plugin_root + 'spec/test-data/' + path # Path Relative to the test data
+          Fastlane::Helper::FilesystemHelper.plugin_root + 'spec/test-data/' + path, # Path Relative to the test data
         ]
           .each do |resolved_path|
           return resolved_path if !resolved_path.nil? && resolved_path.exist?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -144,13 +144,13 @@ module Fastlane
       end
 
       def draw_attachments_to_canvas(entry, canvas)
-        entry['attachments'].each { |attachment|
+        entry['attachments'].each do |attachment|
           if attachment['file'] != nil
             canvas = draw_file_attachment_to_canvas(attachment, canvas, entry)
           elsif attachment['text'] != nil
             canvas = draw_text_attachment_to_canvas(attachment, canvas, entry['locale'])
           end
-        }
+        end
 
         return canvas
       end
@@ -162,9 +162,9 @@ module Fastlane
 
         if attachment.member?('operations')
 
-          attachment['operations'].each { |operation|
+          attachment['operations'].each do |operation|
             image = apply_operation(image, operation, canvas)
-          }
+          end
 
         end
 
@@ -366,17 +366,17 @@ module Fastlane
       def open_image(path)
         path = resolve_path(path)
 
-        Magick::Image.read(path)  {
+        Magick::Image.read(path)  do
           self.background_color = 'transparent'
-        }.first
+        end.first
       end
 
       def create_image(width, height, background = 'transparent')
         background_color = background.paint.to_hex
 
-        Image.new(width, height) {
+        Image.new(width, height) do
           self.background_color = background
-        }
+        end
       end
 
       def can_resolve_path(path)
@@ -399,11 +399,11 @@ module Fastlane
           Fastlane::Helper::FilesystemHelper.plugin_root + path,                        # Path Relative to the plugin
           Fastlane::Helper::FilesystemHelper.plugin_root + 'spec/test-data/' + path,    # Path Relative to the test data
         ]
-          .each { |resolved_path|
+          .each do |resolved_path|
           if resolved_path != nil && resolved_path.exist?
             return resolved_path
           end
-        }
+        end
 
         message = "Unable to locate #{path}"
         UI.crash!(message)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -282,7 +282,7 @@ module Fastlane
       #
       # @return [Magick::Image] The resized image
       def resize_image(original, width, height)
-        UI.user_error!('You must pass an image object to `resize_image`.') if !original.is_a?(Magick::Image)
+        UI.user_error!('You must pass an image object to `resize_image`.') unless original.is_a?(Magick::Image)
 
         original.adaptive_resize(width, height)
       end
@@ -302,9 +302,9 @@ module Fastlane
       #
       # @return [Magick::Image] The resized image
       def composite_image(original, child, x_position, y_position, starting_position = NorthWestGravity)
-        UI.user_error!('You must pass an image object as the first argument to `composite_image`.') if !original.is_a?(Magick::Image)
+        UI.user_error!('You must pass an image object as the first argument to `composite_image`.') unless original.is_a?(Magick::Image)
 
-        UI.user_error!('You must pass an image object as the second argument to `composite_image`.') if !child.is_a?(Magick::Image)
+        UI.user_error!('You must pass an image object as the second argument to `composite_image`.') unless child.is_a?(Magick::Image)
 
         original.composite(child, starting_position, x_position, y_position, Magick::OverCompositeOp)
       end
@@ -336,7 +336,7 @@ module Fastlane
       #
       # @return [Magick::Image] The resized image
       def crop_image(original, x_position, y_position, width, height)
-        UI.user_error!('You must pass an image object to `crop_image`.') if !original.is_a?(Magick::Image)
+        UI.user_error!('You must pass an image object to `crop_image`.') unless original.is_a?(Magick::Image)
 
         original.crop(x_position, y_position, width, height)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -21,7 +21,7 @@ module Fastlane
   module Helper
     class PromoScreenshots
       def initialize
-        if ($skip_magick)
+        if $skip_magick
           message = "PromoScreenshots feature is currently disabled.\n"
           message << "Please, install RMagick if you aim to generate the PromoScreenshots.\n"
           message << "\'bundle install --with screenshots\' should do it if your project is configured for PromoScreenshots.\n"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -63,7 +63,7 @@ module Fastlane
         x_position = 0
         y_position = 0
 
-        if device['text_offset'] != nil
+        unless device['text_offset'].nil?
           x_position = device['text_offset'][0]
           y_position = device['text_offset'][1]
         end
@@ -79,7 +79,7 @@ module Fastlane
       end
 
       def draw_background_to_canvas(canvas, entry)
-        if entry['background'] != nil
+        unless entry['background'].nil?
 
           # If we're passed an image path, let's open it and paint it to the canvas
           if can_resolve_path(entry['background'])
@@ -96,7 +96,7 @@ module Fastlane
 
       def draw_device_frame_to_canvas(device, canvas)
         # Apply the device frame to the canvas, but only if one is provided
-        return canvas unless device['device_frame_size'] != nil
+        return canvas if device['device_frame_size'].nil?
 
         w = device['device_frame_size'][0]
         h = device['device_frame_size'][1]
@@ -104,7 +104,7 @@ module Fastlane
         x = 0
         y = 0
 
-        if device['device_frame_size'] != nil
+        unless device['device_frame_size'].nil?
           x = device['device_frame_offset'][0]
           y = device['device_frame_offset'][1]
         end
@@ -117,7 +117,7 @@ module Fastlane
       def draw_screenshot_to_canvas(entry, canvas, device)
         # Don't require a screenshot to be present – we can just skip
         # this function if one doesn't exist.
-        return canvas unless entry['screenshot'] != nil
+        return canvas if entry['screenshot'].nil?
 
         device_mask = device['screenshot_mask']
         screenshot_size = device['screenshot_size']
@@ -127,7 +127,7 @@ module Fastlane
 
         screenshot = open_image(screenshot)
 
-        screenshot = mask_image(screenshot, open_image(device_mask)) if device_mask != nil
+        screenshot = mask_image(screenshot, open_image(device_mask)) unless device_mask.nil?
 
         screenshot = resize_image(screenshot, screenshot_size[0], screenshot_size[1])
         composite_image(canvas, screenshot, screenshot_offset[0], screenshot_offset[1])
@@ -135,9 +135,9 @@ module Fastlane
 
       def draw_attachments_to_canvas(entry, canvas)
         entry['attachments'].each do |attachment|
-          if attachment['file'] != nil
+          if !attachment['file'].nil?
             canvas = draw_file_attachment_to_canvas(attachment, canvas, entry)
-          elsif attachment['text'] != nil
+          elsif !attachment['text'].nil?
             canvas = draw_text_attachment_to_canvas(attachment, canvas, entry['locale'])
           end
         end
@@ -163,7 +163,7 @@ module Fastlane
         x_pos = attachment['position'][0]
         y_pos = attachment['position'][1]
 
-        if attachment['offset'] != nil
+        unless attachment['offset'].nil?
           x_pos += attachment['offset'][0]
           y_pos += attachment['offset'][1]
         end
@@ -376,7 +376,7 @@ module Fastlane
           Fastlane::Helper::FilesystemHelper.plugin_root + 'spec/test-data/' + path,    # Path Relative to the test data
         ]
           .each do |resolved_path|
-          return resolved_path if resolved_path != nil && resolved_path.exist?
+          return resolved_path if !resolved_path.nil? && resolved_path.exist?
         end
 
         message = "Unable to locate #{path}"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -373,7 +373,7 @@ module Fastlane
           Pathname.new(path),                                                           # Absolute Path
           Pathname.new(FastlaneCore::FastlaneFolder.fastfile_path).dirname + path,      # Path Relative to the fastfile
           Fastlane::Helper::FilesystemHelper.plugin_root + path,                        # Path Relative to the plugin
-          Fastlane::Helper::FilesystemHelper.plugin_root + 'spec/test-data/' + path,    # Path Relative to the test data
+          Fastlane::Helper::FilesystemHelper.plugin_root + 'spec/test-data/' + path # Path Relative to the test data
         ]
           .each do |resolved_path|
           return resolved_path if !resolved_path.nil? && resolved_path.exist?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -412,13 +412,13 @@ module Fastlane
       def resolve_text_into_path(text, locale)
         localizedFile = sprintf(text, locale)
 
-        if File.exist?(localizedFile)
-          text = localizedFile
-        elsif can_resolve_path(localizedFile)
-          text = resolve_path(localizedFile).realpath.to_s
-        else
-          text = sprintf(text, 'source')
-        end
+        text = if File.exist?(localizedFile)
+                 localizedFile
+               elsif can_resolve_path(localizedFile)
+                 resolve_path(localizedFile).realpath.to_s
+               else
+                 sprintf(text, 'source')
+               end
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -46,7 +46,7 @@ module Fastlane
 
       def draw_caption_to_canvas(entry, canvas, device, stylesheet_path = '')
         # If no caption is provided, it's ok to skip the body of this method
-        return canvas if entry['text'] == nil
+        return canvas if entry['text'].nil?
 
         text = entry['text']
         text_size = device['text_size']
@@ -367,7 +367,7 @@ module Fastlane
       end
 
       def resolve_path(path)
-        UI.crash!('Path not provided – you must provide one to continue') if path == nil
+        UI.crash!('Path not provided – you must provide one to continue') if path.nil?
 
         [
           Pathname.new(path),                                                           # Absolute Path

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -410,14 +410,14 @@ module Fastlane
       end
 
       def resolve_text_into_path(text, locale)
-        localizedFile = sprintf(text, locale)
+        localizedFile = format(text, locale)
 
         text = if File.exist?(localizedFile)
                  localizedFile
                elsif can_resolve_path(localizedFile)
                  resolve_path(localizedFile).realpath.to_s
                else
-                 sprintf(text, 'source')
+                 format(text, 'source')
                end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
@@ -14,7 +14,7 @@ module Fastlane
     end
 
     def self.from_file(path)
-      json = JSON.parse(File.read(path), { symbolize_names: true })
+      json = JSON.parse(File.read(path), symbolize_names: true)
       self.new(json)
     end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -13,7 +13,7 @@ module Fastlane
         # TODO: This works only on CircleCI. I chose this variable because it's the one checked by Fastlane::is_ci.
         # Fastlane::is_ci doesn't work here, so reimplementing the code has been necessary.
         # (This should be updated if we change CI or if fastlane is updated.)
-        return File.read(secrets_repository_file_path) unless (self.encrypt || ENV.key?('CIRCLECI'))
+        return File.read(secrets_repository_file_path) unless self.encrypt || ENV.key?('CIRCLECI')
         return nil unless File.file?(encrypted_file_path)
 
         encrypted = File.read(encrypted_file_path)

--- a/spec/android_merge_translators_strings_spec.rb
+++ b/spec/android_merge_translators_strings_spec.rb
@@ -73,9 +73,7 @@ class AMTSTestUtils
     file_path = File.join(@test_folder_path, filename)
 
     dir = File.dirname(file_path)
-    unless File.directory?(dir)
-      FileUtils.mkdir_p(dir)
-    end
+    FileUtils.mkdir_p(dir) unless File.directory?(dir)
 
     File.open(file_path, 'w') { |f| f.write(content) }
   end

--- a/spec/android_merge_translators_strings_spec.rb
+++ b/spec/android_merge_translators_strings_spec.rb
@@ -42,7 +42,7 @@ end
 class AMTSTestUtils
   attr_accessor :test_folder_path
 
-  def initialize()
+  def initialize
     @test_folder_path = File.join(Dir.tmpdir(), 'amts_tests')
   end
 

--- a/spec/android_merge_translators_strings_spec.rb
+++ b/spec/android_merge_translators_strings_spec.rb
@@ -35,7 +35,7 @@ end
 def amts_run_test(script)
   test_script = @amtsTestUtils.get_test_from_file(script)
   @amtsTestUtils.create_test_data(test_script)
-  Fastlane::Actions::AndroidMergeTranslatorsStringsAction.run({ strings_folder: @amtsTestUtils.test_folder_path })
+  Fastlane::Actions::AndroidMergeTranslatorsStringsAction.run(strings_folder: @amtsTestUtils.test_folder_path)
   expect(@amtsTestUtils.read_result_data(test_script)).to eq(test_script['result']['content'])
 end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -20,7 +20,7 @@ describe Fastlane::Configuration do
         branch: 'a_branch',
         pinned_hash: 'a_hash',
         files_to_copy: [{ file: 'a_file_to_copy', destination: 'a_destination', encrypt: true }],
-        file_dependencies: ['a_file_dependencies'],
+        file_dependencies: ['a_file_dependencies']
       }
     end
     let(:configure_json_string) { JSON.pretty_generate(configure_json) }

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
 
           # First run: expect curl, unzip and cp_r to be called to install SwiftGen before running the action
           # See spec_helper.rb for documentation about `expect_shell_command`.
-          expect_shell_command('curl', any_args, /\/.*swiftgen-#{Fastlane::Helper::Ios::L10nHelper::SWIFTGEN_VERSION}.zip/)
+          expect_shell_command('curl', any_args, %r{/.*swiftgen-#{Fastlane::Helper::Ios::L10nHelper::SWIFTGEN_VERSION}.zip})
           expect_shell_command('unzip', any_args)
           expect(FileUtils).to receive(:cp_r)
           expect_shell_command("#{install_dir}/bin/swiftgen", 'config', 'run', '--config', anything)

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -37,6 +37,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
             fi
           SCRIPT
           FileUtils.mkdir_p File.join(install_dir, 'bin')
+          # note: `0o` is octal notation, used to specify chmod-like flags
           File.write(File.join(install_dir, 'bin/swiftgen'), script, perm: 0o766)
 
           # Second run: ensure we only run SwiftGen directly, without a call to curl nor unzip beforehand

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -37,7 +37,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
             fi
           SCRIPT
           FileUtils.mkdir_p File.join(install_dir, 'bin')
-          File.write(File.join(install_dir, 'bin/swiftgen'), script, perm: 0766)
+          File.write(File.join(install_dir, 'bin/swiftgen'), script, perm: 0o766)
 
           # Second run: ensure we only run SwiftGen directly, without a call to curl nor unzip beforehand
           expect_shell_command("#{install_dir}/bin/swiftgen", 'config', 'run', '--config', anything)

--- a/spec/ios_merge_translators_strings_spec.rb
+++ b/spec/ios_merge_translators_strings_spec.rb
@@ -73,9 +73,7 @@ class IMTSTestUtils
     file_path = File.join(@test_folder_path, filename)
 
     dir = File.dirname(file_path)
-    unless File.directory?(dir)
-      FileUtils.mkdir_p(dir)
-    end
+    FileUtils.mkdir_p(dir) unless File.directory?(dir)
 
     File.open(file_path, 'w') { |f| f.write(content) }
   end

--- a/spec/ios_merge_translators_strings_spec.rb
+++ b/spec/ios_merge_translators_strings_spec.rb
@@ -35,7 +35,7 @@ end
 def imts_run_test(script)
   test_script = @imtsTestUtils.get_test_from_file(script)
   @imtsTestUtils.create_test_data(test_script)
-  Fastlane::Actions::IosMergeTranslatorsStringsAction.run({ strings_folder: @imtsTestUtils.test_folder_path })
+  Fastlane::Actions::IosMergeTranslatorsStringsAction.run(strings_folder: @imtsTestUtils.test_folder_path)
   expect(@imtsTestUtils.read_result_data(test_script)).to eq(test_script['result']['content'])
 end
 

--- a/spec/ios_merge_translators_strings_spec.rb
+++ b/spec/ios_merge_translators_strings_spec.rb
@@ -42,7 +42,7 @@ end
 class IMTSTestUtils
   attr_accessor :test_folder_path
 
-  def initialize()
+  def initialize
     @test_folder_path = File.join(Dir.tmpdir(), 'imts_tests')
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ end
 def set_circle_env(define_ci)
   is_ci = ENV.key?('CIRCLECI')
   orig_circle_ci = ENV['CIRCLECI']
-  if (define_ci)
+  if define_ci
     ENV['CIRCLECI'] = 'true'
   else
     ENV.delete 'CIRCLECI'
@@ -35,7 +35,7 @@ def set_circle_env(define_ci)
 
   yield
 ensure
-  if (is_ci)
+  if is_ci
     ENV['CIRCLECI'] = orig_circle_ci
   else
     ENV.delete 'CIRCLECI'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,9 +9,7 @@ SimpleCov.start
 code_coverage_token = ENV['CODECOV_TOKEN'] || false
 
 # If the environment variable is present, format for Codecov
-if code_coverage_token
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
+SimpleCov.formatter = SimpleCov::Formatter::Codecov if code_coverage_token
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require 'simplecov'
 require 'codecov'


### PR DESCRIPTION
Continuing work on #207 and rubocop.

⚠️ Some of the rules that have been incrementally enabled in this PR were not auto-corrected by rubocop but were corrected manually – so will need more attentive review.

This also includes a small refactor (consisting of the extraction of long portion of code into a separate method, to reduce the code complexity and method length, see https://github.com/wordpress-mobile/release-toolkit/pull/214/commits/f84285d778a7d770c7adcf9fc836784777ef705e) that might also need careful review – especially to ensure that all the variables used in the original code were all passed to the method and that the extracted code didn't modify any variable that would then later be used after it in the original code, etc.

The corresponding commits are labeled accordingly (`[rubocop] fix … (manual)` and the like) – in case you want to review commit-per-commit.