### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+Update the `BigDecimal` and `ActiveSupport` gems to clean up our `Gemfile` and improve future compatibility.
 
 ## 1.3.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     fastlane-plugin-wpmreleasetoolkit (1.3.1)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
+      activesupport (~> 6.0)
+      bigdecimal (~> 2.0)
       chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
@@ -19,11 +19,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.6)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     artifactory (3.0.15)
@@ -46,7 +47,7 @@ GEM
     aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
-    bigdecimal (1.4.4)
+    bigdecimal (2.0.3)
     chroma (0.2.0)
     claide (1.0.3)
     claide-plugins (0.9.2)
@@ -312,14 +313,13 @@ GEM
     simplecov-html (0.10.2)
     terminal-notifier (2.0.0)
     terminal-table (1.6.0)
-    thread_safe (0.3.6)
     trailblazer-option (0.1.1)
     tty-cursor (0.7.1)
     tty-screen (0.8.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
@@ -342,6 +342,7 @@ GEM
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
     yard (0.9.26)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -365,4 +366,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.16
+   2.2.22

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -43,13 +43,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'progress_bar', '~> 1.3'
   spec.add_dependency 'parallel', '~> 1.14'
   spec.add_dependency 'chroma', '0.2.0'
-  spec.add_dependency 'activesupport', '~> 5'
-  # Some of the upstream code uses `BigDecimal.new` which version 2.0 of the
-  # `bigdecimal` gem removed. Until we'll find the time to identify the
-  # dependencies and see if we can move them to something compatible with
-  # modern `bigdecimal`, let's constrain the gem to a version still supporting
-  # `.new` but which warns about it deprecation.
-  spec.add_dependency 'bigdecimal', '~> 1.4'
+  spec.add_dependency 'activesupport', '~> 6.0'
+  spec.add_dependency 'bigdecimal', '~> 2.0'
 
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
Updates the `bigdecimal` dependency to the latest version (along with active support).

**To Test**
- Ensure tests pass

There's a good argument to be made for this being a breaking change (given the fact that the underlying dependencies have major version changes).

I don't feel strongly about it either way, but I don't think we use either ActiveSupport or BigDecimal directly, so it _shouldn't_ matter?