### PR TITLE
Fix crashes after testing beta lanes post 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Fix crashes introduced in `1.3.0` – incorrect parameters in calls to `get_release_version`. [#283]
+* Fix the way versioning is handled for alphas – i.e. `version.properties` is indexed by flavor name, defaulting to `zalpha` for alphas. [#283]
 
 ### Internal Changes
 
@@ -25,7 +26,7 @@ _None_
 ### New Features
 
 * Support for a `version.properties` to manage app versioning - all existing paths remain intact and new paths are only used when a `version.properties` file is present.
-* Add support for providing an `app:` parameter to most versioning-related actions to allow support for multiple apps hosted in a monorepo
+* Add support for providing an `app:` parameter to most versioning-related actions to allow support for multiple apps hosted in a monorepo.
 * Supporting the new `version.properties` file also allows for the `HAS_ALPHA_VERSION` variable to be removed as the alpha reference in the properties file will be used going forward.
 * Clients adopting the new `version.properties` will need to implement a gradle task named `updateVersionProperties` to update the `version.properties` file.
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -14,18 +14,18 @@ module Fastlane
         app = params[:app]
 
         # Check versions
-        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(app)
+        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
         message = "[#{app}] The following current version has been detected: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n"
         alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app)
         message << "[#{app}] The following Alpha version has been detected: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
 
         # Check branch
-        app_version = Fastlane::Helper::Android::VersionHelper.get_public_version
+        app_version = Fastlane::Helper::Android::VersionHelper.get_public_version(app)
         UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless !params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version)
 
         # Check user overwrite
         unless params[:base_version].nil?
-          overwrite_version = get_user_build_version(params[:base_version], message)
+          overwrite_version = get_user_build_version(product_name: app, version: params[:base_version], message: message)
           release_version = overwrite_version[0]
           alpha_release_version = overwrite_version[1]
         end
@@ -49,11 +49,11 @@ module Fastlane
         [next_beta_version, next_alpha_version]
       end
 
-      def self.get_user_build_version(version, message)
+      def self.get_user_build_version(product_name:, version:, message:)
         UI.user_error!("[#{app}] Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::GitHelper.checkout_and_pull(release: version)
-        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version
+        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: product_name)
         message << "#{app}] Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}.\n"
-        alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version
+        alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(product_name)
         message << "and Alpha Version: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
         [release_version, alpha_release_version]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         app = params[:app]
         message = ''
-        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version(app) unless !params[:beta] && !params[:final]
+        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app) unless !params[:beta] && !params[:final]
         alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app) if params[:alpha]
 
         UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -14,7 +14,7 @@ module Fastlane
         UI.user_error!('This is not a release branch. Abort.') unless other_action.git_branch.start_with?('release/')
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version(params[:app])
-        message = "Finalizing release: #{version}\n"
+        message = "Finalizing #{params[:app]} release: #{version}\n"
         if params[:skip_confirm]
           UI.message(message)
         else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -7,7 +7,7 @@ module Fastlane
 
         app = ENV['PROJECT_NAME'].nil? ? params[:app] : ENV['PROJECT_NAME']
 
-        release_ver = Fastlane::Helper::Android::VersionHelper.get_release_version(app)
+        release_ver = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
         alpha_ver = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app)
         Fastlane::Helper::GitHelper.create_tag(release_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME])
         Fastlane::Helper::GitHelper.create_tag(alpha_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]) unless alpha_ver.nil? || (params[:tag_alpha] == false)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -42,7 +42,7 @@ module Fastlane
 
         # Extract the version name and code from the release version of the app from `version.properties file`
         #
-        # @param [String] app The name of the app to be used for beta and alpha version update
+        # @param [String] product_name The name of the app to be used for beta and alpha version update
         #
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -6,8 +6,8 @@ describe Fastlane::Helper::Android::VersionHelper do
       test_file_content = <<~CONTENT
         wordpress.versionName=17.0
         wordpress.versionCode=123
-        wordpress.alpha.versionName=alpha-222
-        wordpress.alpha.versionCode=1234
+        wordpress.zalpha.versionName=alpha-222
+        wordpress.zalpha.versionCode=1234
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
@@ -19,8 +19,8 @@ describe Fastlane::Helper::Android::VersionHelper do
       test_file_content = <<~CONTENT
         wordpress.versionName=17.0
         wordpress.versionCode=123
-        wordpress.alpha.versionName=alpha-222
-        wordpress.alpha.versionCode=1234
+        wordpress.zalpha.versionName=alpha-222
+        wordpress.zalpha.versionCode=1234
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)


### PR DESCRIPTION
As I started using the new `1.3.0` release-toolkit to generate WordPress 17.6-rc-4, Jetpack 17.6-rc-4, I encountered some crashes, that this PR intends to fix.

Depending if I run into issues during the final release on Friday, I might need to ad more fixes to this PR before we consider a new release, but the changes that are in so far are already improving the current state and ready to be reviewed.

\cc @JavonDavis for your information