### PR TITLE
Fix the translation progress action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in Glotpress.
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in Glotpress.
+* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in GlotPress.
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        # The status is parsed from Glotpress project page.
+        # The status is parsed from the GlotPress project page.
         # The row can be identified by the language code and the progress is in the column identified by the class "stats percent".
         # When the progress is above 90%, a special badge is added.
         # Because of the way the HTML is organized, this regex matches content spawned on three or four lines

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        regex = "<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*<span.*>([0-9]+)%<\\/span>"
+        regex = "$\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*\\n*.*\\n*.*<td class=\"stats percent\">([0-9]+)%<\/td>$"
 
         # 1. Grep the line with contains the required info.
         # 2. Match the info and extract the value in group 1.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,12 +26,13 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        current = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'current')
-        fuzzy = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'fuzzy')
-        untranslated = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'untranslated')
-        waiting = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'waiting')
+        regex = "<strong><a href=\".*\/#{language_code}\/default\/\">.*<\/strong>\n<span.*>([0-9]+)%<\/span>"
 
-        (current * 100 / (current + fuzzy + untranslated + waiting)).round
+        # 1. Grep the line with contains the required info.
+        # 2. Match the info and extract the value in group 1.
+        # 3. Convert to integer.
+        puts data
+        data.grep(/#{regex}/)[0].match(/#{regex}/)[1].to_i
       end
 
       # Extract the number of strings which are in the given status.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,9 +26,32 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        regex = "$\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*\\n*.*\\n*.*<td class=\"stats percent\">([0-9]+)%<\/td>$"
+        # The status is parsed from Glotpress project page.
+        # The row can be identified by the language code and the progress is in the column identified by the class "stats percent".
+        # When the progress is above 90%, a special badge is added.
+        # Because of the way the HTML is organized, this regex matches content spawned on three or four lines
+        # Regex:
+        # ^           : start of a line
+        # \s*         : any space
+        # <strong><a href=".*\/#{language_code}\/default\/"> : This link contains the language code of that line in the HTML table, so it's a reliable match
+        # .*          : any character. The language name should be here, but it can be less reliable than the language code as a match
+        # <\/strong>  : tag closure
+        # \n          : new line
+        # (?:         : match the following. This starts the "morethan90" special badge, which we expect to exist zero or one times (see the closure of this part of the regex).
+        #       \s*         : any space
+        #       <span class="bubble morethan90"> : Start of the special badge
+        #       \d\d\d?%    : 2 or 3 digits and the percentage char
+        #       <\/span>\n  : Special badge closure and new line
+        # )?          : end of the "morethan90" special badge section. Expect this zero or one times.
+        # \s*<\/td>\n : column closure tag. Any space before of it are ok. Expect new line after it.
+        # \s*         : any space
+        # <td class="stats percent"> : This is the tag which can be used to extract the progress
+        # ([0-9]+)    : progress is the first group
+        # %<\/td>     : tag closure
+        regex = "^\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n"
+        regex += "(?:\\s*<span class=\"bubble morethan90\">\\d\\d\\d?%<\\/span>\\n)?\\s*<\\/td>\\n\\s*<td class=\"stats percent\">([0-9]+)%<\\/td>$"
 
-        # 1. Grep the line with contains the required info.
+        # 1. Merge the array into a single string.
         # 2. Match the info and extract the value in group 1.
         # 3. Convert to integer.
         data.join("\n").match(/#{regex}/)[1].to_i

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,13 +26,12 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        regex = "<strong><a href=\".*\/#{language_code}\/default\/\">.*<\/strong>\n<span.*>([0-9]+)%<\/span>"
+        regex = "<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*<span.*>([0-9]+)%<\\/span>"
 
         # 1. Grep the line with contains the required info.
         # 2. Match the info and extract the value in group 1.
         # 3. Convert to integer.
-        puts data
-        data.grep(/#{regex}/)[0].match(/#{regex}/)[1].to_i
+        data.join("\n").match(/#{regex}/)[1].to_i
       end
 
       # Extract the number of strings which are in the given status.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -49,7 +49,7 @@ module Fastlane
         # ([0-9]+)    : progress is the first group
         # %<\/td>     : tag closure
         regex = "^\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n"
-        regex += "(?:\\s*<span class=\"bubble morethan90\">\\d\\d\\d?%<\\/span>\\n)?\\s*<\\/td>\\n\\s*<td class=\"stats percent\">([0-9]+)%<\\/td>$"
+        regex += '(?:\s*<span class="bubble morethan90">\d\d\d?%<\/span>\n)?\s*<\/td>\n\s*<td class="stats percent">([0-9]+)%<\/td>$'
 
         # 1. Merge the array into a single string.
         # 2. Match the info and extract the value in group 1.

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -345,8 +345,11 @@ def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:
 end
 
 def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
-  res = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-  res << "<span#{ progress.to_i > 90 ? ' class="bubble morethan90"' : '' }>#{progress}%</span>\n"
+  res = "<td>\n"
+  res << "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
+  res << "<span class=\"bubble morethan90\"}>#{progress}%</span>\n" if progress.to_i > 90
+  res << "</td>\n"
+  res << "<td class=\"stats percent\">#{progress}%</td>\n"
 end
 
 def generate_glotpress_response_for_language_status(lang_code:, status_main:, status:, string_count:)

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -335,37 +335,29 @@ def generate_glotpress_response_header
 end
 
 def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:, progress:)
-  lang << <<~LANG
+  res = <<~LANG
     <tr class="odd">
     		<td>
   LANG
 
-  lang << "<strong><a href=\"/projects/apps/android/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-
-  lang << <<~LANG
-        <span class="bubble morethan90">anyperc%</span>
-    </td>
-    <td class="stats percent">anyperc%</td>
-  LANG
-
-  lang << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'untranslated', status: 'untranslated', string_count: waiting)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'waiting', status: 'waiting', string_count: untranslated)
-  lang <<	'</tr>'
+  res << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'untranslated', status: 'untranslated', string_count: waiting)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'waiting', status: 'waiting', string_count: untranslated)
+  res <<	'</tr>'
 end
 
 def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
