### PR TITLE
Add Git helper method to check if a path results ignored

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -225,6 +225,10 @@ module Fastlane
 
         UI.user_error!('You must pass a `destination` to `add_file`') unless params[:destination]
 
+        unless Fastlane::Helper::GitHelper.is_ignored?(path: params[:destination])
+          UI.user_error! "Attempted to add a file to a location which is not ignored under Git (#{params[:destination]})"
+        end
+
         new_config = self.configuration
         new_config.add_file_to_copy(params[:source], params[:destination], params[:encrypt])
         update_configuration(new_config)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -226,7 +226,7 @@ module Fastlane
         UI.user_error!('You must pass a `destination` to `add_file`') unless params[:destination]
 
         unless Fastlane::Helper::GitHelper.is_ignored?(path: params[:destination])
-          UI.user_error! "Attempted to add a file to a location which is not ignored under Git (#{params[:destination]})"
+          UI.user_error! "Attempted to add a file to a location which is not ignored under Git (#{params[:destination]}). Please edit your `.gitignore` manually to fix this."
         end
 
         new_config = self.configuration

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -226,7 +226,7 @@ module Fastlane
         UI.user_error!('You must pass a `destination` to `add_file`') unless params[:destination]
 
         unless Fastlane::Helper::GitHelper.is_ignored?(path: params[:destination])
-          UI.user_error! "Attempted to add a file to a location which is not ignored under Git (#{params[:destination]}). Please edit your `.gitignore` manually to fix this."
+          UI.user_error! "Attempted to add a file to a location which is not ignored under Git (#{params[:destination]}). Please either edit your `.configure` file to use an already-ignored destination, or add that destination to the `.gitignore` manually to fix this."
         end
 
         new_config = self.configuration

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -165,6 +165,23 @@ module Fastlane
         current_branch_name = Action.sh('git', 'symbolic-ref', '-q', 'HEAD')
         UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
       end
+
+      # Checks whether a given path is ignored by Git, relying on Git's
+      # `check-ignore` under the hood.
+      #
+      # @param [String] path The path to check against the the `.gitignore`
+      #
+      # @return [Bool] True if the given path is ignored, false otherwise.
+      def self.is_ignored(path:)
+        begin
+          Action.sh('git', 'check-ignore', path)
+        rescue
+          # if there was an error, either the given path doesn't result as
+          # ignored or the command was called outside of a Git repo (as per the
+          # manpage). In both cases, we want to fail
+          false
+        end
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -175,6 +175,7 @@ module Fastlane
       def self.is_ignored?(path:)
         begin
           Action.sh('git', 'check-ignore', path)
+          return true
         rescue
           # if there was an error, either the given path doesn't result as
           # ignored or the command was called outside of a Git repo (as per the

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -173,15 +173,8 @@ module Fastlane
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
       def self.is_ignored?(path:)
-        begin
-          Action.sh('git', 'check-ignore', path)
-          return true
-        rescue
-          # if there was an error, either the given path doesn't result as
-          # ignored or the command was called outside of a Git repo (as per the
-          # manpage). In both cases, we want to fail
-          false
-        end
+        system("git check-ignore #{path}")
+        $CHILD_STATUS.exitstatus == 0
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -173,8 +173,7 @@ module Fastlane
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
       def self.is_ignored?(path:)
-        system("git check-ignore #{path}")
-        $CHILD_STATUS.exitstatus == 0
+        Actions.sh('git', 'check-ignore', path) { |status, _, _| status.success? }
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -172,7 +172,7 @@ module Fastlane
       # @param [String] path The path to check against the the `.gitignore`
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
-      def self.is_ignored(path:)
+      def self.is_ignored?(path:)
         begin
           Action.sh('git', 'check-ignore', path)
         rescue

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -169,7 +169,7 @@ module Fastlane
       # Checks whether a given path is ignored by Git, relying on Git's
       # `check-ignore` under the hood.
       #
-      # @param [String] path The path to check against the the `.gitignore`
+      # @param [String] path The path to check against `.gitignore`
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
       def self.is_ignored?(path:)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -51,7 +51,7 @@ module Fastlane
       def apply
         # Only decrypt the file if the destination is ignored in Git
         unless Fastlane::Helper::GitHelper.is_ignored?(path: destination_file_path)
-          raise StandardError.new "Attempted to decrypt #{file} to #{destination_file_path} which is not ignored under Git"
+          raise "Attempted to decrypt #{file} to #{destination_file_path} which is not ignored under Git"
         end
 
         # Create the destination directory if it doesn't exist

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -42,7 +42,18 @@ module Fastlane
         File.write(encrypted_file_path, encrypted)
       end
 
+      # "Applies" the instruction described in the instance to the file system.
+      # That is, copies the content of the source `file` to the `destination`
+      # path.
+      #
+      # @raise [StandardError] For security reasons, it will raise if
+      # `destination` is not ignored under Git.
       def apply
