### PR TITLE
Allow secret decryption to location outside Git repository

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -192,7 +192,7 @@ module Fastlane
         end
       end
 
-      OUTSIDE_OF_REPO_ERROR = 'is outside repository at'.freeze
+      OUTSIDE_OF_REPO_ERROR = 'is outside repository'.freeze
       NOT_A_REPO_ERROR = 'fatal: not a git repository (or any of the parent directories): .git'.freeze
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -23,11 +23,14 @@ module Fastlane
         return current_dir.root? == false
       end
 
-      # Travels back the hierarchy of the given path until it finds an existing ancestor, or it reaches the root of the file system.
+      # Travels back the hierarchy of the given path until it finds an existing
+      # ancestor, or it reaches the root of the file system.
       #
       # @param [String] path The path to inspect
       #
-      # @return [Pathname] The first existing ancestor, or `path` itself if it exists
+      # @return [Pathname] The first existing ancestor, or `path` itself if it
+      #         exists
+      #
       def self.first_existing_ancestor_of(path:)
         p = Pathname(path).expand_path
         p = p.parent until p.exist? || p.root?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -204,16 +204,12 @@ module Fastlane
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
       def self.is_ignored?(path:)
-        Actions.sh('git', 'check-ignore', path) do |status, output, _|
-          return true if output.strip == NOT_A_REPO_ERROR
-          return true if output.include? OUTSIDE_OF_REPO_ERROR
+        return true unless is_git_repo?(path: path)
 
+        Actions.sh('git', 'check-ignore', path) do |status, _, _|
           status.success?
         end
       end
-
-      OUTSIDE_OF_REPO_ERROR = 'is outside repository'.freeze
-      NOT_A_REPO_ERROR = 'fatal: not a git repository (or any of the parent directories): .git'.freeze
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -15,12 +15,19 @@ module Fastlane
       #         (i.e. a local working copy) or a subdirectory of one.
       #
       def self.is_git_repo?(path: Dir.pwd)
-        working_path = first_existing_ancestor_of(path: path)
-        current_dir = working_path.directory? ? working_path : working_path.dirname
+        # If the path doesn't exist, find its first ancestor.
+        path = first_existing_ancestor_of(path: path)
+        # Get the path's directory, so we can look in it for the Git folder
+        dir = path.directory? ? path : path.dirname
 
-        current_dir = current_dir.parent until Dir.entries(current_dir).include?('.git') || current_dir.root?
+        # Recursively look for the Git folder until it's found or we read the
+        # the file system root
+        dir = dir.parent until Dir.entries(dir).include?('.git') || dir.root?
 
-        return current_dir.root? == false
+        # If we reached the root, we haven't found a repo. (Technically, there
+        # could be a repo in the root of the system, but that's a usecase that
+        # we don't need to support at this time)
+        return dir.root? == false
       end
 
       # Travels back the hierarchy of the given path until it finds an existing

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -19,7 +19,7 @@ module Fastlane
         args += ['-C', File.file?(path) ? File.dirname(path) : path] unless path.nil?
         args += ['rev-parse']
 
-        Action.sh(args, print_command: true, print_command_output: true, error_callback: ->(e) { puts e }) do |status, _, _|
+        Action.sh(args, print_command_output: false) do |status, _, _|
           status.success?
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -10,7 +10,9 @@ module Fastlane
       # @return [Bool] True if the current directory is the root of a git repo (i.e. a local working copy) or a subdirectory of one.
       #
       def self.is_git_repo?
-        system 'git rev-parse --git-dir 1> /dev/null 2>/dev/null'
+        Action.sh('git', 'rev-parse', '--git-dir', print_command: false, print_command_output: false) do |status, _, _|
+          status.success?
+        end
       end
 
       # Check if the current directory has git-lfs enabled

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -202,7 +202,7 @@ module Fastlane
       #
       # @param [String] path The path to check against `.gitignore`
       #
-      # @return [Bool] True if the given path is ignored or outside the Git repository, false otherwise.
+      # @return [Bool] True if the given path is ignored or outside a Git repository, false otherwise.
       def self.is_ignored?(path:)
         return true unless is_git_repo?(path: path)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -173,8 +173,16 @@ module Fastlane
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
       def self.is_ignored?(path:)
-        Actions.sh('git', 'check-ignore', path) { |status, _, _| status.success? }
+        Actions.sh('git', 'check-ignore', path) do |status, output, _|
+          return true if output.strip == NOT_A_REPO_ERROR
+          return true if output.include? OUTSIDE_OF_REPO_ERROR
+
+          status.success?
+        end
       end
