### PR TITLE
Release 1.0.1 into develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,17 +3,11 @@ version: 2.1
 orbs:
   ios: wordpress-mobile/ios@1.0
 
-jobs:
-  test:
-    executor:
-      name: ios/default
-      xcode-version: "11.2.1"
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      PKG_CONFIG_PATH: "/usr/local/opt/imagemagick@6/lib/pkgconfig"
+# Common steps reused on various jobs
+commands:
+  setup_tools:
+    description: "Install Homebrew and Ruby dependencies"
     steps:
-      - checkout
-
       - restore_cache:
           name: Restore Homebrew + Ruby Dependencies
           keys:
@@ -33,11 +27,21 @@ jobs:
           paths:
             - vendor/
             - /usr/local/Cellar
-            
+
+jobs:
+  test:
+    executor:
+      name: ios/default
+      xcode-version: "11.2.1"
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      PKG_CONFIG_PATH: "/usr/local/opt/imagemagick@6/lib/pkgconfig"
+    steps:
+      - checkout
+      - setup_tools
       - run: # Compile drawText
           name: Compile drawText
           command: bundle exec rake compile
-
       - run:
           name: Run rspec and upload coverage report
           command: |
@@ -46,7 +50,6 @@ jobs:
                               --out test_results/rspec.xml \
                               --format progress \
                               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
@@ -54,7 +57,36 @@ jobs:
       # Coverage reports are sent to Codecov as part of running `rspec`, not as a CircleCI step.
       # We may wish to change this for consistency.
 
+  gem-push:
+    executor:
+      name: ios/default
+      xcode-version: "11.2.1" # We need an Xcode-enabled CI image to build drawText during gem build
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      PKG_CONFIG_PATH: "/usr/local/opt/imagemagick@6/lib/pkgconfig"
+    steps:
+      - checkout
+      - setup_tools
+      - run:
+          name: Build gem
+          command: gem build fastlane-plugin-wpmreleasetoolkit.gemspec
+      - run:
+          name: Check the gem is installable
+          command: gem install fastlane-plugin-wpmreleasetoolkit-*.gem
+      - run:
+          name: Push to RubyGems
+          command: gem push fastlane-plugin-wpmreleasetoolkit-*.gem
+
 workflows:
   test:
     jobs:
       - test
+  release:
+    jobs:
+      - gem-push:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -68,7 +68,7 @@ Naming/PredicateName:
 # Offense count: 19
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Exclude:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ _None_
 
 ### Internal Changes
 
+_None_
+
+## 1.0.1
+
+### Internal Changes
+
 * Updated the `gemspec`'s `bundler` and `rubocop` dependencies to fix a publishing warning. [#261]
 * Fixed an issue with the `gemspec`'s definition of the `drawText` extension – which prevented the native extension from being built when referencing the toolkit via a version number rather than a tag in your `Gemfile`. [#262]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (1.0.0)
+    fastlane-plugin-wpmreleasetoolkit (1.0.1)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -198,7 +198,6 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.1)
     minitest (5.14.4)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -206,8 +205,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.4)
