### PR TITLE
Lookup PRs using the GitHub search API

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -6,34 +6,19 @@ module Fastlane
     class GetPrsListAction < Action
       def self.run(params)
         repository = params[:repository]
-        start_tag = params[:start_tag]
-        end_tag = params[:end_tag]
-        report_path = params[:report_path]
+        report_path = File.expand_path(params[:report_path])
+        tag = params[:tag]
 
         # Get commit list
-        commit_list = sh("git log --pretty=oneline #{start_tag}..#{end_tag}")
+        pr_list = Fastlane::Helper::GithubHelper.get_prs_for_milestone(repository, tag)
 
-        # Extract PRs
-        pr_list = []
-        commit_list.split("\n").each do |commit|
-          if commit.include?('Merge pull request #')
-            # PR found, so extract PR number
-            pr_list.push(commit.partition('#').last.split(' ')[0])
-          end
-        end
-
-        # Get infos from GitHub and put into the target file
-        client = Fastlane::Helper::GithubHelper.github_client()
         File.open(report_path, 'w') do |file|
-          pr_list.each do |pr_number|
-            begin
-              data = client.pull_request(repository, pr_number.to_i)
-              file.puts("##{data[:number]}: #{data[:title]} @#{data[:user][:login]} #{data[:html_url]}")
-            rescue
-              UI.message("Could not find a PR with number #{pr_number.to_i}. Usually this is due to a bad reference in a commit message, but you probably want to check.")
-            end
+          pr_list.each do |data|
+            file.puts("##{data[:number]}: #{data[:title]} @#{data[:user][:login]} #{data[:html_url]}")
           end
         end
+
+        UI.success("Found #{pr_list.count} PRs in #{tag} – saved to #{report_path}")
       end
 
       def self.description
@@ -60,18 +45,14 @@ module Fastlane
                                        description: 'The remote path of the GH repository on which we work',
                                        optional: false,
                                        type: String),
-          FastlaneCore::ConfigItem.new(key: :start_tag,
-                                       description: 'The tag from which the report starts',
-                                       optional: false,
-                                       is_string: true),
-          FastlaneCore::ConfigItem.new(key: :end_tag,
-                                       description: 'The tag to which the report ends',
-                                       optional: true,
-                                       default_value: '.',
-                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :report_path,
                                        env_name: 'GHHELPER_REPORTPATH',
                                        description: 'The path of the report file',
+                                       optional: false,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :tag,
+                                       env_name: 'GHHELPER_CURRENT_VERSION',
+                                       description: 'The version number to fetch PRs for',
                                        optional: false,
                                        is_string: true),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -7,10 +7,10 @@ module Fastlane
       def self.run(params)
         repository = params[:repository]
         report_path = File.expand_path(params[:report_path])
-        tag = params[:tag]
+        milestone = params[:milestone]
 
         # Get commit list
-        pr_list = Fastlane::Helper::GithubHelper.get_prs_for_milestone(repository, tag)
+        pr_list = Fastlane::Helper::GithubHelper.get_prs_for_milestone(repository, milestone)
 
         File.open(report_path, 'w') do |file|
           pr_list.each do |data|
@@ -18,11 +18,11 @@ module Fastlane
           end
         end
 
-        UI.success("Found #{pr_list.count} PRs in #{tag} – saved to #{report_path}")
+        UI.success("Found #{pr_list.count} PRs in #{milestone} – saved to #{report_path}")
       end
 
       def self.description
-        'Generate the list of the PRs from `start_tag` to `end_tag`'
+        'Generate the list of the PRs in the given `repository` for the given `milestone` at the given `report_path'
       end
 
       def self.authors
@@ -35,23 +35,22 @@ module Fastlane
 
       def self.details
         # Optional:
-        'Generate the list of the PRs from `start_tag` to `end_tag`'
+        'Generate the list of the PRs in the given `repository` for the given `milestone` at the given `report_path'
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :repository,
                                        env_name: 'GHHELPER_REPOSITORY',
-                                       description: 'The remote path of the GH repository on which we work',
+                                       description: 'The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)',
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :report_path,
-                                       env_name: 'GHHELPER_REPORTPATH',
-                                       description: 'The path of the report file',
+                                       description: 'The path that the list of PRs should be written to',
                                        optional: false,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :milestone,
-                                       description: 'The milestone to fetch PRs for',
+                                       description: 'The name of the milestone we want to fetch the list of PRs for (e.g.: `16.9`)',
                                        optional: false,
                                        is_string: true),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -22,7 +22,7 @@ module Fastlane
       end
 
       def self.description
-        'Generate the list of the PRs in the given `repository` for the given `milestone` at the given `report_path'
+        'Generate the list of the PRs in the given `repository` for the given `milestone` at the given `report_path`'
       end
 
       def self.authors
