### PR TITLE
Fix a bug in the `plugin_root` method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,12 @@ commands:
           steps:
             - run:
                 name: Install Homebrew dependencies, if neeeded
-                command: brew update && xargs brew install --verbose < .circleci/.brewfile
+                command: |
+                  # Because the CircleCI image uses shallow clones, we need to unshallow them first. See https://bit.ly/3vx6EAL
+                  git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
+                  git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+
+                  brew update && xargs brew install --verbose < .circleci/.brewfile
       - run:
           name: Install Ruby dependencies, if neeeded
           command: bundle check --path vendor/bundle || bundle install --with screenshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+Fixes a bug that was breaking the `promo_screenshots` helper [#276]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -36,7 +36,8 @@ module Fastlane
         while continue
           child_filenames = dir.children.map! { |x| File.basename(x) }
 
-          if child_filenames.include? 'fastlane-plugin-wpmreleasetoolkit.gemspec'
+          # The first option is for development (where the .gemspec is present in the project root), the second is for production (where it is not)
+          if child_filenames.include?('fastlane-plugin-wpmreleasetoolkit.gemspec') || File.basename(dir).include?('fastlane-plugin-wpmreleasetoolkit')
             continue = false
           else
             dir = dir.parent

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -38,7 +38,7 @@ module Fastlane
 
           # The first case is for development – where the `.gemspec` is present in the project root
           # The second case is for production – where there's no `.gemspec`, but the root dir of the plugin is named `fastlane-plugin-wpmreleasetoolkit-{version}`.
-          if child_filenames.include?('fastlane-plugin-wpmreleasetoolkit.gemspec') || File.basename(dir).start_with?('fastlane-plugin-wpmreleasetoolkit')
+          if child_filenames.include?('fastlane-plugin-wpmreleasetoolkit.gemspec') || File.basename(dir).start_with?('fastlane-plugin-wpmreleasetoolkit-')
             continue = false
           else
             dir = dir.parent

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -36,8 +36,9 @@ module Fastlane
         while continue
           child_filenames = dir.children.map! { |x| File.basename(x) }
 
-          # The first option is for development (where the .gemspec is present in the project root), the second is for production (where it is not)
-          if child_filenames.include?('fastlane-plugin-wpmreleasetoolkit.gemspec') || File.basename(dir).include?('fastlane-plugin-wpmreleasetoolkit')
+          # The first case is for development – where the `.gemspec` is present in the project root
+          # The second case is for production – where there's no `.gemspec`, but the root dir of the plugin is named `fastlane-plugin-wpmreleasetoolkit-{version}`.
+          if child_filenames.include?('fastlane-plugin-wpmreleasetoolkit.gemspec') || File.basename(dir).start_with?('fastlane-plugin-wpmreleasetoolkit')
             continue = false
           else
             dir = dir.parent


### PR DESCRIPTION
When generating promo screenshots, the error `Unable to determine the plugin root directory` would come up – this fixes it by better determining the location of the plugin root in production environments (where the .gemspec file would not be present in `fastlane-plugin-wpmreleasetoolkit`.

**To Test:**
Run https://github.com/wordpress-mobile/WordPress-iOS/pull/16571 before and after this PR (don't bother with any of the setup steps – just checking out the branch, updating the reference to the release toolkit to point at this branch, and running `bundle exec fastlane create_jetpack_promo_screenshots` will expose the error)