### PR TITLE
Strip trailing new lines in single line `msgid` when generating `.po[t]` file

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,6 +131,7 @@ RSpec/FilePath:
     - 'spec/android_localize_helper_spec.rb'
     - 'spec/android_merge_translators_strings_spec.rb'
     - 'spec/android_version_helper_spec.rb'
+    - 'spec/an_metadata_update_helper_spec.rb'
     - 'spec/configuration_spec.rb'
     - 'spec/configure_helper_spec.rb'
     - 'spec/encryption_helper_spec.rb'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -50,7 +50,7 @@ module Fastlane
 
         if line_count <= 1
           # Single line output
-          fw.puts("msgid \"#{File.open(@content_file_path, 'r').read}\"")
+          fw.puts("msgid \"#{File.open(@content_file_path, 'r').read.strip}\"")
         else
           # Multiple line output
           fw.puts('msgid ""')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -50,7 +50,7 @@ module Fastlane
 
         if line_count <= 1
           # Single line output
-          fw.puts("msgid \"#{File.open(@content_file_path, 'r').read.strip}\"")
+          fw.puts("msgid \"#{File.open(@content_file_path, 'r').read.rstrip}\"")
         else
           # Multiple line output
           fw.puts('msgid ""')

--- a/spec/an_metadata_update_helper_spec.rb
+++ b/spec/an_metadata_update_helper_spec.rb
@@ -1,0 +1,34 @@
+require 'tmpdir'
+require_relative './spec_helper'
+
+describe Fastlane::Helper::StandardMetadataBlock do
+  it 'strips any trailing newline when generating the block for a single-line input' do
+    Dir.mktmpdir do |dir|
+      input = "Single line message with new line\n"
+
+      # Generate the input file to convert to .pot block
+      input_path = File.join(dir, 'input')
+      File.write(input_path, input)
+      # Ensure the input has only one line
+      expect(File.read(input_path).lines.count).to eq 1
+
+      # Write the .pot block in an output file
+      output_path = File.join(dir, 'output')
+      File.open(output_path, 'w') do |file|
+        described_class.new('any-key', input_path).generate_block(file)
+      end
+
+      # Ensure the output matches the expectation: the trailing new line has
+      # been stripped.
+      #
+      # Note that the final new line is intentional. It's part of the
+      # formatting at the time of writing.
+      expect(File.read(output_path)).to eq <<~EXP
+        msgctxt "any-key"
+        msgid "Single line message with new line"
+        msgstr ""
+
+      EXP
+    end
+  end
+end

--- a/spec/an_metadata_update_helper_spec.rb
+++ b/spec/an_metadata_update_helper_spec.rb
@@ -12,18 +12,17 @@ describe Fastlane::Helper::StandardMetadataBlock do
       # Ensure the input has only one line
       expect(File.read(input_path).lines.count).to eq 1
 
-      # Write the .pot block in an output file
-      output_path = File.join(dir, 'output')
-      File.open(output_path, 'w') do |file|
-        described_class.new('any-key', input_path).generate_block(file)
-      end
+      # Write the .pot block in a StringIO to bypass the filesystem and have
+      # faster tests
+      output_io = StringIO.new
+      described_class.new('any-key', input_path).generate_block(output_io)
 
       # Ensure the output matches the expectation: the trailing new line has
       # been stripped.
       #
       # Note that the final new line is intentional. It's part of the
       # formatting at the time of writing.
-      expect(File.read(output_path)).to eq <<~EXP
+      expect(output_io.string).to eq <<~EXP
         msgctxt "any-key"
         msgid "Single line message with new line"
         msgstr ""

--- a/spec/an_metadata_update_helper_spec.rb
+++ b/spec/an_metadata_update_helper_spec.rb
@@ -30,4 +30,31 @@ describe Fastlane::Helper::StandardMetadataBlock do
       EXP
     end
   end