-  lang = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-  lang << "<span#{ progress.to_i > 90 ? 'class=" bubble morethan90"' : '' }>#{progress}%</span>\n"
+  res = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
+  res << "<span#{ progress.to_i > 90 ? ' class="bubble morethan90"' : '' }>#{progress}%</span>\n"
 end
 
 def generate_glotpress_response_for_language_status(lang_code:, status_main:, status:, string_count:)
-  lang = "<td class=\"stats #{status_main}\" title=\"#{status_main}\">\n"
-  lang << "<a href=\"/projects/apps/whatever/dev/#{lang_code}/default/?filters%5Btranslated%5D=yes&#038;filters%5Bstatus%5D=#{status}\">#{string_count}</a></td>"
+  res = "<td class=\"stats #{status_main}\" title=\"#{status_main}\">\n"
+  res << "<a href=\"/projects/apps/whatever/dev/#{lang_code}/default/?filters%5Btranslated%5D=yes&#038;filters%5Bstatus%5D=#{status}\">#{string_count}</a></td>"
 
-  lang
+  res
 end
 
 def generate_glotpress_response_footer

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -335,11 +335,7 @@ def generate_glotpress_response_header
 end
 
 def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:, progress:)
-  res = <<~LANG
-    <tr class="odd">
-    		<td>
-  LANG
-
+  res = "<tr class=\"odd\">\n"
   res << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
   res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
   res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -347,7 +347,7 @@ end
 def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
   res = "<td>\n"
   res << "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-  res << "<span class=\"bubble morethan90\"}>#{progress}%</span>\n" if progress.to_i > 90
+  res << "<span class=\"bubble morethan90\">#{progress}%</span>\n" if progress.to_i > 90
   res << "</td>\n"
   res << "<td class=\"stats percent\">#{progress}%</td>\n"
 end

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -9,9 +9,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'does not fail when all the languages are above the set threshold' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4', progress: '99' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '99' },
     ]
 
     stub = stub_request(
@@ -38,8 +38,8 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'fails on missing data for a language' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4', progress: '99' },
     ]
 
     stub = stub_request(
@@ -95,10 +95,10 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'fails when one the language is below the set threshold' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
       # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '99' },
     ]
 
     stub = stub_request(
@@ -125,10 +125,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and asks user confirmation when one the language is below the threshold and aborting is disabled' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '99' },
     ]
 
     stub = stub_request(
@@ -162,11 +161,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and asks user confirmation when multiples languages are below the threshold and aborting is disabled' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      # Mock de to be translated at 75%
-      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502', progress: '75' },
     ]
 
     stub = stub_request(
@@ -201,11 +198,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and continues when one the language is below the threshold, aborting is disabled and confirmation is skipped' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      # Mock de to be translated at 75%
-      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502', progress: '75' },
     ]
 
     stub = stub_request(
@@ -239,10 +234,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and continues when multiple languages are below the threshold, aborting is disabled and confirmation is skipped' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '100' },
     ]
 
     stub = stub_request(
@@ -284,7 +278,8 @@ def generate_glotpress_response_body(languages:)
       current: language[:current],
       fuzzy: language[:fuzzy],
       waiting: language[:waiting],
-      untranslated: language[:untranslated]
+      untranslated: language[:untranslated],
+      progress: language[:progress]
     )
   end
 
@@ -311,7 +306,7 @@ def generate_glotpress_response_header
   HEADER
 end
 
-def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:)
+def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:, progress:)
   lang << <<~LANG
     <tr class="odd">
     		<td>
@@ -325,11 +320,17 @@ def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:
     <td class="stats percent">anyperc%</td>
   LANG
 
+  lang << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'untranslated', status: 'untranslated', string_count: waiting)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'waiting', status: 'waiting', string_count: untranslated)
   lang <<	'</tr>'
+end
+
+def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
+  lang = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
+  lang << "<span #{ progress.to_i > 90 ? 'class="bubble morethan90"' : '' }>#{progress}%</span>\n"
 end
 
 def generate_glotpress_response_for_language_status(lang_code:, status_main:, status:, string_count:)


### PR DESCRIPTION
In https://github.com/wordpress-mobile/release-toolkit/pull/263 we introduced a new action which checks the state of the translations on GlotPress.
Since there's no API on GlotPress to get this information, the action extracts the important data from the GlotPress project page. 

While the information about the percentage of translated strings is available in that page, it's a bit difficult to parse because of the layout of the page itself. Extracting the number of `Translated`, `Fuzzy`, `Untranslated` and `Waiting` strings is far easier and the first implementation of the lane used those value to calculate the percentage of the translated strings. 

This is generally acceptable, but it turned out there are edge cases where it may result in pessimistic estimations. 
In particular, it's possible that a string has a current, valid translation, but it also has a pending proposal for a different one. In this case, the number of `Waiting` strings can be higher than 0 even when all the strings are translated, which causes a slightly wrong evaluation of the progress percentage. 
This is especially annoying in the projects where we require translations at 100%, because a single `Waiting` string can lower this number under the threshold. 

This PR updates the action to use a different approach and parse the percentage directly from the HTML page. This requires a regex which analyses text on three or four lines (depending on the case), so it's a bit more complex. A detailed explanation of the new regex is in the code. 

### To test
- Verify CI is green.
- Test on a live GlotPress repository (e.g. https://translate.wordpress.org/projects/apps/android/dev/). 


