### PR TITLE
Add support for commenting on GitHub PRs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -484,3 +484,7 @@ Style/ZeroLengthPredicate:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb'
+
+Style/ClassVars:
+  Exclude:
+    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ _None_
 
 * Added a new `ios_generate_strings_file_from_code` action to replace the now-deprecated `ios_localize_project` action (and `Scripts/localize.py` script in app repos). [#309, #311]
 
+* Added a `comment_on_pr` action to allow commenting on (and updating comments on) PRs.
+
+* Added the ability to use the `GITHUB_TOKEN` environment variable for GitHub operations. `GHHELPER_ACCESS` will be deprecated in a future version.
+
 ### Bug Fixes
 
 _None_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ _None_
 
 * Added a new `ios_generate_strings_file_from_code` action to replace the now-deprecated `ios_localize_project` action (and `Scripts/localize.py` script in app repos). [#309, #311]
 
-* Added a `comment_on_pr` action to allow commenting on (and updating comments on) PRs.
+* Added a `comment_on_pr` action to allow commenting on (and updating comments on) PRs. [#313]
 
-* Added the ability to use the `GITHUB_TOKEN` environment variable for GitHub operations. `GHHELPER_ACCESS` will be deprecated in a future version.
+* Added the ability to use the `GITHUB_TOKEN` environment variable for GitHub operations. `GHHELPER_ACCESS` will be deprecated in a future version. [#313]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -52,13 +52,13 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :reuse_identifier,
             description: 'If provided, the reuse identifier can identify an existing comment to overwrite',
-            is_string: true,
+            type: String,
             default_value: nil
           ),
           FastlaneCore::ConfigItem.new(
             key: :project,
             description: 'The project slug (ex: `rails/rails`)',
-            is_string: true
+            type: String
           ),
           FastlaneCore::ConfigItem.new(
             key: :pr_number,
@@ -68,7 +68,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :body,
             description: 'The content of the comment',
-            is_string: true
+            type: String
           ),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -4,16 +4,24 @@ require 'securerandom'
 
 module Fastlane
   module Actions
+    module SharedValues
+      PR_COMMENT_REUSE_IDENTIFIER = :PR_COMMENT_REUSE_IDENTIFIER
+    end
+
     class CommentOnPrAction < Action
       def self.run(params)
         require_relative '../../helper/github_helper'
 
-        Fastlane::Helper::GithubHelper.comment_on_pr(
+        reuse_identifier = Fastlane::Helper::GithubHelper.comment_on_pr(
           project_slug: params[:project],
           pr_number: params[:pr_number],
           body: params[:body],
           reuse_identifier: params[:reuse_identifier]
         )
+
+        Actions.lane_context[SharedValues::PR_COMMENT_REUSE_IDENTIFIER] = reuse_identifier
+
+        reuse_identifier
       end
 
       def self.description
@@ -63,6 +71,16 @@ module Fastlane
             is_string: true
           ),
         ]
+      end
+
+      def self.output
+        [
+          ['PR_COMMENT_REUSE_IDENTIFIER', 'The `reuse_identifier` for the most recently posted comment'],
+        ]
+      end
+
+      def self.return_value
+        'The `reuse_identifier` for the posted comment (useful for updating it later, if needed)'
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -1,0 +1,74 @@
+require 'fastlane/action'
+require 'rubygems/command_manager'
+require 'securerandom'
+
+module Fastlane
+  module Actions
+    class CommentOnPrAction < Action
+      def self.run(params)
+        require_relative '../../helper/github_helper'
+
+        Fastlane::Helper::GithubHelper.comment_on_pr(
+          project_slug: params[:project],
+          pr_number: params[:pr_number],
+          body: params[:body],
+          reuse_identifier: params[:reuse_identifier]
+        )
+      end
+
+      def self.description
+        'Post a comment on a given PR number (optionally updating an existing one)'
+      end
+
+      def self.authors
+        ['Jeremy Massel']
+      end
+
+      def self.details
+        <<~DETAILS
+          If used just once, this method makes it nice and easy to post a quick comment to a GitHub
+          PR. Subsequent runs will allow you to update an existing comment as many times as you need
+          to (for instance, across multiple CI runs).
+
+          The `:reuse_identifier` config item enables this.
+        DETAILS
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :access_token,
+            env_name: 'GITHUB_TOKEN',
+            description: 'The GitHub token to use for posting the comment',
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :reuse_identifier,
+            description: 'If provided, the reuse identifier can identify an existing comment to overwrite',
+            is_string: true,
+            default_value: SecureRandom.uuid
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :project,
+            description: 'The project slug (ex: `rails/rails`)',
+            is_string: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :pr_number,
+            description: 'The PR number',
+            is_string: false # integer
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :body,
+            description: 'The content of the comment',
+            is_string: true
+          ),
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -21,7 +21,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Jeremy Massel']
+        ['Automattic']
       end
 
       def self.details

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -26,11 +26,10 @@ module Fastlane
 
       def self.details
         <<~DETAILS
-          If used just once, this method makes it nice and easy to post a quick comment to a GitHub
-          PR. Subsequent runs will allow you to update an existing comment as many times as you need
-          to (for instance, across multiple CI runs).
+          If used just once, this method makes it nice and easy to post a quick comment to a GitHub PR.
 
-          The `:reuse_identifier` config item enables this.
+          Subsequent runs will allow you to update an existing comment as many times as you need to
+          (e.g. across multiple CI runs), by using a `:reuse_identifier` to identify the comment to update.
         DETAILS
       end
 
@@ -40,13 +39,13 @@ module Fastlane
             key: :access_token,
             env_name: 'GITHUB_TOKEN',
             description: 'The GitHub token to use for posting the comment',
-            is_string: true
+            type: String
           ),
           FastlaneCore::ConfigItem.new(
             key: :reuse_identifier,
             description: 'If provided, the reuse identifier can identify an existing comment to overwrite',
             is_string: true,
-            default_value: SecureRandom.uuid
+            default_value: nil
           ),
           FastlaneCore::ConfigItem.new(
             key: :project,
@@ -56,7 +55,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :pr_number,
             description: 'The PR number',
-            is_string: false # integer
+            type: Integer
           ),
           FastlaneCore::ConfigItem.new(
             key: :body,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -1,6 +1,4 @@
 require 'fastlane/action'
-require 'rubygems/command_manager'
-require 'securerandom'
 
 module Fastlane
   module Actions

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -55,7 +55,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :project,
-            description: 'The project slug (ex: `rails/rails`)',
+            description: 'The project slug (ex: `wordpress-mobile/wordpress-ios`)',
             type: String
           ),
           FastlaneCore::ConfigItem.new(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -8,7 +8,7 @@ module Fastlane
 
   module Helper
     class GithubHelper
-      def self.github_token
+      def self.github_token!
         token = [
           'GHHELPER_ACCESS', # For historical reasons / backward compatibility
           'GITHUB_TOKEN',    # Used by the `gh` CLI tool
@@ -20,7 +20,7 @@ module Fastlane
       end
 
       def self.github_client
-        client = Octokit::Client.new(access_token: github_token)
+        client = Octokit::Client.new(access_token: github_token!)
 
         # Fetch the current user
         user = client.user

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -8,11 +8,14 @@ module Fastlane
   module Helper
     class GithubHelper
       def self.github_token
-        [
+        token = [
           'GHHELPER_ACCESS', # For historical reasons / backward compatibility
           'GITHUB_TOKEN',    # Used by the `gh` CLI tool
         ].map { |key| ENV[key] }
-          .compact.first
+        .compact
+        .first
+
+        token || UI.user_error!('Please provide a GitHub authentication token via the `GITHUB_TOKEN` environment variable')
       end
 
       def self.github_client

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -141,10 +141,10 @@ module Fastlane
       end
 
       # Creates (or updates an existing) GitHub PR Comment
-      def self.comment_on_pr(project_slug:, pr_number:, body:, reuse_identifier:)
+      def self.comment_on_pr(project_slug:, pr_number:, body:, reuse_identifier: SecureRandom.uuid)
         comments = github_client.issue_comments(project_slug, pr_number)
 
-        existing_comment = comments.detect do |comment|
+        existing_comment = comments.find do |comment|
           comment.body.include?(reuse_identifier)
         end
 
@@ -158,7 +158,7 @@ module Fastlane
       end
 
       def self.prepare_comment_body(body, reuse_identifier)
-        "<!-- REUSE_ID: #{reuse_identifier} -->" + body
+        "<!-- REUSE_ID: #{reuse_identifier} -->\n" + body
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -148,13 +148,13 @@ module Fastlane
         client = github_client
         comments = client.issue_comments(project_slug, pr_number)
 
-        complete_reuse_identifier = "<!-- REUSE_ID: #{reuse_identifier} -->"
+        reuse_marker = "<!-- REUSE_ID: #{reuse_identifier} -->"
 
         existing_comment = comments
                            .select { |comment| comment.user.id == client.user.id } # Only match comments posted by the owner of the GitHub Token
-                           .find { |comment| comment.body.include?(complete_reuse_identifier) }
+                           .find { |comment| comment.body.include?(reuse_marker) }
 
-        comment_body = complete_reuse_identifier + body
+        comment_body = reuse_marker + body
 
         if existing_comment.nil?
           client.add_comment(project_slug, pr_number, comment_body)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -30,8 +30,6 @@ module Fastlane
           # Auto-paginate to ensure we're not missing data
           client.auto_paginate = true
         end
-
-        @@client
       end
 
       def self.get_milestone(repository, release)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -20,16 +20,18 @@ module Fastlane
       end
 
       def self.github_client
-        client = Octokit::Client.new(access_token: github_token!)
+        @@client ||= begin
+          Octokit::Client.new(access_token: github_token!)
 
-        # Fetch the current user
-        user = client.user
-        UI.message("Logged in as: #{user.name}")
+          # Fetch the current user
+          user = client.user
+          UI.message("Logged in as: #{user.name}")
 
-        # Auto-paginate to ensure we're not missing data
-        client.auto_paginate = true
+          # Auto-paginate to ensure we're not missing data
+          client.auto_paginate = true
+        end
 
-        client
+        @@client
       end
 
       def self.get_milestone(repository, release)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -12,7 +12,7 @@ module Fastlane
           'GHHELPER_ACCESS', # For historical reasons / backward compatibility
           'GITHUB_TOKEN',    # Used by the `gh` CLI tool
         ].map { |key| ENV[key] }
-          .detect { |value| !value.nil? }
+          .compact.first
       end
 
       def self.github_client

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -1,6 +1,7 @@
 require 'fastlane_core/ui/ui'
 require 'octokit'
 require 'open-uri'
+require 'securerandom'
 
 module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?('UI')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -150,9 +150,10 @@ module Fastlane
 
         reuse_marker = "<!-- REUSE_ID: #{reuse_identifier} -->"
 
-        existing_comment = comments
-                           .select { |comment| comment.user.id == client.user.id } # Only match comments posted by the owner of the GitHub Token
-                           .find { |comment| comment.body.include?(reuse_marker) }
+        existing_comment = comments.find do |comment|
+          # Only match comments posted by the owner of the GitHub Token, and with the given reuse ID
+          comment.user.id == client.user.id and comment.body.include?(reuse_marker)
+        end
 
         comment_body = reuse_marker + body
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -12,8 +12,8 @@ module Fastlane
           'GHHELPER_ACCESS', # For historical reasons / backward compatibility
           'GITHUB_TOKEN',    # Used by the `gh` CLI tool
         ].map { |key| ENV[key] }
-        .compact
-        .first
+                .compact
+                .first
 
         token || UI.user_error!('Please provide a GitHub authentication token via the `GITHUB_TOKEN` environment variable')
       end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -28,22 +28,22 @@ describe Fastlane::Helper::GithubHelper do
 
     it 'can use `GHHELPER_ACCESS`' do
       ENV['GHHELPER_ACCESS'] = 'GHHELPER_ACCESS'
-      expect(described_class.github_token).to eq('GHHELPER_ACCESS')
+      expect(described_class.github_token!).to eq('GHHELPER_ACCESS')
     end
 
     it 'can use `GITHUB_TOKEN`' do
       ENV['GITHUB_TOKEN'] = 'GITHUB_TOKEN'
-      expect(described_class.github_token).to eq('GITHUB_TOKEN')
+      expect(described_class.github_token!).to eq('GITHUB_TOKEN')
     end
 
     it 'prioritizes GHHELPER_ACCESS` over `GITHUB_TOKEN` if both are present' do
       ENV['GITHUB_TOKEN'] = 'GITHUB_TOKEN'
       ENV['GHHELPER_ACCESS'] = 'GHHELPER_ACCESS'
-      expect(described_class.github_token).to eq('GHHELPER_ACCESS')
+      expect(described_class.github_token!).to eq('GHHELPER_ACCESS')
     end
 
     it 'prints an error if no environment variable is present' do
-      expect { described_class.github_token }.to raise_error(FastlaneCore::Interface::FastlaneError)
+      expect { described_class.github_token! }.to raise_error(FastlaneCore::Interface::FastlaneError)
     end
   end
 

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -48,7 +48,15 @@ describe Fastlane::Helper::GithubHelper do
   end
 
   describe 'comment_on_pr' do
-    let(:client) { double(Octokit::Client, :issue_comments => [], :add_comment => nil, :update_comment => nil, :user => double('User', :id => 1234)) }
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        issue_comments: [],
+        add_comment: nil,
+        update_comment: nil,
+        user: instance_double('User', id: 1234)
+      )
+    end
 
     before do
       allow(described_class).to receive(:github_client).and_return(client)