+
+  it 'does not strip a trailing new line when generating the block for a multi-line input' do
+    Dir.mktmpdir do |dir|
+      input = "Multi-line\nmessage\nwith\ntrailing new line\n"
+
+      # Generate the input file to convert to .pot block
+      input_path = File.join(dir, 'input')
+      File.write(input_path, input)
+
+      # Write the .pot block in a StringIO to bypass the filesystem and have
+      # faster tests
+      output_io = StringIO.new
+      described_class.new('any-key', input_path).generate_block(output_io)
+
+      # Note that the new line after `msgstr` is intentional. It's part of the
+      # formatting at the time of writing.
+      expect(output_io.string).to eq %q(msgctxt "any-key"
+msgid ""
+"Multi-line\n"
+"message\n"
+"with\n"
+"trailing new line\n"
+msgstr ""
+
+)
+    end
+  end
 end

--- a/spec/an_metadata_update_helper_spec.rb
+++ b/spec/an_metadata_update_helper_spec.rb
@@ -46,15 +46,16 @@ describe Fastlane::Helper::StandardMetadataBlock do
 
       # Note that the new line after `msgstr` is intentional. It's part of the
       # formatting at the time of writing.
-      expect(output_io.string).to eq %q(msgctxt "any-key"
-msgid ""
-"Multi-line\n"
-"message\n"
-"with\n"
-"trailing new line\n"
-msgstr ""
+      expect(output_io.string).to eq <<~'EXP'
+        msgctxt "any-key"
+        msgid ""
+        "Multi-line\n"
+        "message\n"
+        "with\n"
+        "trailing new line\n"
+        msgstr ""
 
-)
+      EXP
     end
   end
 end


### PR DESCRIPTION
At the moment, this is just a quick fix. After about an hour of `puts`-driven debugging against https://github.com/Automattic/simplenote-ios/pull/1406, I identified the culprit and wrote a fix for the specific issue.

There's more work to be done in this are though. For a start, [`an_metadata_update_helper.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/07b3152b2b22874fee0c373457668546c9424955/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb) and [`metadata_update_helper.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/07b3152b2b22874fee0c373457668546c9424955/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb) define the same types. E.g.:

https://github.com/wordpress-mobile/release-toolkit/blob/07b3152b2b22874fee0c373457668546c9424955/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb#L1-L4

https://github.com/wordpress-mobile/release-toolkit/blob/07b3152b2b22874fee0c373457668546c9424955/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb#L1-L4

It took me a while to understand why my "breakpoints" in `metadata_helper.rb` ([imported](https://github.com/wordpress-mobile/release-toolkit/blob/07b3152b2b22874fee0c373457668546c9424955/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb#L2) by `gp_update_metadata_source.rb`, [used](https://github.com/wordpress-mobile/release-toolkit/blob/07b3152b2b22874fee0c373457668546c9424955/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb#L8-L10) by `ios_update_metadata_source`, [used](https://github.com/Automattic/simplenote-ios/blob/8ef355d4133ce0db9acde631d91e466685ab5218/fastlane/Fastfile#L119-L121) by the lane that generates the `.pot`) weren't hit. The reason is that for some reason the Ruby interpreter loaded the ones defined in `an_metadata_helper.rb`, possibly due to the `an_` prefix which would make that file load first? Although, I'm not sure why that would be the case since there's no import for that file.

## To test

I added a dedicated unit test here. I ought to add more for other facets of the behavior, but I just wanted to fix the issue to begin with.

Also see steps from https://github.com/Automattic/simplenote-ios/pull/1407.

## Next step

I see a few options:

1. Merge this and ship a new version, hoping this is enough to cover all the paths that generate the issues we've encountered so far
2. Spend a bit more time on this PR, replicating the `.strip` on single line fix for all the other block types, then ship a new version
3. Invest the time right now to get to the bottom of the `an_metadata_` vs `metadata_` issues and improve the `.pot` generation logic, then ship a new version

I'm leaning towards option 2. My current implementation doesn't seem future proof, while option 3 sounds like a lot of work that could easily explode in scope.

Keen to hear what the rest of @wordpress-mobile/owl-team thinks, which is why I asked for your review even though this is still a draft.