### PR TITLE
Add Hound CI config file

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,9 @@
+rubocop:
+  # This should stay in line with the version resolved in the Gemfile.lock,
+  # which you can verify with `bundle info rubocop`.
+  #
+  # Notice that Hound supports only a subset of the RuboCop versions. You can
+  # find the list of supported versions here:
+  # http://help.houndci.com/en/articles/2461415-supported-linters
+  version: 0.75.0
+  config_file: .rubocop.yml


### PR DESCRIPTION
Configures Hound, as discussed [here](https://github.com/wordpress-mobile/release-toolkit/pull/242#discussion_r622018937).

Opened #244 to test the integration. Current status: **not working**.