### PR TITLE
Adds a changelog for "strip trailing newline" bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _None_
 
 ### Bug Fixes
 
+* Strip trailing new lines in single line msgid when generating .po[t] file
+
 _None_
 
 ### Internal Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-* Strip trailing new lines in single line msgid when generating .po[t] file
+* Strip trailing new lines in single line msgid when generating .po[t] file. [#297]
 
 _None_
 


### PR DESCRIPTION
I was planning to do a minor release and realized there wasn't a changelog for https://github.com/wordpress-mobile/release-toolkit/pull/297, so I added the title of that PR to the Bug fixes section. I am no longer planning to do the release, but I think it's still good to have that in the changelog.

P.S: It turns out this is my first PR in this project 😱 