### PR TITLE
CI: Make gem push step depend on other checks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#v1.3.2: ~
+  - &bash_cache automattic/bash-cache#2.0.0: ~
   env: &common_env
     IMAGE_ID: xcode-12.5.1
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
   # Build and Test
   #################
   - label: "🧪 Build and Test"
-    key: "test"
+    key: test
     command: |
       .buildkite/install-dependencies.sh
 
@@ -30,7 +30,8 @@ steps:
   #################
   # Lint
   #################
-  - label: "🧹 Lint"
+  - label: "🧹 Lint (Rubocop)"
+    key: rubocop
     command: |
       .buildkite/install-dependencies.sh
 
@@ -45,6 +46,7 @@ steps:
   # Danger
   #################
   - label: "⛔️ Danger"
+    key: danger
     command: |
       .buildkite/install-dependencies.sh
 
@@ -61,6 +63,7 @@ steps:
   - label: ":rubygems: Publish to RubyGems"
     key: "gem-push"
     if: build.tag != null
+    depends_on: ["test", "rubocop", "danger"]
     # Note: We intentionally call a separate `.sh` script here (as opposed to having all the 
     # commands written inline) to avoid leaking a key used in the process in clear in the
     # BUILDKITE_COMMAND environment variable.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,7 +63,10 @@ steps:
   - label: ":rubygems: Publish to RubyGems"
     key: "gem-push"
     if: build.tag != null
-    depends_on: ["test", "rubocop", "danger"]
+    depends_on:
+     - test
+     - rubocop
+     - danger
     # Note: We intentionally call a separate `.sh` script here (as opposed to having all the 
     # commands written inline) to avoid leaking a key used in the process in clear in the
     # BUILDKITE_COMMAND environment variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+* Ensure that the `gem push` step only runs on CI if lint, test and danger steps passed before it. [#325]
 
 ## 2.3.0
 


### PR DESCRIPTION
 - Make the `gem-push` step depend on lint, test and danger
 - Update the `bash-cache` plugin version
 - ~Update the Xcode image to 13~ ➡️ Back-pedalled on this because xcode-13 image still [requires the `gem install bundler` FIXITs](https://github.com/wordpress-mobile/WordPress-iOS/blob/35819a3b8b150e7a8dad76a474950cace792cc17/.buildkite/commands/build-for-testing.sh#L3-L5) and `xcode-13.1` image (which fixes that) should be out soon, so better wait for it anyway

@jkmassel feel free to take over this PR to bump the `IMAGE_ID` to `xcode-13.1` if it's ready before this PR gets merged. (Otherwise nbd, we'll just migrate in a separate PR 🙃 )