### PR TITLE
Add option to skip updating Deliverfile to ios_bump_version_hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+* Add option to skip updating `Deliverfile` when creating a new hotfix version (`ios_bump_version_hotfix`) [#287]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -9,14 +9,18 @@ module Fastlane
         create_config(params[:previous_version], params[:version])
         show_config()
 
-        UI.message 'Updating Fastlane deliver file...'
-        Fastlane::Helper::Ios::VersionHelper.update_fastlane_deliver(@new_short_version)
-        UI.message 'Done!'
+        update_deliverfile = params[:skip_deliver] == false
+        if update_deliverfile
+          UI.message 'Updating Fastlane deliver file...'
+          Fastlane::Helper::Ios::VersionHelper.update_fastlane_deliver(@new_short_version)
+          UI.message 'Done!'
+        end
+
         UI.message 'Updating XcConfig...'
         Fastlane::Helper::Ios::VersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal)
         UI.message 'Done!'
 
-        Fastlane::Helper::Ios::GitHelper.commit_version_bump(include_deliverfile: true, include_metadata: false)
+        Fastlane::Helper::Ios::GitHelper.commit_version_bump(include_deliverfile: update_deliverfile, include_metadata: false)
 
         UI.message 'Done.'
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -47,6 +47,16 @@ module Fastlane
             description: 'The version to branch from',
             is_string: true
           ),
+          FastlaneCore::ConfigItem.new(
+            key: :skip_deliver,
+            env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_SKIP_DELIVER',
+            description: 'Skips Deliverfile key update',
+            is_string: false, # Boolean parameter
+            optional: true,
+            # Don't skip the Deliverfile by default. At the time of writing, 2 out of 3 consumers
+            # still have a Deliverfile.
+            default_value: false
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -34,18 +34,19 @@ module Fastlane
       end
 
       def self.available_options
-        # Define all options your action supports.
-
-        # Below a few examples
         [
-          FastlaneCore::ConfigItem.new(key: :version,
-                                       env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_VERSION',
-                                       description: 'The version of the hotfix',
-                                       is_string: true),
-          FastlaneCore::ConfigItem.new(key: :previous_version,
-                                       env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION',
-                                       description: 'The version to branch from',
-                                       is_string: true), # the default value if the user didn't provide one
+          FastlaneCore::ConfigItem.new(
+            key: :version,
+            env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_VERSION',
+            description: 'The version of the hotfix',
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :previous_version,
+            env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION',
+            description: 'The version to branch from',
+            is_string: true
+          ),
         ]
       end
 


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-iOS/pull/16805, made the WordPress and Jetpack iOS automation read the version value to apps to `deliver` from the `.xcconfig`. This makes updating that key in the `Deliverfile` unnecessary. In fact, that PR entirely removes the `Deliverfile`.

When it came time to code freeze WordPress/Jetpack iOS version 17.8, the lane failed because of the missing `Deliverfile`. I thought I'd fixed the issue, but I clearly missed the hotfix use case.

This PR adds a `skip_deliver` option to `ios_bump_version_hotfix` to mimic the one in `ios_bump_version_release`. I tested these changes "live" when creating the https://github.com/wordpress-mobile/WordPress-iOS/tree/release/17.7.1 hotfix.

## To test

1. Open WordPress iOS
3. Run `bundle exec new_hotfix_release version:17.7.1` (or whichever version you prefer)
4. Verify the process fails because `Deliverfile` can't be found

<img alt="image" src="https://user-images.githubusercontent.com/1218433/127798830-3760d835-ce05-4229-979b-6365446b0b52.png" width=300/>

1. Delete the new `release/*` branch that the `new_hotfix_release` lane created, both locally and on GitHub
1. [Point the release toolkit to this branch](https://github.com/wordpress-mobile/WordPress-iOS/commit/56ea967f52ccb1f63a2dc914f6774233d7f65111)
2. [Update the `ios_bump_version_hotfix` call to include `skip_deliver: true`](https://github.com/wordpress-mobile/WordPress-iOS/commit/d6a842f8e3a851176d7e1fa7058880b21f6ccc4f)
3. Run `bundle exec new_hotfix_release version:17.7.1` (or whichever version you prefer)
4. Verify the process succeeds

<img alt="image" src="https://user-images.githubusercontent.com/1218433/127800106-4fb0633d-96ac-44c8-b777-209cd1a49eec.png" width=300/>

1. Delete the new `release/*` branch that the `new_hotfix_release` lane created, both locally and on GitHub

---

Based on top of `revert-activesearch-v6-bump` branch for ease of review. Either I or GitHub will update the base appropriately before merging into `trunk`.