### PR TITLE
Update logic to compute the iOS localization paths to return full path

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -70,9 +70,9 @@ module Fastlane
         end
 
         def self.get_from_env!(key:)
-          value = ENV[key]
-          UI.user_error! "Could not find value for \"#{key}\" in environment." if value.nil?
-          return value
+          ENV.fetch(key) do
+            UI.user_error! "Could not find value for \"#{key}\" in environment."
+          end
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -61,14 +61,14 @@ module Fastlane
 
           Fastlane::Helper::GitHelper.commit(message: 'Update metadata translations', files: './fastlane/metadata/', push: true)
         end
-      end
-    end
 
-    private
-
-    def self.strings_files
-      Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do
-        Dir.glob('*.lproj/*.strings')
+        def self.strings_files
+          Dir.glob(
+            File.join(
+              ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], '*.lproj', '*.strings'
+            )
+          )
+        end
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -39,7 +39,7 @@ module Fastlane
         #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
         #
         def self.localize_project
-          Action.sh("cd #{ENV['PROJECT_ROOT_FOLDER']} && ./Scripts/localize.py")
+          Action.sh("cd #{get_from_env!(key: 'PROJECT_ROOT_FOLDER')} && ./Scripts/localize.py")
 
           Fastlane::Helper::GitHelper.commit(message: 'Update strings for localization', files: strings_files, push: true) || UI.message('No new strings, skipping commit')
         end
@@ -53,7 +53,7 @@ module Fastlane
         #       in the release-toolkit instead, and move this code away from `ios_git_helper`.
         #
         def self.update_metadata
-          Action.sh("cd #{ENV['PROJECT_ROOT_FOLDER']} && ./Scripts/update-translations.rb")
+          Action.sh("cd #{get_from_env!(key: 'PROJECT_ROOT_FOLDER')} && ./Scripts/update-translations.rb")
 
           Fastlane::Helper::GitHelper.commit(message: 'Update translations', files: strings_files, push: false)
 
@@ -63,11 +63,16 @@ module Fastlane
         end
 
         def self.strings_files
-          Dir.glob(
-            File.join(
-              ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], '**', '*.strings'
-            )
-          )
+          project_root = get_from_env!(key: 'PROJECT_ROOT_FOLDER')
+          project_name = get_from_env!(key: 'PROJECT_NAME')
+
+          Dir.glob(File.join(project_root, project_name, '**', '*.strings'))
+        end
+
+        def self.get_from_env!(key:)
+          value = ENV[key]
+          UI.user_error! "Could not find value for \"#{key}\" in environment." if value.nil?
+          return value
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -41,9 +41,6 @@ module Fastlane
         def self.localize_project
           Action.sh("cd #{ENV['PROJECT_ROOT_FOLDER']} && ./Scripts/localize.py")
 
-          strings_files = Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do
-            Dir.glob('*.lproj/*.strings')
-          end
           Fastlane::Helper::GitHelper.commit(message: 'Update strings for localization', files: strings_files, push: true) || UI.message('No new strings, skipping commit')
         end
 
@@ -58,15 +55,20 @@ module Fastlane
         def self.update_metadata
           Action.sh("cd #{ENV['PROJECT_ROOT_FOLDER']} && ./Scripts/update-translations.rb")
 
-          strings_files = Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do
-            Dir.glob('*.lproj/*.strings')
-          end
           Fastlane::Helper::GitHelper.commit(message: 'Update translations', files: strings_files, push: false)
 
           Action.sh('cd fastlane && ./download_metadata.swift')
 
           Fastlane::Helper::GitHelper.commit(message: 'Update metadata translations', files: './fastlane/metadata/', push: true)
         end
+      end
+    end
+
+    private
+
+    def self.strings_files
+      Dir.chdir(File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'])) do
+        Dir.glob('*.lproj/*.strings')
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -65,7 +65,7 @@ module Fastlane
         def self.strings_files
           Dir.glob(
             File.join(
-              ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], '*.lproj', '*.strings'
+              ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], '**', '*.strings'
             )
           )
         end

--- a/spec/ios_git_helper_spec.rb
+++ b/spec/ios_git_helper_spec.rb
@@ -1,0 +1,21 @@
+require_relative './spec_helper'
+
+describe Fastlane::Helper::Ios::GitHelper do
+  describe '#get_from_env!' do
+    let(:key) { 'a_key' }
+
+    it 'shows an error when the value is not in the environment' do
+      ENV[key] = nil
+
+      expect(FastlaneCore::UI).to receive(:user_error!)
+      described_class.get_from_env!(key: key)
+    end
+
+    it 'returns the value when in the environment' do
+      ENV[key] = 'abc123'
+
+      expect(FastlaneCore::UI).not_to receive(:user_error!)
+      expect(described_class.get_from_env!(key: key)).to eq('abc123')
+    end
+  end
+end


### PR DESCRIPTION
While running the code freeze for Simplenote 4.35, the lane failed on me with the following error:

```
	 7: from /Users/gio/Developer/a8c/snios/vendor/bundle/ruby/2.6.0/gems/fastlane-2.180.1/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
	 6: from /Users/gio/Developer/a8c/snios/vendor/bundle/ruby/2.6.0/bundler/gems/release-toolkit-413bdfd2a22e/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb:9:in `run'
	 5: from /Users/gio/Developer/a8c/snios/vendor/bundle/ruby/2.6.0/bundler/gems/release-toolkit-413bdfd2a22e/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb:47:in `localize_project'
	 4: from /Users/gio/Developer/a8c/snios/vendor/bundle/ruby/2.6.0/bundler/gems/release-toolkit-413bdfd2a22e/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb:81:in `commit'
	 3: from /Users/gio/.rbenv/versions/2.6.4/lib/ruby/2.6.0/forwardable.rb:230:in `sh'
	 2: from /Users/gio/Developer/a8c/snios/vendor/bundle/ruby/2.6.0/gems/fastlane-2.180.1/fastlane/lib/fastlane/helper/sh_helper.rb:80:in `sh_control_output'
	 1: from /Users/gio/Developer/a8c/snios/vendor/bundle/ruby/2.6.0/gems/fastlane-2.180.1/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
/Users/gio/Developer/a8c/snios/vendor/bundle/ruby/2.6.0/gems/fastlane-2.180.1/fastlane_core/lib/fastlane_core/ui/interface.rb:153:in `shell_error!': [!] Exit status of command 'git add de.lproj/Localizable.strings he.lproj/Localizable.strings zh-Hant-TW.lproj/Localizable.strings ar.lproj/Localizable.strings el.lproj/Localizable.strings ja.lproj/Localizable.strings fa.lproj/Localizable.strings en.lproj/Localizable.strings en.lproj/InfoPlist.strings es.lproj/Localizable.strings it.lproj/Localizable.strings sv.lproj/Localizable.strings ko.lproj/Localizable.strings tr.lproj/Localizable.strings pt-BR.lproj/Localizable.strings ru.lproj/Localizable.strings cy.lproj/Localizable.strings fr.lproj/Localizable.strings id.lproj/Localizable.strings nl.lproj/Localizable.strings zh-Hans-CN.lproj/Localizable.strings' was 128 instead of 0. (FastlaneCore::Interface::FastlaneShellError)
fatal: pathspec 'de.lproj/Localizable.strings' did not match any files
```

Because we ran the glob in the localization folder, the strings path was relative to that folder, but we need it relative to the project root.

I used this branch to finish the code freeze and it worked. See [this commit](https://github.com/Automattic/simplenote-ios/pull/1251/commits/0c38c496671f05ab54fe782ff0c49e9bf0fac8da).