### PR TITLE
Add ios_get_build_version action

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -3,6 +3,9 @@ module Fastlane
     class IosGetAppVersionAction < Action
       def self.run(params)
         require_relative '../../helper/ios/ios_version_helper.rb'
+
+        UI.user_error!('You need to set at least the PUBLIC_CONFIG_FILE env var to the path to the public xcconfig file') unless ENV['PUBLIC_CONFIG_FILE']
+
         Fastlane::Helper::Ios::VersionHelper.get_public_version
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
@@ -1,0 +1,57 @@
+module Fastlane
+  module Actions
+    class IosGetBuildVersionAction < Action
+      def self.run(params)
+        require_relative '../../helper/ios/ios_version_helper.rb'
+
+        if params[:internal]
+          Fastlane::Helper::Ios::VersionHelper.get_internal_version
+        else
+          Fastlane::Helper::Ios::VersionHelper.get_build_version
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Gets the build version of the app'
+      end
+
+      def self.details
+        'Gets the build version (`VERSION_LONG`) of the app from the xcconfig file'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :internal,
+            env_name: 'FL_IOS_BUILD_VERSION_INTERNAL',
+            description: 'If true, returns the internal build version, otherwise returns the public one',
+            is_string: false, # Boolean
+            default_value: false
+          ),
+        ]
+      end
+
+      def self.output
+        # Define the shared values you are going to provide
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+        'Return the public or internal build version of the app'
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ['AliSoftware']
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
@@ -4,7 +4,10 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/ios/ios_version_helper.rb'
 
+        UI.user_error!('You need to set at least the PUBLIC_CONFIG_FILE env var to the path to the public xcconfig file') unless ENV['PUBLIC_CONFIG_FILE']
+
         if params[:internal]
+          UI.user_error!('You need to set the INTERNAL_CONFIG_FILE env var to the path to the internal xcconfig file') unless ENV['INTERNAL_CONFIG_FILE']
           Fastlane::Helper::Ios::VersionHelper.get_internal_version
         else
           Fastlane::Helper::Ios::VersionHelper.get_build_version


### PR DESCRIPTION
## Why

When creating a GitHub release (after a release build is triggered via `new_beta_release` or `finalize_release` in the host apps), iOS currently always uses `ios_get_app_version()`  in the host Fastfiles as the version to use for the GitHub release title and tag name.

This means that even GH releases created as a result of `new_beta_release` end up with a title and git tag of `x.y` instead of using `x.y.0.z` for betas.

To solve this, the host app's `Fastfiles` will need to be able to fetch the build version (`VERSION_LONG` in `xcconfig` files) in order to pass it at call site to `create_gh_release` and for it to use the correct title and tag for betas. This is what this PR adds.

## Target branch

This PR sits on top of `gh-releases/fix-target` from https://github.com/wordpress-mobile/release-toolkit/pull/253 because I needed both fixes at once to continue working on the fixes needed in the host apps' `Fastfile` and the overall issues with GH releases in our process. https://github.com/wordpress-mobile/release-toolkit/pull/253 Should thus ideally be merged first – which should update this PR's branch to `develop` before we can merge that one next.

## To test

 - Edit the `fastlane/Pluginfile` of an host app to point the release toolkit to this branch, and run `bundle install`
 - Run `bundle exec fastlane run ios_get_build_version`. Notice it fails telling you an env var is missing
 - Run `PUBLIC_CONFIG_FILE=config/Version.public.xcconfig bundle exec fastlane run ios_get_build_version` and check that it returns the public build version (e.g. `17.3.0.1`)
 - Run `PUBLIC_CONFIG_FILE=config/Version.public.xcconfig bundle exec fastlane run ios_get_build_version internal:true`, Notice it fails telling you an env var is missing.
 - Run `INTERNAL_CONFIG_FILE=config/Version.internal.xcconfig PUBLIC_CONFIG_FILE=config/Version.public.xcconfig bundle exec fastlane run ios_get_build_version internal:true` and check that it returns the internal build version (e.g. `17.3.0.20210507`)