### PR TITLE
Release 2.3.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ _None_
 
 _None_
 
+## 2.3.0
+
 ## 2.2.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ _None_
 
 ## 2.3.0
 
+### New Features
+
+* Added parameter for default/base branch across several actions [#319]
+
 ## 2.2.0
 
 ### New Features
@@ -30,7 +34,6 @@ _None_
 * Added a `comment_on_pr` action to allow commenting on (and updating comments on) PRs. [#313]
 * Added the ability to use the `GITHUB_TOKEN` environment variable for GitHub operations. `GHHELPER_ACCESS` will be deprecated in a future version. [#313]
 * Added support for downloading GitHub content for private repositories [#321]
-* Added parameter for default/base branch across several actions [#319]
 
 ### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (2.2.0)
+    fastlane-plugin-wpmreleasetoolkit (2.3.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '2.2.0'
+    VERSION = '2.3.0'
   end
 end


### PR DESCRIPTION
#319 added a new CHANGELOG item which was originally part of the `## Develop` heading. After https://github.com/wordpress-mobile/release-toolkit/pull/323 was merged to `develop`, that same item ended up being a part of `2.2.0` and didn't result in a conflict. While cutting the release, I realized the issue and fixed it in this release branch.

In short, even though it looks like `2.2.0` release had an incorrect release note, this is actually not the case and [can be verified from the `2.2.0` tag](https://github.com/wordpress-mobile/release-toolkit/blob/2.2.0/CHANGELOG.md).