@@ -60,40 +68,38 @@ describe Fastlane::Helper::GithubHelper do
     end
 
     it 'will update an existing comment if one is found' do
-      allow(client).to receive(:issue_comments).and_return([mockComment])
+      allow(client).to receive(:issue_comments).and_return([mock_comment])
       expect(client).to receive(:update_comment)
       comment_on_pr
     end
 
     it 'will not match text outside the reuseID tag' do
-      allow(client).to receive(:issue_comments).and_return([mockComment(body: 'test-id')])
+      allow(client).to receive(:issue_comments).and_return([mock_comment(body: 'test-id')])
       expect(client).to receive(:add_comment)
       comment_on_pr
     end
 
     it 'will not match comments belonging to other users' do
-      allow(client).to receive(:issue_comments).and_return([mockComment(user_id: 0)])
+      allow(client).to receive(:issue_comments).and_return([mock_comment(user_id: 0)])
       expect(client).to receive(:add_comment)
       comment_on_pr
     end
 
     it 'will return the reuse identifier' do
-        expect(comment_on_pr).to eq 'test-id'
+      expect(comment_on_pr).to eq 'test-id'
     end
-
-    @private
 
     def comment_on_pr
       described_class.comment_on_pr(
-          project_slug:'test/test',
-          pr_number: 1234,
-          body: 'Test',
-          reuse_identifier: 'test-id'
-        )
+        project_slug: 'test/test',
+        pr_number: 1234,
+        body: 'Test',
+        reuse_identifier: 'test-id'
+      )
     end
 
