### PR TITLE
Release/1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Fix crashes introduced in `1.3.0` – incorrect parameters in calls to `get_release_version`. [#283]
+* Fix the way versioning is handled for alphas – i.e. `version.properties` is indexed by flavor name, defaulting to `zalpha` for alphas. [#283]
 
 ### Internal Changes
 
@@ -25,7 +26,7 @@ _None_
 ### New Features
 
 * Support for a `version.properties` to manage app versioning - all existing paths remain intact and new paths are only used when a `version.properties` file is present.
-* Add support for providing an `app:` parameter to most versioning-related actions to allow support for multiple apps hosted in a monorepo
+* Add support for providing an `app:` parameter to most versioning-related actions to allow support for multiple apps hosted in a monorepo.
 * Supporting the new `version.properties` file also allows for the `HAS_ALPHA_VERSION` variable to be removed as the alpha reference in the properties file will be used going forward.
 * Clients adopting the new `version.properties` will need to implement a gradle task named `updateVersionProperties` to update the `version.properties` file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in Glotpress.
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in Glotpress.
+* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in GlotPress.
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,20 @@ _None_
 
 ### Bug Fixes
 
-* Fix crashes introduced in `1.3.0` – incorrect parameters in calls to `get_release_version`. [#283]
-* Fix the way versioning is handled for alphas – i.e. `version.properties` is indexed by flavor name, defaulting to `zalpha` for alphas. [#283]
-* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in GlotPress.
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 1.3.1
+
+### Bug Fixes
+
+* Fix crashes introduced in `1.3.0` – incorrect parameters in calls to `get_release_version`. [#283]
+* Fix the way versioning is handled for alphas – i.e. `version.properties` is indexed by flavor name, defaulting to `zalpha` for alphas. [#283]
+* Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in GlotPress.
+
 
 ## 1.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (1.3.0)
+    fastlane-plugin-wpmreleasetoolkit (1.3.1)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -228,7 +228,7 @@ GEM
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.6)
+    oj (3.12.0)
     open4 (1.3.4)
     optimist (3.0.1)
     options (2.3.2)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -14,18 +14,18 @@ module Fastlane
         app = params[:app]
 
         # Check versions
-        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(app)
+        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
         message = "[#{app}] The following current version has been detected: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n"
         alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app)
         message << "[#{app}] The following Alpha version has been detected: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
 
         # Check branch
-        app_version = Fastlane::Helper::Android::VersionHelper.get_public_version
+        app_version = Fastlane::Helper::Android::VersionHelper.get_public_version(app)
         UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless !params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version)
 
         # Check user overwrite
         unless params[:base_version].nil?
-          overwrite_version = get_user_build_version(params[:base_version], message)
+          overwrite_version = get_user_build_version(product_name: app, version: params[:base_version], message: message)
           release_version = overwrite_version[0]
           alpha_release_version = overwrite_version[1]
         end
@@ -49,11 +49,11 @@ module Fastlane
         [next_beta_version, next_alpha_version]
       end
 
-      def self.get_user_build_version(version, message)
+      def self.get_user_build_version(product_name:, version:, message:)
         UI.user_error!("[#{app}] Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::GitHelper.checkout_and_pull(release: version)
-        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version
+        release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: product_name)
         message << "#{app}] Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}.\n"
-        alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version
+        alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(product_name)
         message << "and Alpha Version: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
         [release_version, alpha_release_version]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         app = params[:app]
         message = ''
-        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version(app) unless !params[:beta] && !params[:final]
+        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app) unless !params[:beta] && !params[:final]
         alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app) if params[:alpha]
 
         UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -14,7 +14,7 @@ module Fastlane
         UI.user_error!('This is not a release branch. Abort.') unless other_action.git_branch.start_with?('release/')
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version(params[:app])
-        message = "Finalizing release: #{version}\n"
+        message = "Finalizing #{params[:app]} release: #{version}\n"
         if params[:skip_confirm]
           UI.message(message)
         else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -7,7 +7,7 @@ module Fastlane
 
         app = ENV['PROJECT_NAME'].nil? ? params[:app] : ENV['PROJECT_NAME']
 
-        release_ver = Fastlane::Helper::Android::VersionHelper.get_release_version(app)
+        release_ver = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
         alpha_ver = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app)
         Fastlane::Helper::GitHelper.create_tag(release_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME])
         Fastlane::Helper::GitHelper.create_tag(alpha_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]) unless alpha_ver.nil? || (params[:tag_alpha] == false)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -42,7 +42,7 @@ module Fastlane
 
         # Extract the version name and code from the release version of the app from `version.properties file`
         #
