### PR TITLE
Prep work for first 1.0 release: CHANGELOG, Rake task, Danger rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ## Develop
 
-This is our first official release.
-
 ### Breaking Changes
 
 _None_
@@ -19,5 +17,11 @@ _None_
 _None_
 
 ### Internal Changes
+
+_None_
+
+## 1.0.0
+
+This is our first official release.
 
 _None_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Release Toolkit CHANGELOG
+
+---
+
+## Develop
+
+This is our first official release.
+
+### Breaking Changes
+
+_None_
+
+### New Features
+
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_

--- a/Dangerfile
+++ b/Dangerfile
@@ -23,6 +23,13 @@ Please run `bundle install` to make sure they match.
   fail(message)
 end
 
+# Check that the PR contains changes to the CHANGELOG.md file.
+#  - If it's a feature PR, CHANGELOG should have a new entry describing the changes
+#  - If it's a release PR, we expect the CHANGELOG to have been updated during `rake new_release` with updated section title + new placeholder section
+unless git.modified_files.include?('CHANGELOG.md')
+  warn 'Please add an entry in the CHANGELOG.md file to describe the changes made by this PR'
+end
+
 # Lint with Rubocop and report violations inline in GitHub
 github.dismiss_out_of_range_messages # This way, fixed violations should go
 renaming_map = (git.renamed_files || []).map { |e| [e[:before], e[:after]] }.to_h # when files are renamed, git.modified_files contains old name, not new one, so we need to do the convertion

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.18.1)
+    fastlane-plugin-wpmreleasetoolkit (1.0.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -19,7 +19,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.5)
+    activesupport (5.2.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -207,7 +207,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.3)
+    nokogiri (1.11.4)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -344,4 +344,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.11
+   2.2.14

--- a/Rakefile
+++ b/Rakefile
@@ -30,3 +30,89 @@ task :docstats, [:path] do |_, args|
 end
 
 Rake::ExtensionTask.new('drawText')
