### PR TITLE
Make GH Releases point to right commit

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -61,7 +61,7 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :target,
                                        env_name: 'GHHELPER_TARGET_COMMITISH',
-                                       description: 'The branch name or commit sha1 the new tag should point to - if that tag does not exist yet when publishing the release. If omitted, will default to the current HEAD commit at the time of this call',
+                                       description: 'The branch name or commit SHA the new tag should point to - if that tag does not exist yet when publishing the release. If omitted, will default to the current HEAD commit at the time of this call',
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :release_notes_file_path,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -19,7 +19,14 @@ module Fastlane
           UI.user_error!("Can't find file #{file_path}!") unless File.exist?(file_path)
         end
 
-        Fastlane::Helper::GithubHelper.create_release(repository, version, release_notes, assets, prerelease)
+        Fastlane::Helper::GithubHelper.create_release(
+          repository: repository,
+          version: version,
+          target: params[:target],
+          body: release_notes,
+          assets: assets,
+          prerelease: prerelease
+        )
         UI.message('Done')
       end
 
@@ -44,19 +51,24 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :repository,
                                        env_name: 'GHHELPER_REPOSITORY',
-                                       description: 'The remote path of the GH repository on which we work',
+                                       description: 'The slug (`<org>/<repo>`) of the GitHub repository we want to create the release on',
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :version,
                                        env_name: 'GHHELPER_CREATE_RELEASE_VERSION',
                                        description: 'The version of the release',
                                        optional: false,
-                                       is_string: true),
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :target,
+                                       env_name: 'GHHELPER_TARGET_COMMITISH',
+                                       description: 'The branch name or commit sha1 the new tag should point to - if that tag does not exist yet when publishing the release. If omitted, will default to the current HEAD commit at the time of this call',
+                                       optional: true,
+                                       type: String),
           FastlaneCore::ConfigItem.new(key: :release_notes_file_path,
                                        env_name: 'GHHELPER_CREATE_RELEASE_NOTES',
                                        description: 'The path to the file that contains the release notes',
                                        optional: true,
-                                       is_string: true),
+                                       type: String),
           FastlaneCore::ConfigItem.new(key: :release_assets,
                                        env_name: 'GHHELPER_CREATE_RELEASE_ASSETS',
                                        description: 'Assets to upload',

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -23,7 +23,7 @@ module Fastlane
           repository: repository,
           version: version,
           target: params[:target],
-          body: release_notes,
+          description: release_notes,
           assets: assets,
           prerelease: prerelease
         )

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -95,6 +95,15 @@ module Fastlane
         end
       end
 
+      # Get the sha1 of a given git ref. Typically useful to get the sha1 of the current HEAD commit.
+      #
+      # @param [String] ref The git ref (commit, branch name, 'HEAD', …) to resolve as a sha1
+      # @return [String] The commit sha1 of the ref
+      #
+      def self.get_commit_sha(ref: 'HEAD')
+        Action.sh('git', 'rev-parse', ref)
+      end
+
       # Creates a tag for the given version, and optionally push it to the remote.
       #
       # @param [String] version The name of the tag to push, e.g. "1.2"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -95,10 +95,10 @@ module Fastlane
         end
       end
 
-      # Get the sha1 of a given git ref. Typically useful to get the sha1 of the current HEAD commit.
+      # Get the SHA of a given git ref. Typically useful to get the SHA of the current HEAD commit.
       #
-      # @param [String] ref The git ref (commit, branch name, 'HEAD', …) to resolve as a sha1
-      # @return [String] The commit sha1 of the ref
+      # @param [String] ref The git ref (commit, branch name, 'HEAD', …) to resolve as a SHA
+      # @return [String] The commit SHA of the ref
       #
       def self.get_commit_sha(ref: 'HEAD')
         Action.sh('git', 'rev-parse', ref).chomp

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -101,7 +101,7 @@ module Fastlane
       # @return [String] The commit sha1 of the ref
       #
       def self.get_commit_sha(ref: 'HEAD')
-        Action.sh('git', 'rev-parse', ref)
+        Action.sh('git', 'rev-parse', ref).chomp
       end
 
       # Creates a tag for the given version, and optionally push it to the remote.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -101,7 +101,7 @@ module Fastlane
       # @return [String] The commit SHA of the ref
       #
       def self.get_commit_sha(ref: 'HEAD')
-        Action.sh('git', 'rev-parse', ref).chomp
+        Git.open(Dir.pwd).revparse(ref)
       end
 
       # Creates a tag for the given version, and optionally push it to the remote.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -79,8 +79,27 @@ module Fastlane
         github_client().create_milestone(repository, newmilestone_number, options)
       end
 
