### PR TITLE
Add missing mandatory function

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/circleci_trigger_job_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/circleci_trigger_job_action.rb
@@ -54,6 +54,10 @@ module Fastlane
       def self.authors
         ['loremattei']
       end
+
+      def self.is_supported?(platform)
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
While switching Simplenote iOS to trigger the release jobs via API calls, I stumbled into a Fastlane error related to a missing mandatory function in `circleci_trigger_job_action`. 

The error was not raised during the first integration with WPiOS and everything seems to be still working on that repository. 

Anyway, there's no harm with adding it :-) 