### PR TITLE
Fix error in update appstore strings lanes

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -15,7 +15,8 @@ module Fastlane
         # Do
         check_source_files(params[:source_files])
         temp_po_name = create_temp_po(params)
-        swap_po(params[:po_file_path], temp_po_name)
+        UI.message "Temp #{temp_po_name} updated!"
+        # swap_po(params[:po_file_path], temp_po_name)
 
         UI.message "File #{params[:po_file_path]} updated!"
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -15,8 +15,7 @@ module Fastlane
         # Do
         check_source_files(params[:source_files])
         temp_po_name = create_temp_po(params)
-        UI.message "Temp #{temp_po_name} updated!"
-        # swap_po(params[:po_file_path], temp_po_name)
+        swap_po(params[:po_file_path], temp_po_name)
 
         UI.message "File #{params[:po_file_path]} updated!"
       end
@@ -42,7 +41,7 @@ module Fastlane
 
         # Create the new one
         begin
-          File.open(target, 'w') do |fw|
+          File.open(target, 'a') do |fw|
             File.open(orig, 'r').each do |fr|
               write_target_block(fw, fr)
             end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -41,7 +41,7 @@ module Fastlane
 
         # Create the new one
         begin
-          File.open(target, 'a') do |fw|
+          File.open(target, 'w') do |fw|
             File.open(orig, 'r').each do |fr|
               write_target_block(fw, fr)
             end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -127,7 +127,7 @@ module Fastlane
       end
 
       def is_int?(value)
-        true if Integer(string) rescue false
+        true if Integer(value) rescue false
       end
     end
 


### PR DESCRIPTION
This PR just fixes the incorrect variable name that was causing the updates to the appstore strings to fail but I think we'll be deprecating this entire path in https://github.com/wordpress-mobile/release-toolkit/pull/229 but I think it still makes sense to have this fix in