### PR TITLE
Update Android versioning helpers to use unified versions for JP/WP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-_None_
+* Updates the keys used for version reads and bumps when using a `version.properties` file in Android. [#298]
 
 ### New Features
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -34,11 +34,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.details
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -32,11 +32,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.details
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -33,11 +33,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.details
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -45,11 +45,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.details
-        'Bumps the version of the app for a new beta. Requires the `updateVersionProperties` gradle task to update the keys if you are using a `version.properties` file.'
+        'Bumps the version of the app for a new beta.'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_file_by_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_file_by_version.rb
@@ -27,7 +27,7 @@ module Fastlane
 
       def self.details
         'This action extracts the version of the library which is imported by the client app' \
-        'and downloads the request file from the relevant GitHub release'
+          'and downloads the request file from the relevant GitHub release'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_translation_progress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_translation_progress.rb
@@ -98,7 +98,7 @@ module Fastlane
 
       def self.details
         'This actions checks the current status of the translations on GlotPress ' \
-        'and raises an error if it\'s below the provided threshold'
+          'and raises an error if it\'s below the provided threshold'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -13,7 +13,7 @@ module Fastlane
         #
         def self.commit_version_bump
           require_relative './android_version_helper'
-          if Fastlane::Helper::Android::VersionHelper.properties_file_exists
+          if File.exist?(Fastlane::Helper::Android::VersionHelper.version_properties_file)
             Fastlane::Helper::GitHelper.commit(
               message: 'Bump version number',
               files: File.join(ENV['PROJECT_ROOT_FOLDER'], 'version.properties'),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -78,7 +78,7 @@ module Fastlane
           name = text.match(/#{version_name_key}=(\S*)/m)&.captures&.first
           code = text.match(/#{version_code_key}=(\S*)/m)&.captures&.first
 
-          return (name.nil? || code.nil?) ? nil : { VERSION_NAME => name, VERSION_CODE => code.to_i }
+          return name.nil? || code.nil? ? nil : { VERSION_NAME => name, VERSION_CODE => code.to_i }
         end
 
         # Extract the version name and code from the `version.properties` file in the project root
@@ -312,14 +312,14 @@ module Fastlane
         def self.update_versions(app, new_version_beta, new_version_alpha)
           if File.exist?(version_properties_file)
             replacements = {
-              'versionName': (new_version_beta || {})[VERSION_NAME],
-              'versionCode': (new_version_beta || {})[VERSION_CODE],
+              versionName: (new_version_beta || {})[VERSION_NAME],
+              versionCode: (new_version_beta || {})[VERSION_CODE],
               'alpha.versionName': (new_version_alpha || {})[VERSION_NAME],
               'alpha.versionCode': (new_version_alpha || {})[VERSION_CODE]
             }
             content = File.read(version_properties_file)
             content.gsub!(/^(.*) ?=.*$/) do |line|
-              key = $1.to_sym
+              key = Regexp.last_match(1).to_sym
               value = replacements[key]
               value.nil? ? line : "#{key}=#{value}"
             end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -26,7 +26,8 @@ module Fastlane
         #    "1.2" # Assuming build.gradle contains versionName "1.2.0"
         #    "1.2.3" # Assuming build.gradle contains versionName "1.2.3"
         #
-        # @param [String] app The name of the app to be used for beta and alpha version update
+        # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version.
+        #                     Unused anymore, will be removed in future breaking update
         #
         # @return [String] The public-facing version number, extracted from the `versionName` of the `build.gradle` file.
         #         - If this version is a hotfix (more than 2 parts and 3rd part is non-zero), returns the "X.Y.Z" formatted string
@@ -42,7 +43,8 @@ module Fastlane
 
         # Extract the version name and code from the release version of the app from `version.properties file`
         #
-        # @param [String] product_name The name of the app to be used for beta and alpha version update
+        # @param [String] product_name (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version.
+        #                              Unused anymore, will be removed in future breaking update
         #
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #
@@ -81,7 +83,8 @@ module Fastlane
 
         # Extract the version name and code from the `version.properties` file in the project root
         #
-        # @param [String] app The name of the app to be used for beta and alpha version update
+        # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version.
+        #                     Unused anymore, will be removed in future breaking update
         #
         # @return [Hash] A hash with 2 keys `"name"` and `"code"` containing the extracted version name and code, respectively,
         #                or `nil` if `$HAS_ALPHA_VERSION` is not defined.
@@ -284,7 +287,8 @@ module Fastlane
 
         # Prints the current and next release version names to stdout, then returns the next release version
         #
-        # @param [String] app The name of the app to be used for beta and alpha version update
+        # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version update
+        #                     Unused anymore, will be removed in future breaking update
         # @return [String] The next release version name to use after bumping the currently used release version.
         #
         def self.bump_version_release(app)
@@ -300,7 +304,8 @@ module Fastlane
 
         # Update the `version.properties` file with new `versionName` and `versionCode` values
         #
-        # @param [String] app The name of the app to be used for beta and alpha version update
+        # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version update
+        #                     Unused anymore, will be removed in future breaking update
         # @param [Hash] new_version_beta The version hash for the beta, containing values for keys "name" and "code"
         # @param [Hash] new_version_alpha The version hash for the alpha , containing values for keys "name" and "code"
         #
@@ -407,7 +412,7 @@ module Fastlane
         #
         # @return [Bool] true if the string is representing an integer value, false if not
         #
-        def self.is_int? string
+        def self.is_int?(string)
           true if Integer(string) rescue false
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -27,7 +27,7 @@ module Fastlane
         #    "1.2.3" # Assuming build.gradle contains versionName "1.2.3"
         #
         # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version.
-        #                     Unused anymore, will be removed in future breaking update
+        #                     No longer used, will be removed in future breaking update
         #
         # @return [String] The public-facing version number, extracted from the `versionName` of the `build.gradle` file.
         #         - If this version is a hotfix (more than 2 parts and 3rd part is non-zero), returns the "X.Y.Z" formatted string
@@ -44,7 +44,7 @@ module Fastlane
         # Extract the version name and code from the release version of the app from `version.properties file`
         #
         # @param [String] product_name (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version.
-        #                              Unused anymore, will be removed in future breaking update
+        #                              No longer used, will be removed in future breaking update
         #
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #
@@ -84,7 +84,7 @@ module Fastlane
         # Extract the version name and code from the `version.properties` file in the project root
         #
         # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version.
-        #                     Unused anymore, will be removed in future breaking update
+        #                     No longer used, will be removed in future breaking update
         #
         # @return [Hash] A hash with 2 keys `"name"` and `"code"` containing the extracted version name and code, respectively,
         #                or `nil` if `$HAS_ALPHA_VERSION` is not defined.
@@ -288,7 +288,7 @@ module Fastlane
         # Prints the current and next release version names to stdout, then returns the next release version
         #
         # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version update
-        #                     Unused anymore, will be removed in future breaking update
+        #                     No longer used, will be removed in future breaking update
         # @return [String] The next release version name to use after bumping the currently used release version.
         #
         def self.bump_version_release(app)
@@ -305,7 +305,7 @@ module Fastlane
         # Update the `version.properties` file with new `versionName` and `versionCode` values
         #
         # @param [String] app (UNUSED/DEPRECATED) The name of the app to be used for beta and alpha version update
-        #                     Unused anymore, will be removed in future breaking update
+        #                     No longer used, will be removed in future breaking update
         # @param [Hash] new_version_beta The version hash for the beta, containing values for keys "name" and "code"
         # @param [Hash] new_version_alpha The version hash for the alpha , containing values for keys "name" and "code"
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -47,7 +47,7 @@ module Fastlane
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #
         def self.get_release_version(product_name:)
-          return get_version_from_properties(product_name: product_name) if File.exist?(version_properties_file)
+          return get_version_from_properties() if File.exist?(version_properties_file)
 
           section = ENV['HAS_ALPHA_VERSION'].nil? ? 'defaultConfig' : 'vanilla {'
           gradle_path = self.gradle_path
@@ -62,12 +62,11 @@ module Fastlane
 
         # Extract the version name and code from the `version.properties` file in the project root
         #
-        # @param [String] product_name The name of the app to extract the version from e.g. wordpress, simplenote
         # @param [Boolean] is_alpha true if the alpha version should be returned, false otherwise
         #
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #
-        def self.get_version_from_properties(product_name:, is_alpha: false)
+        def self.get_version_from_properties(is_alpha: false)
           return nil unless File.exist?(version_properties_file)
 
           version_name_key = is_alpha ? 'alpha.versionName' : 'versionName'
@@ -88,7 +87,7 @@ module Fastlane
         #                or `nil` if `$HAS_ALPHA_VERSION` is not defined.
         #
         def self.get_alpha_version(app)
-          return get_version_from_properties(product_name: app, is_alpha: true) if File.exist?(version_properties_file)
+          return get_version_from_properties(is_alpha: true) if File.exist?(version_properties_file)
 
           return nil if ENV['HAS_ALPHA_VERSION'].nil?
 

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -11,7 +11,7 @@ describe Fastlane::Helper::Android::VersionHelper do
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
-      allow(File).to receive(:open).with('./version.properties', 'r').and_yield(StringIO.new(test_file_content))
+      allow(File).to receive(:read).with('./version.properties').and_return(test_file_content)
       expect(subject.get_version_from_properties(product_name: 'wordpress')).to eq('name' => '17.0', 'code' => 123)
     end
 
@@ -24,7 +24,7 @@ describe Fastlane::Helper::Android::VersionHelper do
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
-      allow(File).to receive(:open).with('./version.properties', 'r').and_yield(StringIO.new(test_file_content))
+      allow(File).to receive(:read).with('./version.properties').and_return(test_file_content)
       expect(subject.get_version_from_properties(product_name: 'wordpress', is_alpha: true)).to eq('name' => 'alpha-222', 'code' => 1234)
     end
 
@@ -35,7 +35,7 @@ describe Fastlane::Helper::Android::VersionHelper do
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
-      allow(File).to receive(:open).with('./version.properties', 'r').and_yield(StringIO.new(test_file_content))
+      allow(File).to receive(:read).with('./version.properties').and_return(test_file_content)
       expect(subject.get_version_from_properties(product_name: 'jetpack', is_alpha: true)).to be_nil
     end
   end

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -45,6 +45,60 @@ describe Fastlane::Helper::Android::VersionHelper do
     end
   end
 
+  describe 'update_versions' do
+    context 'with a version.properties file' do
+      let(:original_content) do
+        <<~CONTENT
+          # Some header
+
+          versionName=12.3
+          versionCode=1234
+
+          alpha.versionName=alpha-456
+          alpha.versionCode=4567
+        CONTENT
+      end
+      let(:new_beta_version) do
+        { 'name' => '12.4-rc-1', 'code' => '1240' }
+      end
+      let(:new_alpha_version) do
+        { 'name' => 'alpha-457', 'code' => '4570' }
+      end
+
+      it 'updates only the main version if no alpha provided' do
+        expected_content = <<~CONTENT
+          # Some header
+
+          versionName=12.4-rc-1
+          versionCode=1240
+
+          alpha.versionName=alpha-456
+          alpha.versionCode=4567
+        CONTENT
+        allow(File).to receive(:exist?).with('./version.properties').and_return(true)
+        allow(File).to receive(:read).with('./version.properties').and_return(original_content)
+        expect(File).to receive(:write).with('./version.properties', expected_content)
+        subject.update_versions('wordpress', new_beta_version, nil)
+      end
+
+      it 'updates both the main and alpha versions if alpha provided' do
+        expected_content = <<~CONTENT
+          # Some header
+
+          versionName=12.4-rc-1
+          versionCode=1240
+
+          alpha.versionName=alpha-457
+          alpha.versionCode=4570
+        CONTENT
+        allow(File).to receive(:exist?).with('./version.properties').and_return(true)
+        allow(File).to receive(:read).with('./version.properties').and_return(original_content)
+        expect(File).to receive(:write).with('./version.properties', expected_content)
+        subject.update_versions('wordpress', new_beta_version, new_alpha_version)
+      end
+    end
+  end
+
   describe 'get_library_version_from_gradle_config' do
     it 'returns nil when gradle file is not present' do
       allow(File).to receive(:exist?).and_return(false)

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -4,39 +4,44 @@ describe Fastlane::Helper::Android::VersionHelper do
   describe 'get_version_from_properties' do
     it 'returns version name and code when present' do
       test_file_content = <<~CONTENT
-        wordpress.versionName=17.0
-        wordpress.versionCode=123
-        wordpress.zalpha.versionName=alpha-222
-        wordpress.zalpha.versionCode=1234
+        # Some header
+
+        versionName=17.0
+        versionCode=123
+
+        alpha.versionName=alpha-222
+        alpha.versionCode=1234
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:read).with('./version.properties').and_return(test_file_content)
-      expect(subject.get_version_from_properties(product_name: 'wordpress')).to eq('name' => '17.0', 'code' => 123)
+      expect(subject.get_version_from_properties()).to eq('name' => '17.0', 'code' => 123)
     end
 
     it 'returns alpha version name and code when present' do
       test_file_content = <<~CONTENT
-        wordpress.versionName=17.0
-        wordpress.versionCode=123
-        wordpress.zalpha.versionName=alpha-222
-        wordpress.zalpha.versionCode=1234
+        # Some header
+
+        versionName=17.0
+        versionCode=123
+        alpha.versionName=alpha-222
+        alpha.versionCode=1234
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:read).with('./version.properties').and_return(test_file_content)
-      expect(subject.get_version_from_properties(product_name: 'wordpress', is_alpha: true)).to eq('name' => 'alpha-222', 'code' => 1234)
+      expect(subject.get_version_from_properties(is_alpha: true)).to eq('name' => 'alpha-222', 'code' => 1234)
     end
 
     it 'returns nil when alpha version name and code not present' do
       test_file_content = <<~CONTENT
-        jetpack.versionName=17.0
-        jetpack.versionCode=123
+        versionName=17.0
+        versionCode=123
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:read).with('./version.properties').and_return(test_file_content)
-      expect(subject.get_version_from_properties(product_name: 'jetpack', is_alpha: true)).to be_nil
+      expect(subject.get_version_from_properties(is_alpha: true)).to be_nil
     end
   end
 

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane::Helper::ConfigureHelper do
         # reasonable enough assumption to make for the real world usage of this
         # tool. Still, it would be nice to have proper handling of that
         # scenario at some point.
-        `git init --initial-branch main`
+        `git init --initial-branch main | git init`
 
         expect(Fastlane::UI).to receive(:user_error!)
 

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -16,7 +16,7 @@ describe Fastlane::Helper::ConfigureHelper do
         # reasonable enough assumption to make for the real world usage of this
         # tool. Still, it would be nice to have proper handling of that
         # scenario at some point.
-        `git init`
+        `git init --initial-branch main`
 
         expect(Fastlane::UI).to receive(:user_error!)
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -26,12 +26,12 @@ describe Fastlane::Helper::GitHelper do
   end
 
   it 'can detect a valid git repository' do
-    `git init --initial-branch main`
+    `git init --initial-branch main | git init`
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
   end
 
   it 'can detect a valid git repository from a child folder' do
-    `git init --initial-branch main`
+    `git init --initial-branch main | git init`
     `mkdir -p a/b`
     Dir.chdir('./a/b')
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
@@ -39,14 +39,14 @@ describe Fastlane::Helper::GitHelper do
 
   it 'can detect a valid git repository when given a path' do
     Dir.mktmpdir do |dir|
-      `git -C #{dir} init --initial-branch main`
+      `git -C #{dir} init --initial-branch main | git -C #{dir} init`
       expect(Fastlane::Helper::GitHelper.is_git_repo?(path: dir)).to be true
     end
   end
 
   it 'can detect a valid git repository when given a child folder path' do
     Dir.mktmpdir do |dir|
-      `git -C #{dir} init --initial-branch main`
+      `git -C #{dir} init --initial-branch main | git -C #{dir} init`
       path = File.join(dir, 'a', 'b')
       `mkdir -p #{path}`
       expect(Fastlane::Helper::GitHelper.is_git_repo?(path: path)).to be true
@@ -54,13 +54,13 @@ describe Fastlane::Helper::GitHelper do
   end
 
   it 'can detect a repository with Git-lfs enabled' do
-    `git init --initial-branch main`
+    `git init --initial-branch main | git init`
     `git lfs install`
     expect(Fastlane::Helper::GitHelper.has_git_lfs?).to be true
   end
 
   it 'can detect a repository without Git-lfs enabled' do
-    `git init --initial-branch main`
+    `git init --initial-branch main | git init`
     `git lfs uninstall &>/dev/null`
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
     expect(Fastlane::Helper::GitHelper.has_git_lfs?).to be false
@@ -186,7 +186,7 @@ describe Fastlane::Helper::GitHelper do
 end
 
 def setup_git_repo(dummy_file_path: nil, add_file_to_gitignore: false, commit_gitignore: false)
-  `git init --initial-branch main`
+  `git init --initial-branch main | git init`
   `touch .gitignore`
   `git add .gitignore && git commit -m 'Add .gitignore'`
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -26,12 +26,12 @@ describe Fastlane::Helper::GitHelper do
   end
 
   it 'can detect a valid git repository' do
-    `git init`
+    `git init --initial-branch main`
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
   end
 
   it 'can detect a valid git repository from a child folder' do
-    `git init`
+    `git init --initial-branch main`
     `mkdir -p a/b`
     Dir.chdir('./a/b')
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
@@ -39,14 +39,14 @@ describe Fastlane::Helper::GitHelper do
 
   it 'can detect a valid git repository when given a path' do
     Dir.mktmpdir do |dir|
-      `git -C #{dir} init`
+      `git -C #{dir} init --initial-branch main`
       expect(Fastlane::Helper::GitHelper.is_git_repo?(path: dir)).to be true
     end
   end
 
   it 'can detect a valid git repository when given a child folder path' do
     Dir.mktmpdir do |dir|
-      `git -C #{dir} init`
+      `git -C #{dir} init --initial-branch main`
       path = File.join(dir, 'a', 'b')
       `mkdir -p #{path}`
       expect(Fastlane::Helper::GitHelper.is_git_repo?(path: path)).to be true
@@ -54,13 +54,13 @@ describe Fastlane::Helper::GitHelper do
   end
 
   it 'can detect a repository with Git-lfs enabled' do
-    `git init`
+    `git init --initial-branch main`
     `git lfs install`
     expect(Fastlane::Helper::GitHelper.has_git_lfs?).to be true
   end
 
   it 'can detect a repository without Git-lfs enabled' do
-    `git init`
+    `git init --initial-branch main`
     `git lfs uninstall &>/dev/null`
     expect(Fastlane::Helper::GitHelper.is_git_repo?).to be true
     expect(Fastlane::Helper::GitHelper.has_git_lfs?).to be false
@@ -186,7 +186,7 @@ describe Fastlane::Helper::GitHelper do
 end
 
 def setup_git_repo(dummy_file_path: nil, add_file_to_gitignore: false, commit_gitignore: false)
-  `git init`
+  `git init --initial-branch main`
   `touch .gitignore`
   `git add .gitignore && git commit -m 'Add .gitignore'`
 


### PR DESCRIPTION
This is part of project paaHJt-2s8-p2
 - Related PR: https://github.com/wordpress-mobile/WordPress-Android/pull/15230

### What it does

This PR makes the toolkit now use the new convention for the `version.properties` keys, which don't depend on the app name anymore. It does this by:

 - Updating the helper methods `get_version_from_properties` and `update_versions` – which are used to get and bump the Android versions from a `version.properties` file, respectively – to use the new key names, independant of the app (WP/JP)
 - Updating the implementation `update_versions` to not rely on / require the presence of an `updateVersionProperties` gradle task in the client project
 - Updating the helpers and actions' documentation to reflect those changes
 - Add more unit tests

### What it does NOT

This PR does not remove the `app:` parameter / `ConfigItem` from the actions just yet.

This change will be part of a subsequent PR (and will make it a breaking change), and is planned for the next sub-project (part 3 of project thread). Indeed, given the fragility of the release-toolkit (untyped language and lack of tests and all), I prefered to take it one step at a time 😉 . So for now the public API of the fastlane actions are unchanged still expect the `app:` parameter to be provided just like before, but this parameter will be unused and ignored – as it's not used by the private helpers anymore.

### To Test

 - Run `bundle exec rspec` to run the unit tests (or test that the CI runs them and passes)
 - Follow the test steps on https://github.com/wordpress-mobile/WordPress-Android/pull/15230 to test those changes from the client side.