+
+      OUTSIDE_OF_REPO_ERROR = 'is outside repository at'.freeze
+      NOT_A_REPO_ERROR = 'fatal: not a git repository (or any of the parent directories): .git'.freeze
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -5,12 +5,21 @@ module Fastlane
     # Helper methods to execute git-related operations
     #
     module GitHelper
-      # Checks if the current directory is (inside) a git repo
+      # Checks if the given path, or current directory if no path is given, is
+      # inside a Git repository
       #
-      # @return [Bool] True if the current directory is the root of a git repo (i.e. a local working copy) or a subdirectory of one.
+      # @param [String] path An optional path where to check if a Git repo
+      #        exists.
       #
-      def self.is_git_repo?
-        Action.sh('git', 'rev-parse', '--git-dir', print_command: false, print_command_output: false) do |status, _, _|
+      # @return [Bool] True if the current directory is the root of a git repo
+      #         (i.e. a local working copy) or a subdirectory of one.
+      #
+      def self.is_git_repo?(path: nil)
+        args = ['git']
+        args += ['-C', File.file?(path) ? File.dirname(path) : path] unless path.nil?
+        args += ['rev-parse']
+
+        Action.sh(args, print_command_output: false) do |status, _, _|
           status.success?
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -184,16 +184,12 @@ module Fastlane
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
       def self.is_ignored?(path:)
-        Actions.sh('git', 'check-ignore', path) do |status, output, _|
-          return true if output.strip == NOT_A_REPO_ERROR
-          return true if output.include? OUTSIDE_OF_REPO_ERROR
+        return true unless is_git_repo?(path: path)
 
+        Actions.sh('git', 'check-ignore', path) do |status, _, _|
           status.success?
         end
       end
-
-      OUTSIDE_OF_REPO_ERROR = 'is outside repository at'.freeze
-      NOT_A_REPO_ERROR = 'fatal: not a git repository (or any of the parent directories): .git'.freeze
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -184,12 +184,16 @@ module Fastlane
       #
       # @return [Bool] True if the given path is ignored, false otherwise.
       def self.is_ignored?(path:)
-        return true unless is_git_repo?(path: path)
+        Actions.sh('git', 'check-ignore', path) do |status, output, _|
+          return true if output.strip == NOT_A_REPO_ERROR
+          return true if output.include? OUTSIDE_OF_REPO_ERROR
 
-        Actions.sh('git', 'check-ignore', path) do |status, _, _|
           status.success?
         end
       end
+
+      OUTSIDE_OF_REPO_ERROR = 'is outside repository at'.freeze
+      NOT_A_REPO_ERROR = 'fatal: not a git repository (or any of the parent directories): .git'.freeze
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -19,7 +19,7 @@ module Fastlane
         args += ['-C', File.file?(path) ? File.dirname(path) : path] unless path.nil?
         args += ['rev-parse']
 
-        Action.sh(args, print_command_output: false) do |status, _, _|
+        Action.sh(args, print_command: true, print_command_output: true, error_callback: ->(e) { puts e }) do |status, _, _|
           status.success?
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -202,7 +202,7 @@ module Fastlane
       #
       # @param [String] path The path to check against `.gitignore`
       #
-      # @return [Bool] True if the given path is ignored, false otherwise.
+      # @return [Bool] True if the given path is ignored or outside the Git repository, false otherwise.
       def self.is_ignored?(path:)
         return true unless is_git_repo?(path: path)
 

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -1,39 +1,22 @@
 require 'spec_helper.rb'
 
-shared_context 'with temp dir' do
-  before do
-    @tmpdir_path = Dir.mktmpdir
-    @pwd_before_spec_run = Dir.pwd
-    Dir.chdir(tmpdir_path)
-  end
-
-  after do
-    Dir.chdir(pwd_before_spec_run)
-    puts "tmp path is #{tmpdir_path}"
-    FileUtils.rm_rf(tmpdir_path)
-  end
-
-  attr_reader :tmpdir_path
-  attr_reader :pwd_before_spec_run
-end
-
 describe Fastlane::Helper::ConfigureHelper do
-  include_context 'with temp dir'
-
   describe '#add_file' do
     let(:destination) { 'path/to/destination' }
 
     it 'shows the user an error when the destination is not ignored in Git' do
-      allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
-        .with(path: destination)
-        .and_return(false)
+      in_tmp_dir do |tmpdir_path|
+        allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
+          .with(path: destination)
+          .and_return(false)
 
-      allow(Fastlane::Helper::FilesystemHelper).to receive(:project_path)
-        .and_return(Pathname.new(tmpdir_path))
+        allow(Fastlane::Helper::FilesystemHelper).to receive(:project_path)
+          .and_return(Pathname.new(tmpdir_path))
 
