### PR TITLE
Release 2.1.0 into develop

### DIFF
--- a/.buildkite/gem-push.sh
+++ b/.buildkite/gem-push.sh
@@ -1,10 +1,6 @@
 #!/bin/bash -eu
 
-echo "--- :beer: Installing Dependencies"
-brew bundle --file .buildkite/brewfile
-
-echo "--- :rubygems: Setting up Gems"
-install_gems
+./install-dependencies.sh
 
 echo "--- :hammer: Build Gemspec"
 gem build fastlane-plugin-wpmreleasetoolkit.gemspec

--- a/.buildkite/gem-push.sh
+++ b/.buildkite/gem-push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-./install-dependencies.sh
+.buildkite/install-dependencies.sh
 
 echo "--- :hammer: Build Gemspec"
 gem build fastlane-plugin-wpmreleasetoolkit.gemspec

--- a/.buildkite/install-dependencies.sh
+++ b/.buildkite/install-dependencies.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :beer: Installing Dependencies"
+brew bundle --file .buildkite/brewfile
+
+echo "--- :rubygems: Setting up Gems"
+install_gems

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,11 +12,7 @@ steps:
   - label: "🧪 Build and Test"
     key: "test"
     command: |
-      echo "--- :beer: Installing Dependencies"
-      brew bundle --file .buildkite/brewfile
-
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
+      .buildkite/install-dependencies.sh
 
       echo "--- :hammer: Build DrawText"
       bundle exec rake compile
@@ -36,8 +32,7 @@ steps:
   #################
   - label: "🧹 Lint"
     command: |
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
+      .buildkite/install-dependencies.sh
 
       echo "--- :rubocop: Run Rubocop"
       bundle exec rubocop
@@ -51,8 +46,7 @@ steps:
   #################
   - label: "⛔️ Danger"
     command: |
-      echo "--- :rubygems: Setting up Gems"
-      install_gems
+      .buildkite/install-dependencies.sh
 
       echo "--- :rubocop: Run Danger"
       bundle exec danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,21 @@ _None_
 
 ### New Features
 
-* Added a reminder mechanism for when you forgot a prompt was waiting for you in the Terminal. This reminder is [configurable via environment variables](https://github.com/wordpress-mobile/release-toolkit/blob/5c9b79db4bfcb298376fe3e81bc53881795922a5/lib/fastlane/plugin/wpmreleasetoolkit/helper/interactive_prompt_reminder.rb#L3-L22) to change the default delays and optionally opt-in for speaking a voice message in addition to the default beep + dock icon badge. [#302]
+_None_
 
 ### Bug Fixes
 
 _None_
+
+### Internal Changes
+
+_None_
+
+## 2.1.0
+
+### New Features
+
+* Added a reminder mechanism for when you forgot a prompt was waiting for you in the Terminal. This reminder is [configurable via environment variables](https://github.com/wordpress-mobile/release-toolkit/blob/5c9b79db4bfcb298376fe3e81bc53881795922a5/lib/fastlane/plugin/wpmreleasetoolkit/helper/interactive_prompt_reminder.rb#L3-L22) to change the default delays and optionally opt-in for speaking a voice message in addition to the default beep + dock icon badge. [#302]
 
 ### Internal Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (2.0.0)
+    fastlane-plugin-wpmreleasetoolkit (2.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -267,7 +267,6 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
     minitest (5.14.4)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -277,8 +276,7 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -426,4 +424,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.27
+   2.2.29

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '2.0.0'
+    VERSION = '2.1.0'
   end
 end


### PR DESCRIPTION
New version 2.1.0

There's not much new compared to `2.0.0` but it still felt like a good idea to do a new release so soon because:

 - I'm planning to start work on Localization toolchain (ref: paaHJt-2Ib-p2), which means there might be multiple big (potentially breaking?) changes coming soon; so I figured better do a release before starting that large work.
 - Since we just migrated our CI to Buildkite, this was a good occasion to test the `gem push` job on Buildkite early, and fix any issue sooner rather than later if there's any, instead of encountering them while I'll be working on bigger changes.

[EDIT] In fact after opening this PR, the CI failed because we forgot to install some dependencies. Not sure why it worked in #299 but not here now that I look at the pipeline 🤔 . So I took the occasion to fix CI via fd1a15d too, hence the extra changes in this diff.