### PR TITLE
Sanitize GitHub links in Release Notes

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -11,6 +11,7 @@ module Fastlane
         version = params[:version]
         assets = params[:release_assets]
         release_notes = params[:release_notes_file_path].nil? ? '' : File.read(params[:release_notes_file_path])
+        release_notes.gsub!(%r{https://github.com/([^/]*/[^/]*)/(pulls?|issues?)/([0-9]*)}, '\1#\3')
         prerelease = params[:prerelease]
 
         UI.message("Creating draft release #{version} in #{repository}.")


### PR DESCRIPTION
## The issue

It seems like when we put full URLs to GitHub PRs in the body of a GitHub Release (especially if that URL is inside `[]` brackets), like is the case for our release notes, then GitHub renders those in an odd way.

For example, `[https://github.com/wordpress-mobile/WordPress-Android/pull/1234]`  would render like this:
![image](https://user-images.githubusercontent.com/216089/143894605-7d9a002e-f9b4-4de7-8d84-c1b657070e66.png)

## Changes made in this PR to fix it

The change in this toolkit PR replaces instances of text like `https://github.com/wordpress-mobile/WordPress-Android/pull/1234` with `wordpress-mobile/WordPress-Android#1234` – which is then properly rendered by the GitHub UI as a link to the appropriate PR.

It also handles:
 - `/issues/1234` in addition to `/pull/1234`
 - Common typo of `/issue/1234` instead of the official `/issues/1234` as well as `/pulls/1234` instead of the official `/pull/1234` (yep, GitHub is quite inconsistent here)
 - Links to PRs in other repos, like `https://github.com/wordpress-mobile/gutenberg-mobile/pull/4277` will become `wordpress-mobile/gutenberg-mobile#4277`.

I've tested this RegEx and this new line of code using the `pry` REPL, by running `release_notes = File.read('WordPress/metadata/release_notes.txt')` in the REPL, then pasting that new line of code afterwards, and validating that `release_notes` variable after that contained the expected fixed text.

## View the effect in action

You can see for example on [this past GitHub Release](https://github.com/wordpress-mobile/WordPress-Android/releases/tag/18.7-rc-1) how the body is oddly rendered around those links.

I've manually applied (via VSCode search/replace) the same substitution regex as in this code uses on [the latest GitHub Release](https://github.com/wordpress-mobile/WordPress-Android/releases/tag/18.8-rc-1). You can see how the links are rendered in a way nicer way, including the ones to other repos like Gutenberg-Mobile.