-      expect(Fastlane::UI).to receive(:user_error!)
+        expect(Fastlane::UI).to receive(:user_error!)
 
-      described_class.add_file(source: 'path/to/source', destination: destination, encrypt: true)
+        described_class.add_file(source: 'path/to/source', destination: destination, encrypt: true)
+      end
     end
   end
 end

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -1,6 +1,25 @@
 require 'spec_helper.rb'
 
+shared_context 'with temp dir' do
+  before do
+    @tmpdir_path = Dir.mktmpdir
+    @pwd_before_spec_run = Dir.pwd
+    Dir.chdir(tmpdir_path)
+  end
+
+  after do
+    Dir.chdir(pwd_before_spec_run)
+    puts "tmp path is #{tmpdir_path}"
+    FileUtils.rm_rf(tmpdir_path)
+  end
+
+  attr_reader :tmpdir_path
+  attr_reader :pwd_before_spec_run
+end
+
 describe Fastlane::Helper::ConfigureHelper do
+  include_context 'with temp dir'
+
   describe '#add_file' do
     let(:destination) { 'path/to/destination' }
 
@@ -8,6 +27,9 @@ describe Fastlane::Helper::ConfigureHelper do
       allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
         .with(path: destination)
         .and_return(false)
+
+      allow(Fastlane::Helper::FilesystemHelper).to receive(:project_path)
+        .and_return(Pathname.new(tmpdir_path))
 
       expect(Fastlane::UI).to receive(:user_error!)
 

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -5,13 +5,18 @@ describe Fastlane::Helper::ConfigureHelper do
     let(:destination) { 'path/to/destination' }
 
     it 'shows the user an error when the destination is not ignored in Git' do
-      in_tmp_dir do |tmpdir_path|
+      in_tmp_dir do
         allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
           .with(path: destination)
           .and_return(false)
 
-        allow(Fastlane::Helper::FilesystemHelper).to receive(:project_path)
-          .and_return(Pathname.new(tmpdir_path))
+        # Currently, we need a Git repository to exists in the hierarchy
+        # containing the call site otherwise the tests will end up stuck in
+        # some kind of loop (which I haven't fully inspected). That's a
+        # reasonable enough assumption to make for the real world usage of this
+        # tool. Still, it would be nice to have proper handling of that
+        # scenario at some point.
+        `git init`
 
         expect(Fastlane::UI).to receive(:user_error!)
 

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -31,9 +31,7 @@ RSpec.shared_examples 'shared examples' do
   describe '#apply' do
     context 'when the destination is not ignored in Git' do
       it 'raises' do
-        allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
-          .with(path: subject.destination_file_path)
-          .and_return(false)
+        stub_path_as_ignored(path: subject.destination_file_path, ignored: false)
 
         expect(FileUtils).not_to receive(:mkdir_p)
         expect(subject).not_to receive(:source_contents)
@@ -44,9 +42,7 @@ RSpec.shared_examples 'shared examples' do
 
     context 'when the destination is ignored in Git' do
       it 'copies the source to the destination' do
-        allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
-          .with(path: subject.destination_file_path)
-          .and_return(true)
+        stub_path_as_ignored(path: subject.destination_file_path, ignored: true)
 
         allow(FileUtils).to receive(:mkdir_p)
         allow(subject).to receive(:source_contents).and_return('source contents')
@@ -130,4 +126,10 @@ describe Fastlane::Configuration::FileReference do
       end
     end
   end
+end
+
+def stub_path_as_ignored(path:, ignored:)
+  allow(Fastlane::Helper::GitHelper).to receive(:is_ignored?)
+    .with(path: path)
+    .and_return(ignored)
 end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -144,7 +144,7 @@ describe Fastlane::Helper::GitHelper do
 
     # This test ensures we support the usecase of the `configure` tool, which
     # can create new files by decrypting secrets. We need the ability to tell
-    # if a path result as ignored, regardless of whether it exists yet.
+    # if a path result is ignored, regardless of whether it exists yet.
     it 'returns false for files not yet created but part of the repository' do
       setup_git_repo()
       expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be false

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -142,6 +142,14 @@ describe Fastlane::Helper::GitHelper do
       end
     end
 
+    # This test ensures we support the usecase of the `configure` tool, which
+    # can create new files by decrypting secrets. We need the ability to tell
+    # if a path result as ignored, regardless of whether it exists yet.
+    it 'returns false for files not yet created but part of the repository' do
+      setup_git_repo()
+      expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be false
+    end
+
     it 'returns true when the path is outside the repository folder' do
       # This path is in the parent directory, which is not a Git repo
       path = File.join(@path, '..', 'dummy.txt')