-    def mockComment(body: '<!-- REUSE_ID: test-id --> Test', user_id: 1234)
-      double('Comment', :id => 1234, :body => body, :user => double('User', :id => user_id))
+    def mock_comment(body: '<!-- REUSE_ID: test-id --> Test', user_id: 1234)
+      instance_double('Comment', id: 1234, body: body, user: instance_double('User', id: user_id))
     end
   end
 end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -43,7 +43,7 @@ describe Fastlane::Helper::GithubHelper do
     end
 
     it 'prints an error if no environment variable is present' do
-      expect{ described_class.github_token }.to raise_error(FastlaneCore::Interface::FastlaneError)
+      expect { described_class.github_token }.to raise_error(FastlaneCore::Interface::FastlaneError)
     end
   end
 end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -19,4 +19,27 @@ describe Fastlane::Helper::GithubHelper do
       end
     end
   end
+
+  describe 'github_token' do
+    after do
+      ENV['GHHELPER_ACCESS'] = nil
+      ENV['GITHUB_TOKEN'] = nil
+    end
+
+    it 'can use `GHHELPER_ACCESS`' do
+      ENV['GHHELPER_ACCESS'] = 'GHHELPER_ACCESS'
+      expect(described_class.github_token).to eq('GHHELPER_ACCESS')
+    end
+
+    it 'can use `GITHUB_TOKEN`' do
+      ENV['GITHUB_TOKEN'] = 'GITHUB_TOKEN'
+      expect(described_class.github_token).to eq('GITHUB_TOKEN')
+    end
+
+    it 'prioritizes GHHELPER_ACCESS` over `GITHUB_TOKEN` if both are present' do
+      ENV['GITHUB_TOKEN'] = 'GITHUB_TOKEN'
+      ENV['GHHELPER_ACCESS'] = 'GHHELPER_ACCESS'
+      expect(described_class.github_token).to eq('GHHELPER_ACCESS')
+    end
+  end
 end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -41,5 +41,9 @@ describe Fastlane::Helper::GithubHelper do
       ENV['GHHELPER_ACCESS'] = 'GHHELPER_ACCESS'
       expect(described_class.github_token).to eq('GHHELPER_ACCESS')
     end
+
+    it 'prints an error if no environment variable is present' do
+      expect{ described_class.github_token }.to raise_error(FastlaneCore::Interface::FastlaneError)
+    end
   end
 end


### PR DESCRIPTION
Adds an action that makes it easier to add/update PR comments (particularly for installable builds).

This will nicely simplify the process for installable builds, in particular.

**To Test:**
- Includes a new `rspec` test to cover the changes to the GitHub token lookup (to ensure backward compatibility)
- To test locally, you can run: `bundle exec fastlane run comment_on_pr project:wordpress-mobile/release-toolkit pr_number:313 reuse_identifier:my-test`.
- Enter a comment and note that it shows up on this PR.
- Run the command again and enter different text.
- Note that the comment is updated.