+
+desc 'Create a new version of the release-toolkit gem'
+task :release do
+  version_file = File.join('lib', 'fastlane', 'plugin', 'wpmreleasetoolkit', 'version.rb')
+  require_relative(version_file)
+  puts ">>> Current version is: #{Fastlane::Wpmreleasetoolkit::VERSION}"
+
+  puts '>>> New version to use?'
+  new_version = STDIN.gets.chomp
+
+  ### VERSION constant
+  puts '>>> Updating `VERSION` constant in `version.rb`...'
+  content = File.read(version_file)
+  content.gsub!(/VERSION = .*/, "VERSION = '#{new_version}'")
+  File.write(version_file, content)
+  sh('bundle', 'install') # To update Gemfile.lock with new wpmreleasetoolkit version
+
+  ### CHANGELOG.md
+  puts '>>> Updating the `CHANGELOG.md` file...'
+  update_changelog_sections(
+    file: 'CHANGELOG.md',
+    wip_header_title: 'Develop',
+    placeholder_sections: ['Breaking Changes', 'New Features', 'Bug Fixes', 'Internal Changes'],
+    new_section_title: new_version
+  )
+
+  puts <<~INSTRUCTIONS
+
+    >>> WHAT'S NEXT
+
+    Please check that the version bump and CHANGELOG.md updates looks ok.
+    Then, commit the changes in a new `release/#{new_version}` branch and create PRs to `develop` and `trunk`.
+
+    Once the PRs are merged, create a GH release for `#{new_version}` targeting `trunk`,
+    then run `gem build` and `gem push` to upload the version to RubyGems.
+  INSTRUCTIONS
+end
+
+########################
+# Helpers
+########################
+
+def next_index(matching:, after: 0, in_lines:)
+  idx = in_lines[(after + 1)...].index { |l| l =~ matching }
+  return -1 if idx.nil?
+
+  idx + after + 1
+end
+
+def update_changelog_sections(file:, wip_header_title:, placeholder_sections:, empty_section_text: '_None_', new_section_title:)
+  # Read current CHANGELOG
+  lines = File.readlines(file)
+
+  # Find on which line the WIP h2 section starts
+  wip_section_idx = next_index(matching: /\#\# #{wip_header_title}$/, in_lines: lines)
+  raise "#{wip_header_title} section not found in current CHANGELOG!" if wip_section_idx.nil?
+
+  # Update CHANGELOG
+  File.open(file, 'w') do |f|
+    # Insert any preamble lines that exists before wip_header_title h2 section
+    f.puts lines[0...wip_section_idx]
+
+    # Insert the empty section placeholders for the next version
+    f.puts ["\#\# #{wip_header_title}", '']
+    placeholder_sections.each { |s| f.puts ["\#\#\# #{s}", '', empty_section_text, ''] }
+
+    # Insert h2 section title for the new version we're releasing (in place of the old wip_header_title that was used for that h2 section until now)
+    f.puts "\#\# #{new_section_title}"
+
+    # Then print any subsequent h3 section that was in that wip section before... but omitting the ones that are empty
+    current_idx = wip_section_idx + 1 # First line we start our analysis from, to iterate over each h3 subsection and prune the empty ones
+    next_idx = 0
+    loop do
+      next_idx = next_index(matching: /^\#\#/, after: current_idx, in_lines: lines) # Index of next h2 or h3 section to stop at
+      section_lines = lines[current_idx...next_idx] # lines from current_idx (aka subsection title) including, up to but non including next_idx (aka next section's title)
+      body_lines = section_lines.drop(1).reject { |l| l.chomp.empty? } # non-empty lines in the current h3 section
+      f.puts section_lines unless body_lines.empty? || body_lines.first.chomp == empty_section_text # only print section title+body if it wasn't empty
+      break if next_idx == -1 || lines[next_idx].start_with?('## ') # if next section is h2 and not h3 (or we reached end of file), we're finally done with the WIP h2 section and reached the next h2 (for the previous released version)
+
+      current_idx = next_idx
+    end
+
+    # Finally, print all the rest, i.e. everything that was after the WIP section, unprocessed.
+    f.puts lines[next_idx...]
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -32,10 +32,11 @@ end
 Rake::ExtensionTask.new('drawText')
 
 desc 'Create a new version of the release-toolkit gem'
-task :release do
+task :new_release do
   version_file = File.join('lib', 'fastlane', 'plugin', 'wpmreleasetoolkit', 'version.rb')
   require_relative(version_file)
   puts ">>> Current version is: #{Fastlane::Wpmreleasetoolkit::VERSION}"
+  puts ">>> Pending CHANGELOG:\n" + get_changelog_section(file: 'CHANGELOG.md', section_title: 'Develop').map { |l| "| #{l}" }.join
 
   puts '>>> New version to use?'
   new_version = STDIN.gets.chomp
@@ -58,6 +59,8 @@ task :release do
 
   puts <<~INSTRUCTIONS
 
+    ---------------
+
     >>> WHAT'S NEXT
 
     Please check that the version bump and CHANGELOG.md updates looks ok.
@@ -79,12 +82,19 @@ def next_index(matching:, after: 0, in_lines:)
   idx + after + 1
 end
 
+def get_changelog_section(file:, section_title:)
+  lines = File.readlines(file)
+  section_start = next_index(matching: /^\#\# #{section_title}$/, in_lines: lines)
+  section_end = next_index(matching: /^\#\# /, after: section_start, in_lines: lines)
+  puts "#{section_start}...#{section_end}"
+  lines[section_start...section_end]
+end
+
 def update_changelog_sections(file:, wip_header_title:, placeholder_sections:, empty_section_text: '_None_', new_section_title:)
-  # Read current CHANGELOG
   lines = File.readlines(file)
 
   # Find on which line the WIP h2 section starts
-  wip_section_idx = next_index(matching: /\#\# #{wip_header_title}$/, in_lines: lines)
+  wip_section_idx = next_index(matching: /^\#\# #{wip_header_title}$/, in_lines: lines)
   raise "#{wip_header_title} section not found in current CHANGELOG!" if wip_section_idx.nil?
 
   # Update CHANGELOG

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '0.18.1'
+    VERSION = '1.0.0'
   end
 end


### PR DESCRIPTION
This is a Draft for now, just to introduce:

 - [x] A template for the `CHANGELOG.md` file we want to introduce
 - [x] A rake task to start automating the releases.
    - Currently only updates the `VERSION` constant and the `CHANGELOG.md`, and end up with manual instructions for what's next.
    - Side note that the changelog helper function was copied from one of my personal OSS projects, which means it has already been tested a bit with a similar CHANGELOG format in other repos.
    - Improvement idea 1: automate the release branch creation, commit, push, and creation of the `trunk`+`develop` PRs
    - Improvement idea 2: add a task to do the `gem build` + `gem push`. Might require to also add some instructions, ensure that everybody in the team is set as owner of the gem to be able to push new versions, etc… so I kept that for later (after we do our first rubygems push manually probably)
 - [x] A `Danger` rule to ensure that the CHANGELOG file has been modified (`git.modified_files.include?('CHANGELOG.md')` should suffice) and `error` or `warn` if not, to ensure that each future PR adds an entry in the CHANGELOG individually.


TODO:
 - [ ] We might want to fill up some of the CHANGELOG items for this 1.0, to provide what we will ship in that 1.0 that was not part of the previous 0.18.x release. We could also decide that first entry is empty since that's the first official version, and only add what changed in future ones.