### PR TITLE
Fix the drawText binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
       - run:
           name: Install Homebrew dependencies, if neeeded
-          command: xargs brew install --verbose < .circleci/.brewfile
+          command: brew update && xargs brew install --verbose < .circleci/.brewfile
 
       - run:
           name: Install Ruby dependencies, if neeeded

--- a/ext/drawText/drawText/CoreTextStack.swift
+++ b/ext/drawText/drawText/CoreTextStack.swift
@@ -76,24 +76,15 @@ struct CoreTextStack {
     }
 
     func draw(inContext context: CGContext) throws -> CGImage {
-
-        NSGraphicsContext.saveGraphicsState()
-
-        let currentContext = NSGraphicsContext(cgContext: context, flipped: true)
-        NSGraphicsContext.current = currentContext
-
-        /// Without the transform, text is drawn upside down and backwards because of
-        /// macOS' flipped coordinate system.
-        let transform = NSAffineTransform()
-        transform.scaleX(by: 1, yBy: -1)
-        transform.translateX(by: 0, yBy: frameSize.height * -1)
-        transform.concat()
+        let canvas = NSImage(size: NSSize(width: context.width, height: context.height))
+        canvas.lockFocusFlipped(true)
 
         layoutManager.drawGlyphs(forGlyphRange: range, at: .zero)
 
-        NSGraphicsContext.restoreGraphicsState()
+        canvas.unlockFocus()
 
-        guard let image = currentContext.cgContext.makeImage() else {
+        let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+        guard let image = canvas.cgImage(forProposedRect: nil, context: nsContext, hints: nil) else {
             throw TextImageProcessingError(kind: .unableToDrawImage)
         }
 

--- a/ext/drawText/drawText/TextImage.swift
+++ b/ext/drawText/drawText/TextImage.swift
@@ -57,7 +57,7 @@ class TextImage {
         return try String(contentsOfFile: path, encoding: .utf8)
     }
 
-    private func graphicsContext(forSize size: CGSize) throws -> CGContext {
+    private func graphicsContext(forSize size: CGSize) throws -> NSGraphicsContext {
 
         let canvas = NSBitmapImageRep(
             bitmapDataPlanes: nil,
@@ -78,7 +78,7 @@ class TextImage {
             throw TextImageProcessingError(kind: .unableToInitializeGraphicsContext)
         }
 
-        return context.cgContext
+        return context
     }
 }
 


### PR DESCRIPTION
Trying to fix the `Thread 1: EXC_BAD_ACCESS (code=1, address=0x11094c0e4)` error on `drawGlyphs`

![image](https://user-images.githubusercontent.com/216089/118006054-38b16100-b34b-11eb-8f91-3baa31b28375.png)


Seems that passing around a `CGContext` messes things with reference counting (despite Zombies and Address Sanitizer not telling us anything). Passing `NSGraphicsContext` instead seems to fix the crash.

## To Test

- Point WPiOS to this branch of the toolkit, run bundle install
- Ensure you have the promo strings in `fastlane/appstoreres/metadata/*`. If not, run `bundle exec fastlane download_promo_strings` first.
- Run the following command:
```
 bundle exec drawText html="fastlane/appstoreres/metadata/en-US/app_store_screenshot_1.txt" maxWidth=1242 maxHeight=420 output=drawText.out.png fontSize=110 stylesheet="./fastlane/appstoreres/assets/style.css" alignment="center"
```
- Check it didn't crash, and that it generated the `drawText.out.png` file exists, and that it indeed has a size of 1242x480 (at 72ppi) when you open it in Preview