### PR TITLE
Fix hotfix actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Fix crashes in actions dealing with hotfixes. [#288]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -10,10 +10,11 @@ module Fastlane
         app = params[:app]
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
-        new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code]) # Note: this just puts the name/code values in a tuple, unchanged (no actual calc/bumping)
+        new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code]) # NOTE: this just puts the name/code values in a tuple, unchanged (no actual calc/bumping)
         new_release_branch = "release/#{params[:version_name]}"
 
-        name_key, code_key = [Fastlane::Helper::Android::VersionHelper::VERSION_NAME, Fastlane::Helper::Android::VersionHelper::VERSION_CODE]
+        name_key = Fastlane::Helper::Android::VersionHelper::VERSION_NAME
+        code_key = Fastlane::Helper::Android::VersionHelper::VERSION_CODE
         UI.message("Current version [#{app}]: #{current_version[name_key]} (#{current_version[code_key]})")
         UI.message("New hotfix version[#{app}]: #{new_version[name_key]} (#{new_version[code_key]})")
         UI.message("Release branch: #{new_release_branch}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -12,7 +12,7 @@ module Fastlane
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app)
         new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code]) # Note: this just puts the name/code values in a tuple, unchanged (no actual calc/bumping)
-        new_release_branch = "release/#{new_short_version}"
+        new_release_branch = "release/#{params[:version_name]}"
 
         name_key, code_key = [Fastlane::Helper::Android::VersionHelper::VERSION_NAME, Fastlane::Helper::Android::VersionHelper::VERSION_CODE]
         UI.message("Current version [#{app}]: #{current_version[name_key]} (#{current_version[code_key]})")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -10,7 +10,6 @@ module Fastlane
         app = params[:app]
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
-        current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app)
         new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code]) # Note: this just puts the name/code values in a tuple, unchanged (no actual calc/bumping)
         new_release_branch = "release/#{params[:version_name]}"
 
@@ -20,7 +19,7 @@ module Fastlane
         UI.message("Release branch: #{new_release_branch}")
 
         UI.message 'Updating app version...'
-        Fastlane::Helper::Android::VersionHelper.update_versions(app, new_version, current_version_alpha)
+        Fastlane::Helper::Android::VersionHelper.update_versions(app, new_version, nil)
         UI.message 'Done!'
 
         Fastlane::Helper::Android::GitHelper.commit_version_bump()

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -11,12 +11,12 @@ module Fastlane
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(product_name: app)
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(app)
-        new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code])
-        new_short_version = new_version_name
+        new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code]) # Note: this just puts the name/code values in a tuple, unchanged (no actual calc/bumping)
         new_release_branch = "release/#{new_short_version}"
 
-        UI.message("Current version[#{app}]: #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]})")
-        UI.message("New hotfix version[#{app}]: #{new_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}(#{new_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]})")
+        name_key, code_key = [Fastlane::Helper::Android::VersionHelper::VERSION_NAME, Fastlane::Helper::Android::VersionHelper::VERSION_CODE]
+        UI.message("Current version [#{app}]: #{current_version[name_key]} (#{current_version[code_key]})")
+        UI.message("New hotfix version[#{app}]: #{new_version[name_key]} (#{new_version[code_key]})")
         UI.message("Release branch: #{new_release_branch}")
 
         UI.message 'Updating app version...'
@@ -41,25 +41,22 @@ module Fastlane
       end
 
       def self.available_options
-        # Define all options your action supports.
-
-        # Below a few examples
         [
           FastlaneCore::ConfigItem.new(key: :version_name,
                                        env_name: 'FL_ANDROID_BUMP_VERSION_HOTFIX_VERSION',
-                                       description: 'The version of the hotfix',
+                                       description: 'The version name for the hotfix',
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :version_code,
                                        env_name: 'FL_ANDROID_BUMP_VERSION_HOTFIX_CODE',
-                                       description: 'The version of the hotfix'),
+                                       description: 'The version code for the hotfix'),
           FastlaneCore::ConfigItem.new(key: :previous_version_name,
                                        env_name: 'FL_ANDROID_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION',
                                        description: 'The version to branch from',
-                                       is_string: true), # the default value if the user didn't provide one
+                                       is_string: true),
           FastlaneCore::ConfigItem.new(key: :app,
                                        env_name: 'PROJECT_NAME',
                                        description: 'The name of the app to get the release version for',
-                                       is_string: true), # true: verifies the input is a string, false: every kind of value
+                                       is_string: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotifx_prechecks.rb
@@ -14,7 +14,7 @@ module Fastlane
 
         # Confirm
         message = "Requested Hotfix version: #{new_ver}\n"
-        message << "Branching from: #{prev_ver}\n"
+        message << "Branching from tag: #{prev_ver}\n"
 
         if params[:skip_confirm]
           UI.message(message)
@@ -50,13 +50,13 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :version_name,
                                        env_name: 'FL_ANDROID_HOTFIX_PRECHECKS_VERSION',
-                                       description: 'The version to work on', # a short description of this parameter
+                                       description: 'The hotfix version number to create',
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :skip_confirm,
                                        env_name: 'FL_ANDROID_HOTFIX_PRECHECKS_SKIPCONFIRM',
                                        description: 'Skips confirmation',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false), # the default value if the user didn't provide one
+                                       is_string: false, # Boolean
+                                       default_value: false),
         ]
       end
 


### PR DESCRIPTION
Fix crashes and issues with the hotfix actions.

Part of the paaHJt-1WQ-p2 project.

Links to PRs on the app repos' sides:
- [x] `WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/15037
- [x] `woocommerce-android`: https://github.com/woocommerce/woocommerce-android/pull/4454
- [x] ~`simplenote-android`~: no change needed (builds are still made locally not on CI for this one – @mokagio can you confirm?)
- [x] `WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/16880
- [x] `woocommerce-ios`: https://github.com/woocommerce/woocommerce-ios/pull/4703
- [x] `simplenote-ios`: https://github.com/Automattic/simplenote-ios/pull/1373
- [x] `simplenote-macos`: https://github.com/Automattic/simplenote-macos/pull/1010
- [x] ~`simplenote-electron`~: [Does not use the release toolkit](https://github.com/wordpress-mobile/release-toolkit/pull/288#issuecomment-887273865).