### PR TITLE
Fix CI setup to create releases (-> trunk)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,20 +7,24 @@ orbs:
 commands:
   setup_tools:
     description: "Install Homebrew and Ruby dependencies"
+    parameters:
+      skip_brew_install:
+        type: boolean
+        default: false
     steps:
       - restore_cache:
           name: Restore Homebrew + Ruby Dependencies
           keys:
             - &cache_key brew-dependencies-{{ checksum ".circleci/.brewfile" }}-{{ checksum "Gemfile.lock" }}
-
-      - run:
-          name: Install Homebrew dependencies, if neeeded
-          command: brew update && xargs brew install --verbose < .circleci/.brewfile
-
+      - unless:
+          condition: <<parameters.skip_brew_install>>
+          steps:
+            - run:
+                name: Install Homebrew dependencies, if neeeded
+                command: brew update && xargs brew install --verbose < .circleci/.brewfile
       - run:
           name: Install Ruby dependencies, if neeeded
           command: bundle check --path vendor/bundle || bundle install --with screenshots
-
       - save_cache:
           name: Cache Homebrew + Ruby Dependencies
           key: *cache_key
@@ -61,18 +65,16 @@ jobs:
     executor:
       name: ios/default
       xcode-version: "11.2.1" # We need an Xcode-enabled CI image to build drawText during gem build
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      PKG_CONFIG_PATH: "/usr/local/opt/imagemagick@6/lib/pkgconfig"
     steps:
       - checkout
-      - setup_tools
+      - setup_tools:
+          skip_brew_install: true
       - run:
           name: Build gem
           command: gem build fastlane-plugin-wpmreleasetoolkit.gemspec
       - run:
           name: Check the gem is installable
-          command: gem install fastlane-plugin-wpmreleasetoolkit-*.gem
+          command: gem install --user-install fastlane-plugin-wpmreleasetoolkit-*.gem
       - run:
           name: Push to RubyGems
           command: gem push fastlane-plugin-wpmreleasetoolkit-*.gem

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,10 @@ jobs:
           command: gem install --user-install fastlane-plugin-wpmreleasetoolkit-*.gem
       - run:
           name: Push to RubyGems
-          command: gem push fastlane-plugin-wpmreleasetoolkit-*.gem
+          command: |
+            echo ":rubygems_api_key: ${GEM_HOST_API_KEY}" >>"$HOME/.gem/credentials"
+            chmod 600 "$HOME/.gem/credentials"
+            gem push fastlane-plugin-wpmreleasetoolkit-*.gem
 
 workflows:
   test:


### PR DESCRIPTION
Since the initial CircleCI setup steps failed to push `1.0.1`, I fixed the `.circleci/config.yml` in a dedicated branch (cut from `trunk`) and deleted the old `1.0.1` tag to recreate it on top of this fix.

The fix:
 - Avoids installing `brew` dependencies that are not needed for `gem build` and `gem push`, avoiding to waste CI time unnecessarily
 - Test the install of the gem using `--user-install` to avoid permission issues of trying to install it system-wide
 - Setup the RubyGems credentials file before calling `gem push` (the [RubyGems doc](https://guides.rubygems.org/command-reference/#gem-push) made me wrongly believe having the `GEM_HOST_API_KEY` env var set would be enough, but apparently not)

Now merging this fix back into `trunk`.