### PR TITLE
Merge release 0.18.1 into develop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.18.0)
+    fastlane-plugin-wpmreleasetoolkit (0.18.1)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -190,7 +190,7 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -334,4 +334,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.10
+   2.2.11

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '0.18.0'
+    VERSION = '0.18.1'
   end
 end


### PR DESCRIPTION
Bundling a new release to fix the localization files issues in the iOS automation we've been experiencing recently. See #236.

I decided to do a patch bump instead of a minor version because this is just a bug fix of an existing feature, not a new functionality.

~~I'm not sure whether I should tag the tip of the `release/0.18.1` branch or the merge into `develop` as `0.18.1`. Normally, I'd tag the tip of the release branch.~~ Interesting. Neither of my guesses were correct. Looking at the recent tags, the commit that's tagged is the one with the merge into `trunk`. TIL.