### PR TITLE
Update default branch to trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-_None_
+* Updated default branch for clients to `trunk`
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-* Updated default branch for clients to `trunk`
+_None_
 
 ### New Features
 
@@ -15,6 +15,7 @@
 * Added a `comment_on_pr` action to allow commenting on (and updating comments on) PRs. [#313]
 
 * Added the ability to use the `GITHUB_TOKEN` environment variable for GitHub operations. `GHHELPER_ACCESS` will be deprecated in a future version. [#313]
+* Added parameter for default/base branch across several actions [#319]
 
 ### Bug Fixes
 

--- a/Rakefile
+++ b/Rakefile
@@ -74,7 +74,7 @@ task :new_release do
   Console.header 'Commit and push changes...'
   GitHelper.commit_files("Bumped to version #{new_version}", [VERSION_FILE, 'Gemfile.lock', 'CHANGELOG.md'])
 
-  Console.header 'Opening PR drafts in your default browser...'
+  Console.header 'Opening PR draft in your default browser...'
   GitHelper.prepare_github_pr("release/#{new_version}", 'trunk', "Release #{new_version} into trunk", "New version #{new_version}. Be sure to create a GitHub Release and tag once this PR gets merged.")
 
   Console.info <<~INSTRUCTIONS

--- a/Rakefile
+++ b/Rakefile
@@ -75,7 +75,6 @@ task :new_release do
   GitHelper.commit_files("Bumped to version #{new_version}", [VERSION_FILE, 'Gemfile.lock', 'CHANGELOG.md'])
 
   Console.header 'Opening PR drafts in your default browser...'
-  GitHelper.prepare_github_pr("release/#{new_version}", 'develop', "Release #{new_version} into develop", "New version #{new_version}")
   GitHelper.prepare_github_pr("release/#{new_version}", 'trunk', "Release #{new_version} into trunk", "New version #{new_version}. Be sure to create a GitHub Release and tag once this PR gets merged.")
 
   Console.info <<~INSTRUCTIONS
@@ -84,8 +83,8 @@ task :new_release do
 
     >>> WHAT'S NEXT
 
-    1. Create PRs to `develop` and `trunk`.
-    2. Once the PRs are merged, publish a GitHub release for \`#{new_version}\`, targeting \`trunk\`,
+    1. Create a PR against `trunk`.
+    2. Once the PR is merged, publish a GitHub release for \`#{new_version}\`, targeting \`trunk\`,
        creating a new \`#{new_version} tag in the process.
 
     The creation of the new tag will trigger a CI workflow that will take care of doing the

--- a/docs/screenshot-compositor.md
+++ b/docs/screenshot-compositor.md
@@ -23,7 +23,7 @@ This argument is a path to the directory containing the screenshots, typically g
 
 **`metadata_folder`**
 
-This argument is a path to the directory containing any metadata, such as localized strings for use on the final screenshots. This directory should contain subdirectories named after locales. 
+This argument is a path to the directory containing any metadata, such as localized strings for use on the final screenshots. This directory should contain subdirectories named after locales.
 
 > Note: The tool will automatically check these directories, and will be default use any locales found in both directories.
 
@@ -43,7 +43,7 @@ The tool uses a `.json` file for configuration. By default, the tool will attemp
 
 The following sample implementations provide a good example of how to create a configuration file:
 
-- [WordPress Android](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/fastlane/screenshots.json)
+- [WordPress Android](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/fastlane/screenshots.json)
 
 ## Creating a configuration file
 
@@ -160,7 +160,7 @@ Entries specify the set of output screenshots. This takes the form of an array o
 
 > Note: There is a 1:1 relationship between entries and the final screenshots. Note that it is not necessary to create a set of entries for each locale – this is automatically handled for you.
 
-Each entry looks something like this: 
+Each entry looks something like this:
 
 ```json
 {
@@ -251,19 +251,19 @@ Specifies a list of attachments, which can be images or text. They are composite
 ```
 Text attachments use the following keys:
 
-**`text`** 
+**`text`**
 
 Specifies the path to the text file for this attachment. The path should be specified relative to the configuration file, and can contain the `{locale}` placeholder to allow for localization.
 
-**`size`** 
+**`size`**
 
-Sets the dimensions of the text bounding box within the final image. This must be provided as an array with two values corresponding to the width and height, respectively. If the size is too small, the compositor will crash saying it was unable to draw the text in an area this small. The text will be horizontally and vertically centered within the bounding box. 
+Sets the dimensions of the text bounding box within the final image. This must be provided as an array with two values corresponding to the width and height, respectively. If the size is too small, the compositor will crash saying it was unable to draw the text in an area this small. The text will be horizontally and vertically centered within the bounding box.
 
-**`position`** 
+**`position`**
 
 Sets the origin of the text bounding box within the final image. This must be provided as an array with two values corresponding to the x and y coordinates, respectively.
 
-**`font-size`** 
+**`font-size`**
 
 Specifies the font size for the text of this attachment. If this number is too large, such that it doesn't fit into the bounding box described by the `size` key, the compositor will exit with an error message.
 
@@ -282,19 +282,19 @@ Specifies a stylesheet used for this attachment. It should contain a path to the
 
 Image attachments use the following keys:
 
-**`file`** 
+**`file`**
 
 Specifies the path to the attachment image. The path should be specified relative to the configuration file, and can contain the `{locale}` placeholder to allow for localization.
 
-**`size`** 
+**`size`**
 
 Sets the dimensions of the attachment within the final image. This must be provided as an array with two values corresponding to the width and height, respectively.
 
-**`position`** 
+**`position`**
 
 Sets the origin of the attachment within the final image. This must be provided as an array with two values corresponding to the x and y coordinates, respectively.
 
-**`operations`** 
+**`operations`**
 
 Specifies a set of operations to perform on the attachment prior to drawing it to the canvas. Operations run in the order they're specified within the configuration file. Operations are defined as an array of hashes. For example:
 
@@ -308,7 +308,7 @@ Specifies a set of operations to perform on the attachment prior to drawing it t
 
 They use the following keys:
 
-**`type`** 
+**`type`**
 
 Describes the type of operation. Currently `crop` is the only operation that can be specified.
 
@@ -316,10 +316,10 @@ Describes the type of operation. Currently `crop` is the only operation that can
 
 *Crop* allows you to crop the image using two keys:
 
-**`at`** 
+**`at`**
 
 Specifies the origin point crop bounding box. This must be provided as an array with two values corresponding to the x and y coordinates, respectively.
 
-**`to`** 
+**`to`**
 
 Specifies the dimensions of the crop bounding box. This must be provided as an array with two values corresponding to the width and height, respectively.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -8,8 +8,9 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        # Checkout trunk and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
+        # Checkout default branch and update
+        default_branch = params[:default_branch] || 'develop'
+        Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Check versions
         release_version = Fastlane::Helper::Android::VersionHelper.get_release_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper'
 
         # Checkout default branch and update
-        default_branch = params[:default_branch] || 'develop'
+        default_branch = params[:default_branch]
         Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Check versions
@@ -81,6 +81,11 @@ module Fastlane
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false), # the default value if the user didn't provide one
+          FastlaneCore::ConfigItem.new(key: :default_branch,
+                                       env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
+                                       description: 'Default branch of the repository',
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -8,8 +8,8 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        # Checkout develop and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('develop')
+        # Checkout trunk and update
+        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
 
         # Check versions
         release_version = Fastlane::Helper::Android::VersionHelper.get_release_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -84,7 +84,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       type: String,
                                        default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -8,7 +8,7 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        other_action.ensure_git_branch(branch: 'develop')
+        other_action.ensure_git_branch(branch: 'trunk')
 
         # Create new configuration
         new_short_version = Fastlane::Helper::Android::VersionHelper.bump_version_release
@@ -28,9 +28,9 @@ module Fastlane
         UI.message("New version: #{new_short_version}")
         UI.message("Release branch: #{new_release_branch}")
 
-        # Update local develop and branch
+        # Update local trunk and branch
         UI.message 'Creating new branch...'
-        Fastlane::Helper::GitHelper.create_branch(new_release_branch, from: 'develop')
+        Fastlane::Helper::GitHelper.create_branch(new_release_branch, from: 'trunk')
         UI.message 'Done!'
 
         UI.message 'Updating app version...'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -8,7 +8,7 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        default_branch = params[:default_branch] || 'develop'
+        default_branch = params[:default_branch]
         other_action.ensure_git_branch(branch: default_branch)
 
         # Create new configuration
@@ -53,7 +53,13 @@ module Fastlane
       end
 
       def self.available_options
-        # Define all options your action supports.
+        [
+          FastlaneCore::ConfigItem.new(key: :default_branch,
+                                       env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
+                                       description: 'Default branch of the repository',
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
+        ]
       end
 
       def self.output

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -8,7 +8,8 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        other_action.ensure_git_branch(branch: 'trunk')
+        default_branch = params[:default_branch] || 'develop'
+        other_action.ensure_git_branch(branch: default_branch)
 
         # Create new configuration
         new_short_version = Fastlane::Helper::Android::VersionHelper.bump_version_release
@@ -28,9 +29,9 @@ module Fastlane
         UI.message("New version: #{new_short_version}")
         UI.message("Release branch: #{new_release_branch}")
 
-        # Update local trunk and branch
+        # Update local default branch and create branch from it
         UI.message 'Creating new branch...'
-        Fastlane::Helper::GitHelper.create_branch(new_release_branch, from: 'trunk')
+        Fastlane::Helper::GitHelper.create_branch(new_release_branch, from: default_branch)
         UI.message 'Done!'
 
         UI.message 'Updating app version...'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -57,7 +57,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       type: String,
                                        default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -11,8 +11,9 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        # Checkout trunk and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
+        # Checkout default branch and update
+        default_branch = params[:default_branch] || 'develop'
+        Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Create versions
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version
@@ -23,7 +24,7 @@ module Fastlane
         no_alpha_version_message = "No alpha version configured. If you wish to configure an alpha version please update version.properties to include an alpha key for this app\n"
         # Ask user confirmation
         unless params[:skip_confirm]
-          confirm_message = "Building a new release branch starting from trunk.\nCurrent version is #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
+          confirm_message = "Building a new release branch starting from #{default_branch}.\nCurrent version is #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += current_alpha_version.nil? ? no_alpha_version_message : "Current Alpha version is #{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += current_alpha_version.nil? ? '' : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
@@ -47,7 +48,7 @@ module Fastlane
       end
 
       def self.details
-        'Updates the trunk branch, checks the app version and ensure the branch is clean'
+        'Updates the default branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -11,8 +11,8 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        # Checkout develop and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('develop')
+        # Checkout trunk and update
+        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
 
         # Create versions
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version
@@ -23,7 +23,7 @@ module Fastlane
         no_alpha_version_message = "No alpha version configured. If you wish to configure an alpha version please update version.properties to include an alpha key for this app\n"
         # Ask user confirmation
         unless params[:skip_confirm]
-          confirm_message = "Building a new release branch starting from develop.\nCurrent version is #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
+          confirm_message = "Building a new release branch starting from trunk.\nCurrent version is #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += current_alpha_version.nil? ? no_alpha_version_message : "Current Alpha version is #{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += current_alpha_version.nil? ? '' : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
@@ -47,7 +47,7 @@ module Fastlane
       end
 
       def self.details
-        'Updates the develop branch, checks the app version and ensure the branch is clean'
+        'Updates the trunk branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -62,7 +62,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       type: String,
                                        default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -12,7 +12,7 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper'
 
         # Checkout default branch and update
-        default_branch = params[:default_branch] || 'develop'
+        default_branch = params[:default_branch]
         Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Create versions
@@ -59,6 +59,11 @@ module Fastlane
                                        description: 'Skips confirmation before codefreeze',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false), # the default value if the user didn't provide one
+          FastlaneCore::ConfigItem.new(key: :default_branch,
+                                       env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
+                                       description: 'Default branch of the repository',
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -8,8 +8,9 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        # Checkout trunk and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
+        # Checkout default branch and update
+        default_branch = params[:default_branch] || 'develop'
+        Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Check versions
         build_version = Fastlane::Helper::Ios::VersionHelper.get_build_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper'
 
         # Checkout default branch and update
-        default_branch = params[:default_branch] || 'develop'
+        default_branch = params[:default_branch]
         Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Check versions
@@ -70,6 +70,11 @@ module Fastlane
                                        description: 'Skips confirmation',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false), # the default value if the user didn't provide one
+          FastlaneCore::ConfigItem.new(key: :default_branch,
+                                       env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
+                                       description: 'Default branch of the repository',
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -8,8 +8,8 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        # Checkout develop and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('develop')
+        # Checkout trunk and update
+        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
 
         # Check versions
         build_version = Fastlane::Helper::Ios::VersionHelper.get_build_version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -73,7 +73,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       type: String,
                                        default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -8,7 +8,7 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        default_branch = params[:default_branch] || 'develop'
+        default_branch = params[:default_branch]
         other_action.ensure_git_branch(branch: default_branch)
 
         # Create new configuration
@@ -65,7 +65,11 @@ module Fastlane
                                        description: 'Skips Deliver key update',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false), # the default value if the user didn't provide one
-
+          FastlaneCore::ConfigItem.new(key: :default_branch,
+                                       env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
+                                       description: 'Default branch of the repository',
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -8,16 +8,16 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        other_action.ensure_git_branch(branch: 'develop')
+        other_action.ensure_git_branch(branch: 'trunk')
 
         # Create new configuration
         @new_version = Fastlane::Helper::Ios::VersionHelper.bump_version_release()
         create_config()
         show_config()
 
-        # Update local develop and branch
-        Fastlane::Helper::GitHelper.checkout_and_pull('develop')
-        Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: 'develop')
+        # Update local trunk and branch
+        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
+        Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: 'trunk')
         UI.message 'Done!'
 
         UI.message 'Updating glotPressKeys...' unless params[:skip_glotpress]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -8,16 +8,17 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        other_action.ensure_git_branch(branch: 'trunk')
+        default_branch = params[:default_branch] || 'develop'
+        other_action.ensure_git_branch(branch: default_branch)
 
         # Create new configuration
         @new_version = Fastlane::Helper::Ios::VersionHelper.bump_version_release()
         create_config()
         show_config()
 
-        # Update local trunk and branch
-        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
-        Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: 'trunk')
+        # Update local default branch and create branch from it
+        Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
+        Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: default_branch)
         UI.message 'Done!'
 
         UI.message 'Updating glotPressKeys...' unless params[:skip_glotpress]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -68,7 +68,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       type: String,
                                        default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -9,7 +9,7 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper'
 
         # Checkout default branch and update
-        default_branch = params[:default_branch] || 'develop'
+        default_branch = params[:default_branch]
         Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Create versions
@@ -49,6 +49,11 @@ module Fastlane
                                        description: 'Skips confirmation before codefreeze',
                                        is_string: false, # true: verifies the input is a string, false: every kind of value
                                        default_value: false), # the default value if the user didn't provide one
+          FastlaneCore::ConfigItem.new(key: :default_branch,
+                                       env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
+                                       description: 'Default branch of the repository',
+                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -8,8 +8,9 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        # Checkout trunk and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
+        # Checkout default branch and update
+        default_branch = params[:default_branch] || 'develop'
+        Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)
 
         # Create versions
         current_version = Fastlane::Helper::Ios::VersionHelper.get_public_version
@@ -17,7 +18,7 @@ module Fastlane
         next_version = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(current_version)
 
         # Ask user confirmation
-        unless params[:skip_confirm] || UI.confirm("Building a new release branch starting from trunk.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
+        unless params[:skip_confirm] || UI.confirm("Building a new release branch starting from #{default_branch}.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
           UI.user_error!('Aborted by user request')
         end
 
@@ -37,7 +38,7 @@ module Fastlane
       end
 
       def self.details
-        'Updates the trunk branch, checks the app version and ensure the branch is clean'
+        'Updates the default branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -8,8 +8,8 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        # Checkout develop and update
-        Fastlane::Helper::GitHelper.checkout_and_pull('develop')
+        # Checkout trunk and update
+        Fastlane::Helper::GitHelper.checkout_and_pull('trunk')
 
         # Create versions
         current_version = Fastlane::Helper::Ios::VersionHelper.get_public_version
@@ -17,7 +17,7 @@ module Fastlane
         next_version = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(current_version)
 
         # Ask user confirmation
-        unless params[:skip_confirm] || UI.confirm("Building a new release branch starting from develop.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
+        unless params[:skip_confirm] || UI.confirm("Building a new release branch starting from trunk.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
           UI.user_error!('Aborted by user request')
         end
 
@@ -37,7 +37,7 @@ module Fastlane
       end
 
       def self.details
-        'Updates the develop branch, checks the app version and ensure the branch is clean'
+        'Updates the trunk branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -52,7 +52,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
+                                       type: String,
                                        default_value: Fastlane::Helper::GitHelper::DEFAULT_GIT_BRANCH),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -5,6 +5,11 @@ module Fastlane
     # Helper methods to execute git-related operations
     #
     module GitHelper
+      # Fallback default branch of the client repository. It's currently set to 'develop' for
+      # backwards compatibility.
+      # TODO: Set to 'trunk' for the next major release.
+      DEFAULT_GIT_BRANCH = 'develop'.freeze
+
       # Checks if the given path, or current directory if no path is given, is
       # inside a Git repository
       #

--- a/rakelib/git_helpers.rake
+++ b/rakelib/git_helpers.rake
@@ -11,7 +11,7 @@ module GitHelper
     elsif branch_exists
       Rake.sh('git', 'checkout', release_branch)
     else # create it
-      abort('Aborted, as not run from develop nor release branch') unless current_branch == 'develop' || Console.confirm("You are not on 'develop', nor already on '#{release_branch}'. Do you really want to cut the release branch from #{current_branch}?")
+      abort('Aborted, as not run from trunk nor release branch') unless current_branch == 'trunk' || Console.confirm("You are not on 'trunk', nor already on '#{release_branch}'. Do you really want to cut the release branch from #{current_branch}?")
 
       Rake.sh('git', 'checkout', '-b', release_branch)
     end

--- a/spec/ci_helper_spec.rb
+++ b/spec/ci_helper_spec.rb
@@ -29,10 +29,10 @@ describe Fastlane::Helper::CircleCIHelper do
     describe Fastlane::Helper::CircleCIHelper.new(login: 'my_circleci_token', repository: 'test_repo') do
       it 'triggers a job' do
         stub = stub_request(:post, 'https://circleci.com/api/v2/project/github/wordpress-mobile/test_repo/pipeline').with(
-          body: { branch: 'develop', parameters: nil },
+          body: { branch: 'trunk', parameters: nil },
           headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json', 'Circle-Token' => 'my_circleci_token' }
         ).to_return(body: 'efg')
-        subject.trigger_job(branch: 'develop')
+        subject.trigger_job(branch: 'trunk')
         expect(stub).to have_been_made.once
       end
     end


### PR DESCRIPTION
This PR prepares the `release-toolkit` for the removal of `develop` branch for its clients as well as the library itself. I haven't worked with `release-toolkit` almost at all, so I basically searched for `develop` and replaced the ones that made sense to me with `trunk`. I considered using a `DEFAULT_BRANCH` constant, but I wasn't sure where to put it. 😅 Since we also refer to this branch in comments and it's not very likely to change again, I proceeded with a simple text replacement.

I am hoping reviewers can point out anything I might have missed. If you can take a moment to do a quick search, I'd really appreciate it.

Please review this PR but keep it as draft until the clients are ready for the update. Once we merge this, I think we should do a major update as this is a breaking change.