-        # @param [String] app The name of the app to be used for beta and alpha version update
+        # @param [String] product_name The name of the app to be used for beta and alpha version update
         #
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        # The status is parsed from Glotpress project page.
+        # The status is parsed from the GlotPress project page.
         # The row can be identified by the language code and the progress is in the column identified by the class "stats percent".
         # When the progress is above 90%, a special badge is added.
         # Because of the way the HTML is organized, this regex matches content spawned on three or four lines

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,7 +26,7 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        regex = "<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*<span.*>([0-9]+)%<\\/span>"
+        regex = "$\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*\\n*.*\\n*.*<td class=\"stats percent\">([0-9]+)%<\/td>$"
 
         # 1. Grep the line with contains the required info.
         # 2. Match the info and extract the value in group 1.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,12 +26,13 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        current = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'current')
-        fuzzy = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'fuzzy')
-        untranslated = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'untranslated')
-        waiting = extract_value_from_translation_info_data(data: data, language_code: language_code, status: 'waiting')
+        regex = "<strong><a href=\".*\/#{language_code}\/default\/\">.*<\/strong>\n<span.*>([0-9]+)%<\/span>"
 
-        (current * 100 / (current + fuzzy + untranslated + waiting)).round
+        # 1. Grep the line with contains the required info.
+        # 2. Match the info and extract the value in group 1.
+        # 3. Convert to integer.
+        puts data
+        data.grep(/#{regex}/)[0].match(/#{regex}/)[1].to_i
       end
 
       # Extract the number of strings which are in the given status.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,9 +26,32 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        regex = "$\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*\\n*.*\\n*.*<td class=\"stats percent\">([0-9]+)%<\/td>$"
+        # The status is parsed from Glotpress project page.
+        # The row can be identified by the language code and the progress is in the column identified by the class "stats percent".
+        # When the progress is above 90%, a special badge is added.
+        # Because of the way the HTML is organized, this regex matches content spawned on three or four lines
+        # Regex:
+        # ^           : start of a line
+        # \s*         : any space
+        # <strong><a href=".*\/#{language_code}\/default\/"> : This link contains the language code of that line in the HTML table, so it's a reliable match
+        # .*          : any character. The language name should be here, but it can be less reliable than the language code as a match
+        # <\/strong>  : tag closure
+        # \n          : new line
+        # (?:         : match the following. This starts the "morethan90" special badge, which we expect to exist zero or one times (see the closure of this part of the regex).
+        #       \s*         : any space
+        #       <span class="bubble morethan90"> : Start of the special badge
+        #       \d\d\d?%    : 2 or 3 digits and the percentage char
+        #       <\/span>\n  : Special badge closure and new line
+        # )?          : end of the "morethan90" special badge section. Expect this zero or one times.
+        # \s*<\/td>\n : column closure tag. Any space before of it are ok. Expect new line after it.
+        # \s*         : any space
+        # <td class="stats percent"> : This is the tag which can be used to extract the progress
+        # ([0-9]+)    : progress is the first group
+        # %<\/td>     : tag closure
+        regex = "^\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n"
+        regex += "(?:\\s*<span class=\"bubble morethan90\">\\d\\d\\d?%<\\/span>\\n)?\\s*<\\/td>\\n\\s*<td class=\"stats percent\">([0-9]+)%<\\/td>$"
 
-        # 1. Grep the line with contains the required info.
+        # 1. Merge the array into a single string.
         # 2. Match the info and extract the value in group 1.
         # 3. Convert to integer.
         data.join("\n").match(/#{regex}/)[1].to_i

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -26,13 +26,12 @@ module Fastlane
       # @return [Integer] The percentage of the translated strings.
       #
       def self.get_translation_status(data:, language_code:)
-        regex = "<strong><a href=\".*\/#{language_code}\/default\/\">.*<\/strong>\n<span.*>([0-9]+)%<\/span>"
+        regex = "<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n.*<span.*>([0-9]+)%<\\/span>"
 
         # 1. Grep the line with contains the required info.
         # 2. Match the info and extract the value in group 1.
         # 3. Convert to integer.
-        puts data
-        data.grep(/#{regex}/)[0].match(/#{regex}/)[1].to_i
+        data.join("\n").match(/#{regex}/)[1].to_i
       end
 
       # Extract the number of strings which are in the given status.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -49,7 +49,7 @@ module Fastlane
         # ([0-9]+)    : progress is the first group
         # %<\/td>     : tag closure
         regex = "^\\s*<strong><a href=\".*\\/#{language_code}\\/default\\/\">.*<\\/strong>\\n"
-        regex += "(?:\\s*<span class=\"bubble morethan90\">\\d\\d\\d?%<\\/span>\\n)?\\s*<\\/td>\\n\\s*<td class=\"stats percent\">([0-9]+)%<\\/td>$"
+        regex += '(?:\s*<span class="bubble morethan90">\d\d\d?%<\/span>\n)?\s*<\/td>\n\s*<td class="stats percent">([0-9]+)%<\/td>$'
 
         # 1. Merge the array into a single string.
         # 2. Match the info and extract the value in group 1.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '1.3.0'
+    VERSION = '1.3.1'
   end
 end

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -6,8 +6,8 @@ describe Fastlane::Helper::Android::VersionHelper do
       test_file_content = <<~CONTENT
         wordpress.versionName=17.0
         wordpress.versionCode=123
-        wordpress.alpha.versionName=alpha-222
-        wordpress.alpha.versionCode=1234
+        wordpress.zalpha.versionName=alpha-222
+        wordpress.zalpha.versionCode=1234
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
@@ -19,8 +19,8 @@ describe Fastlane::Helper::Android::VersionHelper do
       test_file_content = <<~CONTENT
         wordpress.versionName=17.0
         wordpress.versionCode=123
-        wordpress.alpha.versionName=alpha-222
-        wordpress.alpha.versionCode=1234
+        wordpress.zalpha.versionName=alpha-222
+        wordpress.zalpha.versionCode=1234
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -345,8 +345,11 @@ def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:
 end
 
 def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
-  res = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-  res << "<span#{ progress.to_i > 90 ? ' class="bubble morethan90"' : '' }>#{progress}%</span>\n"
+  res = "<td>\n"
+  res << "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
+  res << "<span class=\"bubble morethan90\"}>#{progress}%</span>\n" if progress.to_i > 90
+  res << "</td>\n"
+  res << "<td class=\"stats percent\">#{progress}%</td>\n"
 end
 
 def generate_glotpress_response_for_language_status(lang_code:, status_main:, status:, string_count:)

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -335,37 +335,29 @@ def generate_glotpress_response_header
 end
 
 def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:, progress:)
-  lang << <<~LANG
+  res = <<~LANG
     <tr class="odd">
     		<td>
   LANG
 
-  lang << "<strong><a href=\"/projects/apps/android/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-
-  lang << <<~LANG
-        <span class="bubble morethan90">anyperc%</span>
-    </td>
-    <td class="stats percent">anyperc%</td>
-  LANG
-
-  lang << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'untranslated', status: 'untranslated', string_count: waiting)
-  lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'waiting', status: 'waiting', string_count: untranslated)
-  lang <<	'</tr>'
+  res << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'untranslated', status: 'untranslated', string_count: waiting)
+  res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'waiting', status: 'waiting', string_count: untranslated)
+  res <<	'</tr>'
 end
 
 def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
