### PR TITLE
Adds support for downloading GitHub content for private repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ _None_
 
 * Added the ability to use the `GITHUB_TOKEN` environment variable for GitHub operations. `GHHELPER_ACCESS` will be deprecated in a future version. [#313]
 
+* Added support for downloading GitHub content for private repositories
+
 ### Bug Fixes
 
 * Fixed the rendering of PR links in the body of GitHub Releases created via the `create_release` action. [#316]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -132,8 +132,8 @@ module Fastlane
         download_path = File.join(download_folder, file_name)
 
         download_url = github_client.contents(repository,
-                                              :path => file_path,
-                                              :ref => tag).download_url
+                                              path: file_path,
+                                              ref: tag).download_url
         begin
           uri = URI.parse(download_url)
           uri.open do |remote_file|

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -131,8 +131,11 @@ module Fastlane
         file_name = File.basename(file_path)
         download_path = File.join(download_folder, file_name)
 
+        download_url = github_client.contents(repository,
+                                              :path => file_path,
+                                              :ref => tag).download_url
         begin
-          uri = URI.parse("https://raw.githubusercontent.com/#{repository}/#{tag}/#{file_path}")
+          uri = URI.parse(download_url)
           uri.open do |remote_file|
             File.write(download_path, remote_file.read)
           end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -3,17 +3,32 @@ require 'webmock/rspec'
 
 describe Fastlane::Helper::GithubHelper do
   describe 'download_file_from_tag' do
+    let(:test_repo) { 'repo-test/project-test' }
+    let(:test_tag) { '1.0' }
+    let(:test_file) { 'test-folder/test-file.xml' }
+    let(:content_url) { "https://api.github.com/repos/#{test_repo}/contents/#{test_file}?ref=#{test_tag}" }
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        contents: double(download_url: content_url) # rubocop:disable RSpec/VerifiedDoubles
+      )
+    end
+
+    before do
+      allow(described_class).to receive(:github_client).and_return(client)
+    end
+
     it 'fails if it does not find the right release on GitHub' do
-      stub = stub_request(:get, 'https://raw.githubusercontent.com/repo-test/project-test/1.0/test-file.xml').to_return(status: [404, 'Not Found'])
-      expect(described_class.download_file_from_tag(repository: 'repo-test/project-test', tag: '1.0', file_path: 'test-file.xml', download_folder: './')).to be_nil
+      stub = stub_request(:get, content_url).to_return(status: [404, 'Not Found'])
+      expect(described_class.download_file_from_tag(repository: test_repo, tag: test_tag, file_path: test_file, download_folder: './')).to be_nil
       expect(stub).to have_been_made.once
     end
 
     it 'writes the raw content to a file' do
-      stub = stub_request(:get, 'https://raw.githubusercontent.com/repo-test/project-test/1.0/test-file.xml').to_return(status: 200, body: 'my-test-content')
+      stub = stub_request(:get, content_url).to_return(status: 200, body: 'my-test-content')
       Dir.mktmpdir('a8c-download-repo-file-') do |tmpdir|
         dst_file = File.join(tmpdir, 'test-file.xml')
-        expect(described_class.download_file_from_tag(repository: 'repo-test/project-test', tag: '1.0', file_path: 'test-file.xml', download_folder: tmpdir)).to eq(dst_file)
+        expect(described_class.download_file_from_tag(repository: test_repo, tag: test_tag, file_path: test_file, download_folder: tmpdir)).to eq(dst_file)
         expect(stub).to have_been_made.once
         expect(File.read(dst_file)).to eq('my-test-content')
       end


### PR DESCRIPTION
This PR adds support for downloading files from private GitHub repos. This is necessary to localize the `Automattic/about-automattic-android` private repository.

**This PR needs to be merged and a new tag/release has to be created before the next code freeze on Monday.**