+        # Only decrypt the file if the destination is ignored in Git
+        unless Fastlane::Helper::GitHelper.is_ignored?(path: destination_file_path)
+          raise StandardError.new "Attempted to decrypt #{file} to #{destination_file_path} which is not ignored under Git"
+        end
+
         # Create the destination directory if it doesn't exist
         FileUtils.mkdir_p(Pathname.new(destination_file_path).dirname)
         # Copy/decrypt the file

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -51,7 +51,7 @@ module Fastlane
       def apply
         # Only decrypt the file if the destination is ignored in Git
         unless Fastlane::Helper::GitHelper.is_ignored?(path: destination_file_path)
-          raise "Attempted to decrypt #{file} to #{destination_file_path} which is not ignored under Git"
+          raise "Attempted to decrypt #{file} to #{destination_file_path} which is not ignored under Git. Please either edit your `.configure` file to use an already-ignored destination, or add that destination to the `.gitignore` manually to fix this."
         end
 
         # Create the destination directory if it doesn't exist

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper.rb'
+
+describe Fastlane::Helper::ConfigureHelper do
+
+  describe '#add_file' do
+    let(:destination) { 'path/to/destination' }
+
+    it 'shows the user an error when the destination is not ignored in Git' do
+      allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
+        .with(path: destination)
+        .and_return(false)
+
+      expect(Fastlane::UI).to receive(:user_error!)
+
+      described_class.add_file({ source: 'path/to/source', destination: destination, encrypt: true })
+    end
+  end
+end

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -35,9 +35,9 @@ RSpec.shared_examples 'shared examples' do
           .with(path: subject.destination_file_path)
           .and_return(false)
 
-        expect(FileUtils).to_not receive(:mkdir_p)
-        expect(subject).to_not receive(:source_contents)
-        expect(File).to_not receive(:write)
+        expect(FileUtils).not_to receive(:mkdir_p)
+        expect(subject).not_to receive(:source_contents)
+        expect(File).not_to receive(:write)
         expect { subject.apply }.to raise_error(RuntimeError)
       end
     end

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -38,7 +38,7 @@ RSpec.shared_examples 'shared examples' do
         expect(FileUtils).to_not receive(:mkdir_p)
         expect(subject).to_not receive(:source_contents)
         expect(File).to_not receive(:write)
-        expect { subject.apply }.to raise_error(StandardError)
+        expect { subject.apply }.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -30,11 +30,13 @@ RSpec.shared_examples 'shared examples' do
 
   describe '#apply' do
     context 'when the destination is not ignored in Git' do
-      it 'raises' do
+      before do
         allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
           .with(path: subject.destination_file_path)
           .and_return(false)
+      end
 
+      it 'raises' do
         expect(FileUtils).not_to receive(:mkdir_p)
         expect(subject).not_to receive(:source_contents)
         expect(File).not_to receive(:write)
@@ -43,11 +45,13 @@ RSpec.shared_examples 'shared examples' do
     end
 
     context 'when the destination is ignored in Git' do
-      it 'copies the source to the destination' do
+      before do
         allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
           .with(path: subject.destination_file_path)
           .and_return(true)
+      end
 
+      it 'copies the source to the destination' do
         allow(FileUtils).to receive(:mkdir_p)
         allow(subject).to receive(:source_contents).and_return('source contents')
         expect(File).to receive(:write).with(subject.destination_file_path, 'source contents')

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -29,11 +29,30 @@ RSpec.shared_examples 'shared examples' do
   end
 
   describe '#apply' do
-    it 'copies the source to the destination' do
-      allow(FileUtils).to receive(:mkdir_p)
-      allow(subject).to receive(:source_contents).and_return('source contents')
-      expect(File).to receive(:write).with(subject.destination_file_path, 'source contents')
-      subject.apply
+    context 'when the destination is not ignored in Git' do
+      it 'raises' do
+        allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
+          .with(path: subject.destination_file_path)
+          .and_return(false)
+
+        expect(FileUtils).to_not receive(:mkdir_p)
+        expect(subject).to_not receive(:source_contents)
+        expect(File).to_not receive(:write)
+        expect { subject.apply }.to raise_error(StandardError)
+      end
+    end
+
+    context 'when the destination is ignored in Git' do
+      it 'copies the source to the destination' do
+        allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
+          .with(path: subject.destination_file_path)
+          .and_return(true)
+
+        allow(FileUtils).to receive(:mkdir_p)
+        allow(subject).to receive(:source_contents).and_return('source contents')
+        expect(File).to receive(:write).with(subject.destination_file_path, 'source contents')
+        subject.apply
+      end
     end
   end
 end

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -30,13 +30,11 @@ RSpec.shared_examples 'shared examples' do
 
   describe '#apply' do
     context 'when the destination is not ignored in Git' do