-  lang = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-  lang << "<span#{ progress.to_i > 90 ? 'class=" bubble morethan90"' : '' }>#{progress}%</span>\n"
+  res = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
+  res << "<span#{ progress.to_i > 90 ? ' class="bubble morethan90"' : '' }>#{progress}%</span>\n"
 end
 
 def generate_glotpress_response_for_language_status(lang_code:, status_main:, status:, string_count:)
-  lang = "<td class=\"stats #{status_main}\" title=\"#{status_main}\">\n"
-  lang << "<a href=\"/projects/apps/whatever/dev/#{lang_code}/default/?filters%5Btranslated%5D=yes&#038;filters%5Bstatus%5D=#{status}\">#{string_count}</a></td>"
+  res = "<td class=\"stats #{status_main}\" title=\"#{status_main}\">\n"
+  res << "<a href=\"/projects/apps/whatever/dev/#{lang_code}/default/?filters%5Btranslated%5D=yes&#038;filters%5Bstatus%5D=#{status}\">#{string_count}</a></td>"
 
-  lang
+  res
 end
 
 def generate_glotpress_response_footer

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -335,11 +335,7 @@ def generate_glotpress_response_header
 end
 
 def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:, progress:)
-  res = <<~LANG
-    <tr class="odd">
-    		<td>
-  LANG
-
+  res = "<tr class=\"odd\">\n"
   res << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
   res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
   res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -347,7 +347,7 @@ end
 def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
   res = "<td>\n"
   res << "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
