### PR TITLE
Remove import of unused Codecov CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   ios: wordpress-mobile/ios@1.0
-  codecov: codecov/codecov@1.0.2
 
 jobs:
   test:


### PR DESCRIPTION
I've been auditing our Codecov usages after their [Bash Uploader
incident](https://about.codecov.io/security-update/).

I noticed we import the Codecov CircleCI orb, but we don't use it
because `rspec` takes care of uploading the results.

```yaml
 # Coverage reports are sent to Codecov as part of running `rspec`, not as a CircleCI step.
 # We may wish to change this for consistency.
```

This PR removes the unused orb.

For what is worth, I think it's best to not use CI for this an rely on
the repo-specific automation: it makes the whole setup less CI dependant
and easier to port to a new vendor.