@@ -35,7 +35,7 @@ module Fastlane
 
       def self.details
         # Optional:
-        'Generate the list of the PRs in the given `repository` for the given `milestone` at the given `report_path'
+        description
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -46,7 +46,7 @@ module Fastlane
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :report_path,
-                                       description: 'The path that the list of PRs should be written to',
+                                       description: 'The path where the list of PRs should be written to',
                                        optional: false,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :milestone,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -50,9 +50,8 @@ module Fastlane
                                        description: 'The path of the report file',
                                        optional: false,
                                        is_string: true),
-          FastlaneCore::ConfigItem.new(key: :tag,
-                                       env_name: 'GHHELPER_CURRENT_VERSION',
-                                       description: 'The version number to fetch PRs for',
+          FastlaneCore::ConfigItem.new(key: :milestone,
+                                       description: 'The milestone to fetch PRs for',
                                        optional: false,
                                        is_string: true),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -14,6 +14,9 @@ module Fastlane
         user = client.user
         UI.message("Logged in as: #{user.name}")
 
+        # Auto-paginate to ensure we're not missing data
+        client.auto_paginate = true
+
         client
       end
 
@@ -26,6 +29,16 @@ module Fastlane
         end
 
         return mile
+      end
+
+      # Downloads a file from the given GitHub tag
+      #
+      # @param String repository The repository name (including the organization) [ex: wordpress-mobile/wordpress-ios]
+      # @param String tag The name of the tag we're downloading from [ex: 16.9]
+      # @return [<Sawyer::Resource>] A list of the PRs for the given milestone, sorted by number
+      #
+      def self.get_prs_for_milestone(repository, release)
+        github_client().search_issues("type:pr milestone:16.9 repo:wordpress-mobile/wordpress-ios")[:items].sort_by(&:number)
       end
 
       def self.get_last_milestone(repository)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -33,8 +33,8 @@ module Fastlane
 
       # Fetch all the PRs for a given milestone
       #
-      # @param String repository The repository name (including the organization) [ex: wordpress-mobile/wordpress-ios]
-      # @param String milestone The name of the tag we're downloading from [ex: 16.9]
+      # @param [String] repository The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)
+      # @param [String] milestone The name of the milestone we want to fetch the list of PRs for (e.g.: `16.9`)
       # @return [<Sawyer::Resource>] A list of the PRs for the given milestone, sorted by number
       #
       def self.get_prs_for_milestone(repository, milestone)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -38,7 +38,7 @@ module Fastlane
       # @return [<Sawyer::Resource>] A list of the PRs for the given milestone, sorted by number
       #
       def self.get_prs_for_milestone(repository, milestone)
-        github_client().search_issues("type:pr milestone:#{milestone} repo:#{repository}")[:items].sort_by(&:number)
+        github_client.search_issues(%(type:pr milestone:"#{milestone}" repo:#{repository}))[:items].sort_by(&:number)
       end
 
       def self.get_last_milestone(repository)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -31,14 +31,14 @@ module Fastlane
         return mile
       end
 
-      # Downloads a file from the given GitHub tag
+      # Fetch all the PRs for a given milestone
       #
       # @param String repository The repository name (including the organization) [ex: wordpress-mobile/wordpress-ios]
-      # @param String tag The name of the tag we're downloading from [ex: 16.9]
+      # @param String milestone The name of the tag we're downloading from [ex: 16.9]
       # @return [<Sawyer::Resource>] A list of the PRs for the given milestone, sorted by number
       #
-      def self.get_prs_for_milestone(repository, release)
-        github_client().search_issues("type:pr milestone:16.9 repo:wordpress-mobile/wordpress-ios")[:items].sort_by(&:number)
+      def self.get_prs_for_milestone(repository, milestone)
+        github_client().search_issues("type:pr milestone:#{milestone} repo:#{repository}")[:items].sort_by(&:number)
       end
 
       def self.get_last_milestone(repository)


### PR DESCRIPTION
Now that our PRs are consistently tagged with a milestone, we can fetch the PR list based on that, rather than by parsing commits.

This PR updates the release toolkit to use this method. The changes are backward-incompatible, but won't silently fail.

**To Test:**
- Download this PR and run `bundle exec fastlane run get_prs_list repository:wordpress-mobile/wordpress-ios report_path:~/test.txt tag:16.9`. Note that all of the PR data is downloaded in the same format. [note: you'll need `GHHELPER_ACCESS` set as an environment variable with your GitHub token]
- Compare the results of the command above with a pre-existing file on your local machine. The ordering might be different, but the format should be identical (you can see this in the code as well – the line to generate the file is unchanged).