-  res << "<span class=\"bubble morethan90\"}>#{progress}%</span>\n" if progress.to_i > 90
+  res << "<span class=\"bubble morethan90\">#{progress}%</span>\n" if progress.to_i > 90
   res << "</td>\n"
   res << "<td class=\"stats percent\">#{progress}%</td>\n"
 end

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -9,9 +9,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'does not fail when all the languages are above the set threshold' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4', progress: '99' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '99' },
     ]
 
     stub = stub_request(
@@ -38,8 +38,8 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'fails on missing data for a language' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '2,078', fuzzy: '2', waiting: '3', untranslated: '4', progress: '99' },
     ]
 
     stub = stub_request(
@@ -95,10 +95,10 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'fails when one the language is below the set threshold' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
       # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '99' },
     ]
 
     stub = stub_request(
@@ -125,10 +125,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and asks user confirmation when one the language is below the threshold and aborting is disabled' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '99' },
     ]
 
     stub = stub_request(
@@ -162,11 +161,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and asks user confirmation when multiples languages are below the threshold and aborting is disabled' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      # Mock de to be translated at 75%
-      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502', progress: '75' },
     ]
 
     stub = stub_request(
@@ -201,11 +198,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and continues when one the language is below the threshold, aborting is disabled and confirmation is skipped' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      # Mock de to be translated at 75%
-      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '1,585', fuzzy: '0', waiting: '0', untranslated: '502', progress: '75' },
     ]
 
     stub = stub_request(
@@ -239,10 +234,9 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 
   it 'prints the report and continues when multiple languages are below the threshold, aborting is disabled and confirmation is skipped' do
     langs = [
-      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0' },
-      # Mock de to be translated at 51%
-      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4' },
-      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2' },
+      { lang_name: 'arabic', lang_code: 'ar', current: '2,087', fuzzy: '0', waiting: '0', untranslated: '0', progress: '100' },
+      { lang_name: 'german', lang_code: 'de', current: '1,078', fuzzy: '2', waiting: '1003', untranslated: '4', progress: '51' },
+      { lang_name: 'spanish', lang_code: 'es', current: '2,085', fuzzy: '0', waiting: '0', untranslated: '2', progress: '100' },
     ]
 
     stub = stub_request(
@@ -284,7 +278,8 @@ def generate_glotpress_response_body(languages:)
       current: language[:current],
       fuzzy: language[:fuzzy],
       waiting: language[:waiting],
-      untranslated: language[:untranslated]
+      untranslated: language[:untranslated],
+      progress: language[:progress]
     )
   end
 
@@ -311,7 +306,7 @@ def generate_glotpress_response_header
   HEADER
 end
 
-def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:)
+def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:, progress:)
   lang << <<~LANG
     <tr class="odd">
     		<td>
@@ -325,11 +320,17 @@ def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:
     <td class="stats percent">anyperc%</td>
   LANG
 
+  lang << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'untranslated', status: 'untranslated', string_count: waiting)
   lang << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'waiting', status: 'waiting', string_count: untranslated)
   lang <<	'</tr>'
+end
+
+def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
+  lang = "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
+  lang << "<span #{ progress.to_i > 90 ? 'class="bubble morethan90"' : '' }>#{progress}%</span>\n"
 end
 
 def generate_glotpress_response_for_language_status(lang_code:, status_main:, status:, string_count:)


### PR DESCRIPTION
Merge `release/1.3.1` into `trunk` in order to release it. This is a bug fix only version, with these changes: 
- Fix crashes introduced in `1.3.0` – incorrect parameters in calls to `get_release_version`. [#283]
- Fix the way versioning is handled for alphas – i.e. `version.properties` is indexed by flavor name, defaulting to `zalpha` for alphas. [#283]
- Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in GlotPress. [#284]