### PR TITLE
Opt-out form platform-specific gems installation in Bundler

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_SPECIFIC_PLATFORM: "false"
+BUNDLE_WITH: "test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
                   brew update && xargs brew install --verbose < .circleci/.brewfile
       - run:
           name: Install Ruby dependencies, if neeeded
-          command: bundle check --path vendor/bundle || bundle install --with screenshots
+          command: bundle check --path vendor/bundle || bundle install
       - save_cache:
           name: Cache Homebrew + Ruby Dependencies
           key: *cache_key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Gems
         run: |
           bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          BUNDLE_WITHOUT=test bundle install --jobs 4 --retry 3
 
       - name: Run Danger
         run: bundle exec danger

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .idea
 
 # Ruby / Bundler
-.bundle/
 vendor/bundle
 
 # Fastlane

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ _None_
 * Fix the way versioning is handled for alphas – i.e. `version.properties` is indexed by flavor name, defaulting to `zalpha` for alphas. [#283]
 * Fixed an issue in `check_translation_progress` where a wrong evaluation of the progress is possible when there are Waiting string in GlotPress.
 
+### Internal Changes
+
+* Opt-out from installing platform-specific gems with Bundler [#293]
 
 ## 1.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,7 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -269,7 +270,8 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.7-x86_64-darwin)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -415,4 +417,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.24
+   2.2.25


### PR DESCRIPTION
See discussion [here](https://github.com/wordpress-mobile/release-toolkit/pull/292#issuecomment-891758279)

To ensure the setting is persisted for every user of the repository, I decided to track the Bundler config file. This seems like a good idea anyway, even though Bundler currently has a [bug](https://github.com/rubygems/rubygems/issues/3708) resulting in that file being changed sometimes, which can be confusing for developers.