-      before do
+      it 'raises' do
         allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
           .with(path: subject.destination_file_path)
           .and_return(false)
-      end
 
-      it 'raises' do
         expect(FileUtils).not_to receive(:mkdir_p)
         expect(subject).not_to receive(:source_contents)
         expect(File).not_to receive(:write)
@@ -45,13 +43,11 @@ RSpec.shared_examples 'shared examples' do
     end
 
     context 'when the destination is ignored in Git' do
-      before do
+      it 'copies the source to the destination' do
         allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
           .with(path: subject.destination_file_path)
           .and_return(true)
-      end
 
-      it 'copies the source to the destination' do
         allow(FileUtils).to receive(:mkdir_p)
         allow(subject).to receive(:source_contents).and_return('source contents')
         expect(File).to receive(:write).with(subject.destination_file_path, 'source contents')

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -93,7 +93,7 @@ describe Fastlane::Helper::GitHelper do
     it 'checks if a file path results ignored by Git using check-ignore' do
       path = 'path/to/file'
       expect_shell_command('git', 'check-ignore', path)
-      Fastlane::Helper::GitHelper.is_ignored(path: path)
+      Fastlane::Helper::GitHelper.is_ignored?(path: path)
     end
   end
 end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -97,7 +97,7 @@ describe Fastlane::Helper::GitHelper do
     it 'returns false when the path is not ignored' do
       setup_git_repo(
         dummy_file_path: path,
-        in_gitignore: false
+        add_file_to_gitignore: false
       )
       expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be false
     end
@@ -112,8 +112,8 @@ describe Fastlane::Helper::GitHelper do
         # and verified here. – Gio
         setup_git_repo(
           dummy_file_path: path,
-          in_gitignore: true,
-          gitignore_committed: false
+          add_file_to_gitignore: true,
+          commit_gitignore: false
         )
         expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be true
       end
@@ -121,8 +121,8 @@ describe Fastlane::Helper::GitHelper do
       it 'returns true when the .gitignore has no uncommitted changes' do
         setup_git_repo(
           dummy_file_path: path,
-          in_gitignore: true,
-          gitignore_committed: true
+          add_file_to_gitignore: true,
+          commit_gitignore: true
         )
         expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be true
       end
@@ -131,7 +131,7 @@ describe Fastlane::Helper::GitHelper do
   end
 end
 
-def setup_git_repo(dummy_file_path:, in_gitignore:, gitignore_committed: false)
+def setup_git_repo(dummy_file_path:, add_file_to_gitignore:, commit_gitignore: false)
   `git init`
   `touch .gitignore`
   `git add .gitignore && git commit -m 'Add .gitignore'`
@@ -139,8 +139,8 @@ def setup_git_repo(dummy_file_path:, in_gitignore:, gitignore_committed: false)
   `echo abc > #{dummy_file_path}`
 
   # no point in commiting the gitignore if the file shouldn't be in it
-  return unless in_gitignore
+  return unless add_file_to_gitignore
 
   `echo #{dummy_file_path} > .gitignore`
-  `git add .gitignore && git commit -m 'Update .gitignore'` if gitignore_committed
+  `git add .gitignore && git commit -m 'Update .gitignore'` if commit_gitignore
 end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -89,5 +89,11 @@ describe Fastlane::Helper::GitHelper do
       expect_shell_command('git', 'push', 'origin', 'HEAD').once
       Fastlane::Helper::GitHelper.commit(message: @message, push: true)
     end
+
+    it 'checks if a file path results ignored by Git using check-ignore' do
+      path = 'path/to/file'
+      expect_shell_command('git', 'check-ignore', path)
+      Fastlane::Helper::GitHelper.is_ignored(path: path)
+    end
   end
 end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -92,6 +92,10 @@ describe Fastlane::Helper::GitHelper do
   end
 
   describe '#is_ignored?' do
+    before do
+      allow(FastlaneCore::Helper).to receive(:sh_enabled?).and_return(true)
+    end
+
     let(:path) { 'dummy.txt' }
 
     it 'returns false when the path is not ignored' do


### PR DESCRIPTION
Adds a bit of security to the secrets management by preventing a user from decrypting a secret to a location that is not `.gitgnored`.

It covers the `configure_apply`, `_update`, and `_add_files_to_copy` actions.

I decided not to edit the `.gitignore` via the automation to leave the user the flexibility to change path or use a pattern in the `.gitignore`.

To test this implementation, you can checkout [this demo PR](https://github.com/Automattic/simplenote-ios/pull/1263) or do something along the lines of:

1. Get a repo on this version of the release toolkit
2. Update the `.configure` with a file to decrypt to a location that's not ignored
3. Run the `configure_apply` and `configure_update` actions to verify they show an error
4. Run the `configure_add_files_to_copy` and pass a destination path not ignored to verify it shows an error