### PR TITLE
Fix tag deletion logic

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -6,9 +6,6 @@ module Fastlane
 
         require_relative '../../helper/git_helper.rb'
 
-        # Delete the current version's tag (if it exists)
-        Fastlane::Helper::GitHelper.delete_tags(params[:version])
-
         # Delete 4-parts version names starting with our version number
         parts = params[:version].split('.')
         pattern = parts.fill('*', parts.length...4).join('.') # "1.2.*.*" or "1.2.3.*"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -5,18 +5,20 @@ module Fastlane
         UI.message("Deleting tags for version: #{params[:version]}")
 
         require_relative '../../helper/git_helper.rb'
-        Fastlane::Helper::Ios::GitHelper.delete_tags(params[:version])
 
-        # Cleanup local tags and refetch them to make sure we're up-to-date with remote
-        local_tags = Fastlane::Helper::GitHelper.list_local_tags()
-        Fastlane::Helper::GitHelper.delete_tags(local_tags, delete_on_remote: true)
-        Fastlane::Helper::GitHelper.fetch_all_tags()
+        # Delete the current version's tag (if it exists)
+        Fastlane::Helper::GitHelper.delete_tags(params[:version])
 
-        # Now delete intermediate tags (4-parts version names starting with our version number)
+        # Delete 4-parts version names starting with our version number
         parts = params[:version].split('.')
         pattern = parts.fill('*', parts.length...4).join('.') # "1.2.*.*" or "1.2.3.*"
+
         intermediate_tags = Fastlane::Helper::GitHelper.list_local_tags(matching: pattern)
-        Fastlane::Helper::GitHelper.delete_tags(intermediate_tags, delete_on_remote: true)
+        tag_count = intermediate_tags.count
+
+        if tag_count > 0 && UI.confirm("Are you sure you want to delete #{tag_count} tags?")
+          Fastlane::Helper::GitHelper.delete_tags(intermediate_tags, delete_on_remote: true)
+        end
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -6,9 +6,6 @@ module Fastlane
 
         require_relative '../../helper/git_helper.rb'
 
-        # Download all the remote tags prior to starting – that way we don't miss any on the server
-        Fastlane::Helper::GitHelper::fetch_all_tags
-
         # Delete 4-parts version names starting with our version number
         parts = params[:version].split('.')
         pattern = parts.fill('*', parts.length...4).join('.') # "1.2.*.*" or "1.2.3.*"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -6,6 +6,9 @@ module Fastlane
 
         require_relative '../../helper/git_helper.rb'
 
+        # Download all the remote tags prior to starting – that way we don't miss any on the server
+        Fastlane::Helper::GitHelper::fetch_all_tags
+
         # Delete 4-parts version names starting with our version number
         parts = params[:version].split('.')
         pattern = parts.fill('*', parts.length...4).join('.') # "1.2.*.*" or "1.2.3.*"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -123,22 +123,14 @@ module Fastlane
       # @param [Array<String>] tag_names The list of tags to delete
       # @param [Bool] delete_on_remote If true, will also delete the tag from the remote. Otherwise, it will only be deleted locally.
       #
-      def self.delete_tags(tag_names, delete_on_remote: false)
-
-        tag_names = [tag_names] unless tag_names.is_a? Array
+      def self.delete_tags(tags_to_delete, delete_on_remote: false)
 
         g = Git.open(Dir.pwd)
-        local_tag_names = g.tags.map do |tag|
-          tag.name
-        end
+        local_tag_names = g.tags.map(&:name)
 
-        tag_names.each do |tag|
-          Action.sh('git', 'tag', '-d', *tag) if local_tag_names.include? tag
-        end
-
-        if delete_on_remote
-          remote_refs = tag_names.map { |tag| ":refs/tags/#{tag}" }
-          Action.sh('git', 'push', 'origin', *remote_refs)
+        Array(tags_to_delete).select { |tag| local_tag_names.include? tag }.each do |tag|
+          g.delete_tag(tag)
+          g.push('origin', ":refs/tags/#{tag}") if delete_on_remote 
         end
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -131,8 +131,8 @@ module Fastlane
         g = Git.open(Dir.pwd)
         local_tag_names = g.tags.map(&:name)
 
-        Array(tags_to_delete).select { |tag| local_tag_names.include? tag }.each do |tag|
-          g.delete_tag(tag)
+        Array(tags_to_delete).each do |tag|
+          g.delete_tag(tag) if local_tag_names.include?(tag)
           g.push('origin', ":refs/tags/#{tag}") if delete_on_remote 
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -124,7 +124,6 @@ module Fastlane
       # @param [Bool] delete_on_remote If true, will also delete the tag from the remote. Otherwise, it will only be deleted locally.
       #
       def self.delete_tags(tags_to_delete, delete_on_remote: false)
-
         g = Git.open(Dir.pwd)
         local_tag_names = g.tags.map(&:name)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -124,7 +124,18 @@ module Fastlane
       # @param [Bool] delete_on_remote If true, will also delete the tag from the remote. Otherwise, it will only be deleted locally.
       #
       def self.delete_tags(tag_names, delete_on_remote: false)
-        Action.sh('git', 'tag', '-d', *tag_names)
+
+        tag_names = [tag_names] unless tag_names.is_a? Array
+
+        g = Git.open(Dir.pwd)
+        local_tag_names = g.tags.map do |tag|
+          tag.name
+        end
+
+        tag_names.each do |tag|
+          Action.sh('git', 'tag', '-d', *tag) if local_tag_names.include? tag
+        end
+
         if delete_on_remote
           remote_refs = tag_names.map { |tag| ":refs/tags/#{tag}" }
           Action.sh('git', 'push', 'origin', *remote_refs)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -124,6 +124,10 @@ module Fastlane
       # @param [Bool] delete_on_remote If true, will also delete the tag from the remote. Otherwise, it will only be deleted locally.
       #
       def self.delete_tags(tags_to_delete, delete_on_remote: false)
+        # Download all the remote tags prior to starting – that way we don't miss any on the server
+        fetch_all_tags
+
+        # Then start deleting tags
         g = Git.open(Dir.pwd)
         local_tag_names = g.tags.map(&:name)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -124,10 +124,6 @@ module Fastlane
       # @param [Bool] delete_on_remote If true, will also delete the tag from the remote. Otherwise, it will only be deleted locally.
       #
       def self.delete_tags(tags_to_delete, delete_on_remote: false)
-        # Download all the remote tags prior to starting – that way we don't miss any on the server
-        fetch_all_tags
-
-        # Then start deleting tags
         g = Git.open(Dir.pwd)
         local_tag_names = g.tags.map(&:name)
 


### PR DESCRIPTION
This PR reworks the tag deletion logic to rework the approach:

1. Nothing is deleted without confirmation
2. Previously, the logic was to delete all local tags and re-download them – this approach isn't compatible with confirmation, so it needs to go – we can handle it later on in the process anyway.
3. There's some logic to better handle string/array input

It should be fairly clear how this works, but if you want to test it in the context of a project, you can run `bundle exec fastlane run ios_clear_intermediate_tags` in a project with your release toolkit dependency pointing at this branch (or create some tags on your local copy of the release toolkit to test with).