### PR TITLE
Fix the build of drawText extension during bundle install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,9 @@ _None_
 
 ### Internal Changes
 
-Updated the Gemspec's `bundler` and `rubocop` dependencies to fix a publishing warning.
+* Updated the `gemspec`'s `bundler` and `rubocop` dependencies to fix a publishing warning. [#261]
+* Fixed an issue with the `gemspec`'s definition of the `drawText` extension – which prevented the native extension from being built when referencing the toolkit via a version number rather than a tag in your `Gemfile`. [#262]
 
 ## 1.0.0
 
 This is our first official release.
-
-_None_

--- a/bin/drawText
+++ b/bin/drawText
@@ -2,6 +2,7 @@
 
 require 'rake'
 require 'os'
+require 'pathname'
 
 abort 'Fatal Error: `drawText` can only be run on macOS.' unless OS.mac?
 

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # These files are used to generate Makefile files which in turn are used
   # to build and install the C extension.
-  spec.extensions = ['ext/drawText/extconf.rb']
+  spec.extensions = ['ext/drawText/extconf.rb', 'ext/drawText/makefile.example']
 
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/wordpress-mobile/release-toolkit'
   spec.license       = 'MIT'
 
-  spec.files         = Dir['lib/**/*'] + %w[README.md LICENSE]
+  spec.files         = Dir['lib/**/*'] + Dir['ext/drawText/{makefile.example,drawText/**/*,drawText Tests/**/*,drawText.xcodeproj/**/*}'] + %w[README.md LICENSE]
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 
   spec.files << 'ext/drawText/extconf.rb'
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   # These files are used to generate Makefile files which in turn are used
   # to build and install the C extension.
-  spec.extensions = ['ext/drawText/extconf.rb', 'ext/drawText/makefile.example']
+  spec.extensions = ['ext/drawText/extconf.rb']
 
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency


### PR DESCRIPTION
## Why?

Trying to fix the error when doing a `bundle install` on a project pointing to `1.0.0` of this gem.

<details><summary>📋 See full error log</summary>

```
Installing fastlane-plugin-wpmreleasetoolkit 1.0.0 (was 0.18.1) with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/olivier/Documents/Dev/apps/woocommerce-ios/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-wpmreleasetoolkit-1.0.0/ext/drawText
/Users/olivier/.rbenv/versions/2.6.4/bin/ruby -I /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0 -r ./siteconf20210520-38383-14irkq3.rb extconf.rb
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/Users/olivier/.rbenv/versions/2.6.4/bin/$(RUBY_BASE_NAME)
/Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:1385:in `initialize': No such file or directory @ rb_sysopen -
/Users/olivier/Documents/Dev/apps/woocommerce-ios/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-wpmreleasetoolkit-1.0.0/ext/drawText/makefile.example (Errno::ENOENT)
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:1385:in `open'
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:1385:in `copy_file'
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:492:in `copy_file'
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:419:in `block in cp'
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:1557:in `block in fu_each_src_dest'
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:1573:in `fu_each_src_dest0'
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:1555:in `fu_each_src_dest'
	from /Users/olivier/.rbenv/versions/2.6.4/lib/ruby/2.6.0/fileutils.rb:418:in `cp'
	from extconf.rb:10:in `<main>'

extconf failed, exit code 1

Gem files will remain installed in /Users/olivier/Documents/Dev/apps/woocommerce-ios/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-wpmreleasetoolkit-1.0.0 for inspection.
Results logged to /Users/olivier/Documents/Dev/apps/woocommerce-ios/vendor/bundle/ruby/2.6.0/extensions/x86_64-darwin-19/2.6.0/fastlane-plugin-wpmreleasetoolkit-1.0.0/gem_make.out
```
</details>

## How

Added the missing `makefile.example` and all the source files and xcodeproj to the appropriate line in the `gemspec` so that they're included in the gem to compile.

## Test

- Checkout this branch
- Delete any previously build `.gem` package if you ran `gem build` previously, and also uninstall the 1.0.0 gem if you installed it previously, to be sure we don't accidentally invoke the wrong version during our testing
- Run `gem build fastlane-plugin-wpmreleasetoolkit` to build the `.gem` package.
- Run `gem install fastlane-plugin-wpmreleasetoolkit-1.0.0.gem` and check that it builds the `drawText` native extension without error
- Execute the bin/drawText shim that got installed in your gem home to ensure that it exists and runs without segfault or crash (but just errors for incorrect arguments)

```
$ rm fastlane-plugin-wpmreleasetoolkit-*.gem

$ gem uninstall fastlane-plugin-wpmreleasetoolkit 
Remove executables:
	drawText

in addition to the gem? [Yn]  Y
Removing drawText
Successfully uninstalled fastlane-plugin-wpmreleasetoolkit-1.0.0

$ gem build fastlane-plugin-wpmreleasetoolkit.gemspec 
  Successfully built RubyGem
  Name: fastlane-plugin-wpmreleasetoolkit
  Version: 1.0.0
  File: fastlane-plugin-wpmreleasetoolkit-1.0.0.gem

$ gem install fastlane-plugin-wpmreleasetoolkit-1.0.0.gem 
Building native extensions. This could take a while...
Successfully installed fastlane-plugin-wpmreleasetoolkit-1.0.0
Parsing documentation for fastlane-plugin-wpmreleasetoolkit-1.0.0
Done installing documentation for fastlane-plugin-wpmreleasetoolkit after 0 seconds
1 gem installed

$ $(gem env gemdir)/gems/fastlane-plugin-wpmreleasetoolkit-1.0.0/bin/drawText  
Error: Unable to read HTML string
Usage: ./draw-text
    html={file path or quotes-enclosed HTML string [required]}
    maxWidth={ integer [required] }
    maxHeight={ integer [required] }
    fontSize={ CSS-size compatible string [default = 12px }
    color={ color or hex code [default = white] }
    align={ CSS text-alignment value [default = center] }
    stylesheet={ File Path to a custom stylesheet [default = none] }
```