-      def self.create_release(repository, version, release_notes, assets, prerelease)
-        release = github_client().create_release(repository, version, name: version, draft: true, prerelease: prerelease, body: release_notes)
+      # Creates a Release on GitHub as a Draft
+      #
+      # @param [String] repository The repository to create the GitHub release on. Typically a repo slug (<org>/<repo>).
+      # @param [String] version The version for which to create this release. Will be used both as the name of the tag and the name of the release.
+      # @param [String?] target The commit sha1 or branch name that this release will point to when it's published and creates the tag.
+      #        If nil (the default), will use the repo's current HEAD commit at the time this method is called.
+      #        Unused if the tag already exists.
+      # @param [String] body The text to use as the release's body / description (typically the release notes)
+      # @param [Array<String>] assets List of file paths to attach as assets to the release
+      # @param [TrueClass|FalseClass] prerelease Indicates if this should be created as a pre-release (i.e. for alpha/beta)
+      #
+      def self.create_release(repository:, version:, target: nil, body:, assets:, prerelease:)
+        release = github_client().create_release(
+          repository,
+          version, # tag name
+          name: version, # release name
+          target_commitish: target || Fastlane::Helper::GitHelper.get_commit_sha,
+          draft: true,
+          prerelease: prerelease,
+          body: body
+        )
         assets.each do |file_path|
           github_client().upload_asset(release[:url], file_path, content_type: 'application/octet-stream')
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -86,19 +86,19 @@ module Fastlane
       # @param [String?] target The commit SHA or branch name that this release will point to when it's published and creates the tag.
       #        If nil (the default), will use the repo's current HEAD commit at the time this method is called.
       #        Unused if the tag already exists.
-      # @param [String] body The text to use as the release's body / description (typically the release notes)
+      # @param [String] description The text to use as the release's body / description (typically the release notes)
       # @param [Array<String>] assets List of file paths to attach as assets to the release
       # @param [TrueClass|FalseClass] prerelease Indicates if this should be created as a pre-release (i.e. for alpha/beta)
       #
-      def self.create_release(repository:, version:, target: nil, body:, assets:, prerelease:)
+      def self.create_release(repository:, version:, target: nil, description:, assets:, prerelease:)
         release = github_client().create_release(
           repository,
           version, # tag name
           name: version, # release name
-          target_commitish: target || Fastlane::Helper::GitHelper.get_commit_sha,
+          target_commitish: target || Git.open(Dir.pwd).log.first.sha,
           draft: true,
           prerelease: prerelease,
-          body: body
+          body: description
         )
         assets.each do |file_path|
           github_client().upload_asset(release[:url], file_path, content_type: 'application/octet-stream')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -83,7 +83,7 @@ module Fastlane
       #
       # @param [String] repository The repository to create the GitHub release on. Typically a repo slug (<org>/<repo>).
       # @param [String] version The version for which to create this release. Will be used both as the name of the tag and the name of the release.
-      # @param [String?] target The commit sha1 or branch name that this release will point to when it's published and creates the tag.
+      # @param [String?] target The commit SHA or branch name that this release will point to when it's published and creates the tag.
       #        If nil (the default), will use the repo's current HEAD commit at the time this method is called.
       #        Unused if the tag already exists.
       # @param [String] body The text to use as the release's body / description (typically the release notes)


### PR DESCRIPTION
## Why?

When creating a GitHub release via the API with a tag value of `x.y`, the created release will either (1) point to the existing tag `x.y` if that tag already exists at the time the GH release is created, or (2) create the tag if it did not exist, **making that tag point to the default branch of the repo** (e.g. `develop`) unless otherwise specified.

Before we migrated to our new process of creating using the API to trigger CI builds, our process was to create the tag first, so we were in case 1. With the new process, we don't create the tag beforehand, so that makes us land in case 2.

Unfortunately we didn't specify a target commit for the tag to be created. This resulted in **the publication of our GitHub releases to create tags on `develop`** (instead of the commit we were on when CI created the release build). **This means that our tags were pointing to the incorrect commit**.

## How

Make the API call specify an explicit commit sha as the target of the GitHub release. Defaults to the SHA of the current commit (HEAD).

## To test

 - Go to an app repository, and create some dummy files for some fake release notes and assets
```sh
echo "This is a test release that should not be published and is only used to test a feature of the release toolkit." >rn.txt
echo "Fake asset 1" >asset1.txt
echo "Fake asset 2" >asset2.txt
```
 - Ensure you have a GitHub token set in your `GHHELPER_ACCESS` env var. (If not, `export GHHELPER_ACCESS=…` your token, you probably have one in one of your `~/.*-env.default` files)
 - Run the following command, replacing `<org>/<repo>` with the slug of your app repo:
```
bundle exec fastlane run create_release repository:<org>/<repo> version:test-do-not-publish release_notes_file_path:rn.txt release_assets:asset1.txt,asset2.txt prerelease:true
```
 - Check in the Releases tab of the repo on GitHub that the draft release was created. Edit the created release, and observe that the `@ Target:` dropdown would suggest that the tag will be pointing to `develop` when the release will be published. Discard the GitHub draft release.
 - Update your `fastlane/Pluginfile` to point the toolkit to this PR's branch & `bundle install`.
 - Re-run the fastlane command above
 - Check the Releases tab on GitHub again, and check that the new release draft now targets the commit SHA that your local repo was on when you ran the command (compare with `git rev-parse HEAD`).
 - Discard the GitHub release draft and the temporary changes you made to your app repo.