-      mini_portile2 (~> 2.5.0)
+    nokogiri (1.11.4-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -349,4 +347,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.14
+   2.2.15

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/rakelib/changelog_parser.rake
+++ b/rakelib/changelog_parser.rake
@@ -1,0 +1,98 @@
+
+class ChangelogParser
+  PENDING_SECTION_TITLE = 'Develop'.freeze
+  EMPTY_PLACEHOLDER = '_None_'.freeze
+  SUBSECTIONS_SEMVER_MAP = { 'Breaking Changes': 3, 'New Features': 2, 'Bug Fixes': 1, 'Internal Changes': 1 }
+
+  def initialize(file: 'CHANGELOG.md')
+    @lines = File.readlines(file)
+    @current_index = nil
+    @pending_section = nil
+  end
+
+  # @return the title of the section after the pending one -- which should match the latest released version
+  def parse_pending_section
+    (lines_before_first_section, _, title) = advance_to_next_header(level: 2)
+    raise "Expected #{PENDING_SECTION_TITLE} as first section but found #{title} instead." unless title == PENDING_SECTION_TITLE
+
+    subsections = []
+    prev_subtitle = nil
+    loop do
+      (lines, next_level, next_subtitle) = advance_to_next_header(level: 2..3)
+      subsections.append({title: prev_subtitle, lines: lines}) unless lines.reject { |l| l.chomp.empty? || l.chomp == EMPTY_PLACEHOLDER }.empty?
+      prev_subtitle = next_subtitle
+
+      break if next_level < 3
+    end
+    @pending_section = { lines_before: lines_before_first_section, subsections: subsections, next_title: prev_subtitle }
+    prev_subtitle
+  end
+
+  def cleaned_pending_changelog_lines
+    lines = []
+    @pending_section[:subsections].map do |s|
+      lines.append "\#\#\# #{s[:title]}\n" unless s[:title].nil? # subsection title is nil for lines between h2 and first h3
+      lines += s[:lines]
+    end
+    lines
+  end
+
+  def guessed_next_semantic_version(current:)
+    comps = current.split('.')
+    idx_to_bump = 3 - semver_category
+    comps[idx_to_bump] = "#{comps[idx_to_bump].to_i + 1}"
+    ((idx_to_bump+1)...(comps.length)).each { |i| comps[i] = '0' }
+    comps.join('.')
+  end
+
+  def update_for_new_release(new_file: 'CHANGELOG.md', new_version:)
+    raise 'You need to call #parse_pending_section first' if @pending_section.nil?
+
+    puts ">>> Updating CHANGELOG..."
+
+    File.open(new_file, 'w') do |f|
+      f.puts @pending_section[:lines_before]
+      # Empty placeholder section for next version after this one
+      f.puts placeholder_section
+      # Section for new version, with the non-empty subsections found while parsing first section
+      f.puts "\#\# #{new_version}\n\n"
+      f.puts cleaned_pending_changelog_lines
+      f.puts "\#\# #{@pending_section[:next_title]}"
+      f.puts read_up_to_end
+    end
+  end
+
+  private
+
+  # Advance line pointer to next index of provided `level`
+  # @return [Array] A 3-item array of [scanned_lines, next_header_level, next_header_title]
+  def advance_to_next_header(level:)
+    range = level.is_a?(Range) ? level : level..level
+    regex = /^(\#{#{range.min},#{range.max}}) ?([^#].*)$/ # A line starting with {range.min,range.max} times '#' then optional space then a title
+    start_idx = @current_index.nil? ? 0 : @current_index + 1
+    offset = @lines[start_idx...].index { |l| l =~ regex }
+    @current_index = offset.nil? ? -1 : start_idx + offset
+
+    m = regex.match(@lines[@current_index])
+    return [@lines[start_idx...@current_index], m[1].length, m[2]]
+  end
+
+  def read_up_to_end
+    idx = @current_index + 1
+    @current_index = -1
+    @lines[idx...]
+  end
+
+  def placeholder_section
+    lines = ["\#\# #{PENDING_SECTION_TITLE}\n\n"]
+    lines += SUBSECTIONS_SEMVER_MAP.keys.map { |s| "\#\#\# #{s}\n\n#{EMPTY_PLACEHOLDER}\n\n" }
+    lines.join
+  end
+
+  # @return the SemVer category (as described in Gem::Version doc). 3=major, 2=minor, 1=patch
+  def semver_category
+    raise 'You need to call #parse_pending_section first' if @pending_section.nil?
+
+    @pending_section[:subsections].map { |s| SUBSECTIONS_SEMVER_MAP[s[:title].to_sym] || 1 }.max || 1
+  end
+end

--- a/rakelib/changelog_parser.rake
+++ b/rakelib/changelog_parser.rake
@@ -48,8 +48,6 @@ class ChangelogParser
   def update_for_new_release(new_file: 'CHANGELOG.md', new_version:)
     raise 'You need to call #parse_pending_section first' if @pending_section.nil?
 
-    puts ">>> Updating CHANGELOG..."
-
     File.open(new_file, 'w') do |f|
       f.puts @pending_section[:lines_before]
       # Empty placeholder section for next version after this one

--- a/rakelib/console.rake
+++ b/rakelib/console.rake
@@ -1,0 +1,34 @@
+module Console
+  # ANSI colors
+  RED = 1
+  GREEN = 2
+  YELLOW = 3
+  PURPLE = 4
+
+  def self.color_puts(lines, color_code:)
+    puts "\x1b[3#{color_code}m#{lines}\x1b[0m"
+  end
+
+  def self.header(title)
+    color_puts(">>> #{title}", color_code: GREEN) # green
+  end
+
+  def self.info(text)
+    color_puts(text, color_code: YELLOW) # yellow
+  end
+
+  def self.warning(text)
+    color_puts(title, color_code: RED) # red
+  end
+
+  def self.print_indented_lines(lines)
+    color_puts(lines.map { |l| "| #{l}" }.join, color_code: YELLOW)
+  end
+
+  def self.prompt(text, default_value)
+    color_puts("#{text} [#{default_value}]?", color_code: GREEN)
+    answer = $stdin.gets.chomp
+    answer = default_value if answer.empty?
+    answer
+  end
+end

--- a/rakelib/git_helpers.rake
+++ b/rakelib/git_helpers.rake
@@ -1,0 +1,28 @@
+module GitHelper
+  def self.current_branch
+    `git branch --show-current`.chomp
+  end
+
+  def self.check_or_create_branch(new_version)
+    release_branch = "release/#{new_version}"
+    if self.current_branch == release_branch
+      puts 'Already on release branch'
+    else
+      sh('git', 'checkout', '-b', release_branch)
+    end
+  end
+
+  def self.prepare_github_pr(head, base, title, body)
+    require 'open-uri'
+    qtitle = title.gsub(' ', '%20')
+    qbody = body.gsub(' ', '%20')
+    uri = "https://github.com/wordpress-mobile/release-toolkit/compare/#{base}...#{head}?expand=1&title=#{qtitle}&body=#{qbody}"
+    Rake.sh('open', uri)
+  end
+
+  def self.commit_files(message, files, push: true)
+    Rake.sh('git', 'add', *files)
+    Rake.sh('git', 'commit', '-m', message)
+    Rake.sh('git', 'push', 'origin', self.current_branch) if push
+  end
+end


### PR DESCRIPTION
New version 1.0.1

* Improves the release script to the next level
* Release 1.0.1

Note: to create this PR, all I had to do was to run `bundle exec rake new_release`, and the script took care of all the following:

 - Showed me the CHANGELOG entries (stripped from empty subsections) for the pending version in the console
 - Suggested me the new version bump to do based on the CHANGELOG (only Internal Changes so it concluded only a patch bump and thus suggested `1.0.1`)
 - Updated the `VERSION` constant and the `CHANGELOG` automatically, and ran `bundle install` to update `Gemfile.lock` too
 - Checked that the gem was installable (`gem build` + `gem install`)
 - Ensured I was on release branch, then commited and pushed
 - Opened 2 pages on my default browser ready to create the PRs to develop and trunk
 - Told me the next steps once PR got merged was to create a GH release and tag and let CI push to RubyGems for me

![image](https://user-images.githubusercontent.com/216089/119564368-ffe0a580-bda8-11eb-867e-cf73c355a559.png)
![image](https://user-images.githubusercontent.com/216089/119564425-125adf00-bda9-11eb-8879-3b4b33336c7b.png)

<details><summary>Here's the entire console log</summary>

```
$ be rake new_release
>>> Current version is: 1.0.0
>>> Pending CHANGELOG:
| ### Internal Changes
| 
| * Updated the `gemspec`'s `bundler` and `rubocop` dependencies to fix a publishing warning. [#261]
| * Fixed an issue with the `gemspec`'s definition of the `drawText` extension – which prevented the native extension from being built when referencing the toolkit via a version number rather than a tag in your `Gemfile`. [#262]
| 

New version to release [1.0.1]?

Already on release branch
>>> Update `VERSION` constant in `version.rb`...
bundle install
Using rake 12.3.3
Using CFPropertyList 3.0.3
Using concurrent-ruby 1.1.8
Using minitest 5.14.4
Using thread_safe 0.3.6
Using public_suffix 4.0.6
Using ast 2.4.2
Using atomos 0.1.3
Using aws-eventstream 1.1.0
Using aws-partitions 1.406.0
Using jmespath 1.4.0
Using babosa 1.0.4
Using bigdecimal 1.4.4
Using bundler 2.2.15
Using chroma 0.2.0
Using claide 1.0.3
Using colored2 3.1.2
Using nap 1.1.0
Using open4 1.3.4
Using json 2.5.1
Using docile 1.3.5
Using simplecov-html 0.10.2
Using coderay 1.1.3
Using colored 1.2
Using highline 1.7.10
Using rexml 3.2.5
Using faraday-excon 1.1.0
Using faraday-net_http 1.0.1
Using faraday-net_http_persistent 1.1.0
Using multipart-post 2.0.0
Using ruby2_keywords 0.0.4
Using rchardet 1.8.0
Using no_proxy_fix 0.1.2
Using gh_inspector 1.1.3
Using parallel 1.20.1
Using unicode-display_width 1.7.0
Using multi_json 1.15.0
Using ruby-progressbar 1.11.0
Using regexp_parser 2.1.1
Using mini_mime 1.0.2
Using diff-lcs 1.4.4
Using retriable 3.1.2
Using digest-crc 0.6.2
Using mini_magick 4.11.0
Using plist 3.5.0
Using rubyzip 2.3.0
Using security 0.1.3
Using fastimage 2.2.0
Using slack-notifier 2.3.2
Using jwt 2.2.2
Using tty-screen 0.8.1
Using memoist 0.16.2
Using word_wrap 1.0.0
Using os 1.1.1
Using declarative 0.0.20
Using nanaimo 0.3.0
Using rouge 2.0.7
Using racc 1.5.2
Using options 2.3.2
Using rake-compiler 1.1.1
Using emoji_regex 3.2.1
Using dotenv 2.7.6
Using method_source 0.9.2
Using terminal-notifier 2.0.0
Using yard 0.9.26
Using httpclient 2.8.3
Using tzinfo 1.2.9
Using addressable 2.7.0
Using aws-sigv4 1.2.2
Using cork 0.3.0
Using uber 0.1.0
Using commander-fastlane 4.4.6
Using google-cloud-errors 1.0.1
Using crack 0.4.5
Using git 1.8.1
Using kramdown 2.3.1
Using parser 3.0.1.1
Using terminal-table 1.8.0
Using xcodeproj 1.19.0
Using xcpretty 0.3.0
Using nokogiri 1.11.4 (x86_64-darwin)
Using progress_bar 1.3.3
Using pry 0.12.2
Using aws-sdk-core 3.110.0
Using claide-plugins 0.9.2
Using kramdown-parser-gfm 1.1.0
Using simplecov 0.16.1
Using xcpretty-travis-formatter 1.0.0
Using aws-sdk-kms 1.39.0
Using codecov 0.2.12
Using aws-sdk-s3 1.86.2
Using rspec-support 3.10.0
Using naturally 2.2.0
Using rspec-core 3.10.0
Using simctl 1.6.8
Using rspec_junit_formatter 0.4.1
Using tty-cursor 0.7.1
Using declarative-option 0.1.0
Using tty-spinner 0.9.3
Using optimist 3.0.1
Using rubocop-ast 1.5.0
Using diffy 3.4.0
Using faraday 1.4.1
Using unf_ext 0.0.7.7
Using faraday-http-cache 2.2.0
Using excon 0.78.1
Using rspec-expectations 3.10.0
Using rspec-mocks 3.10.0
Using rmagick 4.1.2
Using rspec 3.10.0
Using i18n 1.8.10
Using oj 3.11.5
Using activesupport 5.2.6
Using jsonlint 0.3.0
Using faraday_middleware 1.0.0
Using signet 0.14.0
Using google-cloud-env 1.4.0
Using googleauth 0.14.0
Using google-cloud-core 1.5.0
Using rainbow 3.0.0
Using representable 3.0.4
Using rubocop 1.15.0
Using hashdiff 1.0.1
Using unf 0.1.4
Using sawyer 0.8.2
Using domain_name 0.5.20190701
Using octokit 4.21.0
Using http-cookie 1.0.3
Using danger 8.2.3
Using google-api-client 0.38.0
Using rubocop-require_tools 0.1.2
Using google-cloud-storage 1.29.2
Using fastlane-plugin-wpmreleasetoolkit 1.0.1 (was 1.0.0) from source at `.` and installing its executables
Using webmock 3.11.1
Using danger-rubocop 0.8.1
Using faraday-cookie_jar 0.0.7
Using rubocop-rspec 2.3.0
Using fastlane 2.170.0
Bundle complete! 16 Gemfile dependencies, 138 gems now installed.
Bundled gems are installed into `./vendor/bundle`
>>> Updating CHANGELOG...
>>> Testing that the gem builds and installs...
gem build fastlane-plugin-wpmreleasetoolkit.gemspec
  Successfully built RubyGem
  Name: fastlane-plugin-wpmreleasetoolkit
  Version: 1.0.1
  File: fastlane-plugin-wpmreleasetoolkit-1.0.1.gem
gem uninstall fastlane-plugin-wpmreleasetoolkit -v 1.0.0
Gem 'fastlane-plugin-wpmreleasetoolkit' is not installed
gem install fastlane-plugin-wpmreleasetoolkit-1.0.0.gem
Building native extensions. This could take a while...
Successfully installed fastlane-plugin-wpmreleasetoolkit-1.0.0
Parsing documentation for fastlane-plugin-wpmreleasetoolkit-1.0.0
Done installing documentation for fastlane-plugin-wpmreleasetoolkit after 0 seconds
1 gem installed
git add lib/fastlane/plugin/wpmreleasetoolkit/version.rb Gemfile.lock CHANGELOG.md
git commit -m Bumped to version 1.0.1
[release/1.0.1 ca99691] Bumped to version 1.0.1
 3 files changed, 10 insertions(+), 6 deletions(-)
git push origin release/1.0.1
Enumerating objects: 17, done.
Counting objects: 100% (17/17), done.
Delta compression using up to 16 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (9/9), 726 bytes | 726.00 KiB/s, done.
Total 9 (delta 5), reused 0 (delta 0)
remote: Resolving deltas: 100% (5/5), completed with 5 local objects.
To github.com:wordpress-mobile/release-toolkit.git
   018963b..ca99691  release/1.0.1 -> release/1.0.1
>>> Opening PR drafts in your default browser...
open https://github.com/wordpress-mobile/release-toolkit/compare/develop...release/1.0.1?expand=1&title=Release%201.0.1%20into%20develop&body=New%20version%201.0.1
open https://github.com/wordpress-mobile/release-toolkit/compare/trunk...release/1.0.1?expand=1&title=Release%201.0.1%20into%20trunk&body=New%20version%201.0.1.%20Be%20sure%20to%20create%20a%20GitHub%20Release%20and%20tag%20once%20this%20PR%20gets%20merged.

---------------

>>> WHAT'S NEXT

1. Create PRs to `develop` and `trunk`.
2. Once the PRs are merged, publish a GitHub release for `1.0.1`, targeting `trunk`,
   creating a new `1.0.1 tag in the process.

The creation of the new tag will trigger a CI workflow that will take care of doing the
`gem push` of the new version to RubyGems.

```
</details>

Note: I obviously haven't yet tested the `gem push` steps from CI, since those are currently configured to push on tag. Hopefully that will work on first try (if not I will delete the tag, try to fix CI, and recreate the tag all manually)