### PR TITLE
Initial editorconfig setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,11 +12,8 @@ trim_trailing_whitespace = true
 max_line_length=120
 
 # Ruby specific rules
-[*.rb]
+[{*.rb,Fastfile,Gemfile}]
 indent_style = space
 indent_size = 2
 
-# Fastlane specific rules
-[**Fastfile]
-indent_style = space
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# top-most EditorConfig file
+root = true
+
+# Apply to all files
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Kotlin specific rules
+[*.{kt,kts}]
+max_line_length=120
+
+# Ruby specific rules
+[*.rb]
+indent_style = space
+indent_size = 2
+
+# Fastlane specific rules
+[**Fastfile]
+indent_style = space
+


### PR DESCRIPTION
This PR builds up on [the initial proposal](https://github.com/wordpress-mobile/WordPress-Android/pull/12414) by @oguzkocer which was put on hold because of time issues before his sabbatical.

I'm starting from the ruleset defined in that PR because we mostly agreed on it. 

I'm moving this to `release-toolkit` because I think it would be nice that we share the rules across all the repositories, so that if we make a change, it's easily deployed without having the open PRs on every project. 
So far, the best solution I've found is to rely on `.editorconfig`'s standard behaviour of looking up for a configuration file in every parent folder until it finds one with `root=true`. 
So, my proposal would be to add `.editorconfig` to this repository and update the configuration tasks we already have on every app (`rake dependencies` and `gradle configureApply`) to download it in the parent folder. 

This way, we'll have a shared base configuration and every project will be able to tweak it's own rules if they want to by adding a specific `.editorconfig`.

If you have a better solution to share the file across different repos, please let me know :-) 