@@ -161,10 +169,14 @@ describe Fastlane::Helper::GitHelper do
   end
 end
 
-def setup_git_repo(dummy_file_path:, add_file_to_gitignore:, commit_gitignore: false)
+def setup_git_repo(dummy_file_path: nil, add_file_to_gitignore: false, commit_gitignore: false)
   `git init`
   `touch .gitignore`
   `git add .gitignore && git commit -m 'Add .gitignore'`
+
+  # If we don't have a path for the file, we don't care the values of the two
+  # flag arguments are irrelevant. We can just finish here.
+  return if dummy_file_path.nil?
 
   `echo abc > #{dummy_file_path}`
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -19,9 +19,22 @@ describe Fastlane::Helper::GitHelper do
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be false
   end
 
+  it 'can detect a missing git repository when given a path' do
+    Dir.mktmpdir do |dir|
+      expect(Fastlane::Helper::GitHelper.is_git_repo?(path: dir)).to be false
+    end
+  end
+
   it 'can detect a valid git repository' do
     `git init`
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
+  end
+
+  it 'can detect a valid git repository when given a path' do
+    Dir.mktmpdir do |dir|
+      `git -C #{dir} init`
+      expect(Fastlane::Helper::GitHelper.is_git_repo?(path: dir)).to be true
+    end
   end
 
   it 'can detect a repository with Git-lfs enabled' do

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -30,10 +30,26 @@ describe Fastlane::Helper::GitHelper do
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
   end
 
+  it 'can detect a valid git repository from a child folder' do
+    `git init`
+    `mkdir -p a/b`
+    Dir.chdir('./a/b')
+    expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
+  end
+
   it 'can detect a valid git repository when given a path' do
     Dir.mktmpdir do |dir|
       `git -C #{dir} init`
       expect(Fastlane::Helper::GitHelper.is_git_repo?(path: dir)).to be true
+    end
+  end
+
+  it 'can detect a valid git repository when given a child folder path' do
+    Dir.mktmpdir do |dir|
+      `git -C #{dir} init`
+      path = File.join(dir, 'a', 'b')
+      `mkdir -p #{path}`
+      expect(Fastlane::Helper::GitHelper.is_git_repo?(path: path)).to be true
     end
   end
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -6,6 +6,8 @@ describe Fastlane::Helper::GitHelper do
     @path = Dir.mktmpdir
     @tmp = Dir.pwd
     Dir.chdir(@path)
+
+    allow(FastlaneCore::Helper).to receive(:sh_enabled?).and_return(true)
   end
 
   after(:each) do
@@ -92,10 +94,6 @@ describe Fastlane::Helper::GitHelper do
   end
 
   describe '#is_ignored?' do
-    before do
-      allow(FastlaneCore::Helper).to receive(:sh_enabled?).and_return(true)
-    end
-
     let(:path) { 'dummy.txt' }
 
     it 'returns false when the path is not ignored' do

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -130,6 +130,23 @@ describe Fastlane::Helper::GitHelper do
         expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be true
       end
     end
+
+    it 'returns true when the path is outside the repository folder' do
+      # This path is in the parent directory, which is not a Git repo
+      path = File.join(@path, '..', 'dummy.txt')
+
+      setup_git_repo(dummy_file_path: path, add_file_to_gitignore: false)
+      expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be true
+    end
+
+    # This is sort of redundant given the previous example already ensures the
+    # same logic. But, we'll be using paths starting with `~` as part of our
+    # configurations, so it felt appopriate to explicitly ensure this important
+    # use case is respected.
+    it 'returns true when the path is in the home folder ' do
+      path = '~/a/path'
+      expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be true
+    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,3 +65,12 @@ def expect_shell_command(*command, exitstatus: 0, output: '')
 
   expect(Open3).to receive(:popen2e).with(*command).and_yield(mock_input, mock_output, mock_thread)
 end
+
+# Executes the given block within an ad hoc temporary directory.
+def in_tmp_dir
+  Dir.mktmpdir('a8c-release-toolkit-tests-') do |tmpdir|
+    Dir.chdir(tmpdir) do
+      yield tmpdir
+    end
+  end
+end


### PR DESCRIPTION
In _previous PR_, we prevented `configure` from decrypting files to a location that is not ignored by Git. This relies under the hood on `git check-ignore`.

Soon after merging, I realized that this solution was incomplete because `git check-ignore` will fail when given a path that is not inside the repository.

That's no good for us because we want to be able to decrypt files to `~/.configure/$PROJECT_NAME`.

You can see this in action in https://github.com/Automattic/simplenote-ios/pull/1276, which includes "testing" instructions.