### PR TITLE
Track result of running `bundle install` on M1 chip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -276,7 +277,8 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -424,4 +426,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.29
+   2.2.31


### PR DESCRIPTION
Run on my M1 MacMini test device.

Either I didn't run `bundle install` at the time of `f509e58`, or we had to run it on an M1 first in order for the `nokogiri` platform-agnostic value to be picked up, or there was some bug in Bundler itself that
prevent that from happening. I'm mentioning the chance of a bug in Bundler because, when I run `bundle install` with Bundler 2.2.11, it remained stuck with the Intel-based version of the gem, unable to understand it had to build from native extensions. Upgrading to the latest version solved the issue. I decided not to investigate further.