### PR TITLE
Update regex used to find library version in gradle path

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -305,7 +305,7 @@ module Fastlane
 
           File.open(gradle_file_path, 'r') do | f |
             text = f.read
-            text.match(/^(?:\w*\.)?#{Regexp.escape(import_key)}\s*=\s*['"](.*?)["']/m)&.captures&.first
+            text.match(/^(\s*)(?:\w*\.)?#{Regexp.escape(import_key)}\s*=\s*['"](.*?)["']/m)&.captures&.last
           end
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -305,7 +305,7 @@ module Fastlane
 
           File.open(gradle_file_path, 'r') do | f |
             text = f.read
-            text.match(/^(\s*)(?:\w*\.)?#{Regexp.escape(import_key)}\s*=\s*['"](.*?)["']/m)&.captures&.last
+            text.match(/^\s*(?:\w*\.)?#{Regexp.escape(import_key)}\s*=\s*['"](.*?)["']/m)&.captures&.first
           end
         end
 

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -54,6 +54,17 @@ describe Fastlane::Helper::Android::VersionHelper do
       allow(File).to receive(:open).with('./build.gradle', 'r').and_yield(StringIO.new(test_file_content))
       expect(subject.get_library_version_from_gradle_config(import_key: 'my-test-key')).to eq('my_test_value')
       expect(subject.get_library_version_from_gradle_config(import_key: 'my_test_key_double')).to be_nil
+
+      # Make sure it works with spaces starting the line
+      test_file_content = <<~CONTENT
+        my-test-key-foo = 'foo'
+        my-test-key-bad = "extbad"
+              ext.my-test-key = 'my_test_value'
+      CONTENT
+
+      allow(File).to receive(:exists?).and_return(true)
+      allow(File).to receive(:open).with('./build.gradle', 'r').and_yield(StringIO.new(test_file_content))
+      expect(subject.get_library_version_from_gradle_config(import_key: 'my-test-key')).to eq('my_test_value')
     end
   end
 end


### PR DESCRIPTION
After digging into it an issue with the gutenberg-mobile it seems since the line with the gutenberg mobile version begins with spaces, the current regex won't match that to find the version, this is a proposed change to fix that. 