### PR TITLE
Rename Linter helper in preparation for new upcoming actions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -306,7 +306,7 @@ Style/MutableConstant:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb'
+    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/version.rb'
     - 'spec/release_notes_helper_spec.rb'
 
@@ -403,7 +403,7 @@ Style/RescueStandardError:
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb'
-    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb'
+    - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb'
     - 'lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb'
 
 # Offense count: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _None_
 ### Internal Changes
 
 * Ensure that the `gem push` step only runs on CI if lint, test and danger steps passed before it. [#325]
+* Rename internal `Ios::L10nHelper` to `Ios::L10nLinterHelper`. [#328]
 
 ## 2.3.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -17,8 +17,8 @@ module Fastlane
       def self.run_linter(params)
         UI.message 'Linting localizations for parameter placeholders consistency...'
 
-        require_relative '../../helper/ios/ios_l10n_helper'
-        helper = Fastlane::Helper::Ios::L10nHelper.new(
+        require_relative '../../helper/ios/ios_l10n_linter_helper'
+        helper = Fastlane::Helper::Ios::L10nLinterHelper.new(
           install_path: resolve_path(params[:install_path]),
           version: params[:version]
         )
@@ -92,7 +92,7 @@ module Fastlane
             description: 'The path where to install the SwiftGen tooling needed to run the linting process. If a relative path, should be relative to your repo_root',
             type: String,
             optional: true,
-            default_value: "vendor/swiftgen/#{Fastlane::Helper::Ios::L10nHelper::SWIFTGEN_VERSION}"
+            default_value: "vendor/swiftgen/#{Fastlane::Helper::Ios::L10nLinterHelper::SWIFTGEN_VERSION}"
           ),
           FastlaneCore::ConfigItem.new(
             key: :version,
@@ -100,7 +100,7 @@ module Fastlane
             description: 'The version of SwiftGen to install and use for linting',
             type: String,
             optional: true,
-            default_value: Fastlane::Helper::Ios::L10nHelper::SWIFTGEN_VERSION
+            default_value: Fastlane::Helper::Ios::L10nLinterHelper::SWIFTGEN_VERSION
           ),
           FastlaneCore::ConfigItem.new(
             key: :input_dir,
@@ -115,7 +115,7 @@ module Fastlane
             description: 'The language that should be used as the base language that every other language will be compared against',
             type: String,
             optional: true,
-            default_value: Fastlane::Helper::Ios::L10nHelper::DEFAULT_BASE_LANG
+            default_value: Fastlane::Helper::Ios::L10nLinterHelper::DEFAULT_BASE_LANG
           ),
           FastlaneCore::ConfigItem.new(
             key: :only_langs,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
@@ -4,7 +4,7 @@ require 'tmpdir'
 module Fastlane
   module Helper
     module Ios
-      class L10nHelper
+      class L10nLinterHelper
         SWIFTGEN_VERSION = '6.4.0'
         DEFAULT_BASE_LANG = 'en'
         CONFIG_FILE_NAME = 'swiftgen-stringtypes.yml'

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -18,7 +18,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
 
           # First run: expect curl, unzip and cp_r to be called to install SwiftGen before running the action
           # See spec_helper.rb for documentation about `expect_shell_command`.
-          expect_shell_command('curl', any_args, %r{/.*swiftgen-#{Fastlane::Helper::Ios::L10nHelper::SWIFTGEN_VERSION}.zip})
+          expect_shell_command('curl', any_args, %r{/.*swiftgen-#{Fastlane::Helper::Ios::L10nLinterHelper::SWIFTGEN_VERSION}.zip})
           expect_shell_command('unzip', any_args)
           expect(FileUtils).to receive(:cp_r)
           expect_shell_command("#{install_dir}/bin/swiftgen", 'config', 'run', '--config', anything)
@@ -33,7 +33,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
           script = <<~SCRIPT
             #!/bin/sh
             if [[ "$1" == "--version" ]]; then
-              echo "SwiftGen v#{Fastlane::Helper::Ios::L10nHelper::SWIFTGEN_VERSION} (Fake binstub)"
+              echo "SwiftGen v#{Fastlane::Helper::Ios::L10nLinterHelper::SWIFTGEN_VERSION} (Fake binstub)"
             fi
           SCRIPT
           FileUtils.mkdir_p File.join(install_dir, 'bin')
@@ -102,7 +102,7 @@ def run_l10n_linter_test(data_file)
   # Note: We will install SwiftGen in vendor/swiftgen if it's not already installed yet, and intentionally won't
   #       remove this after the test ends, so that further executions of the test run faster.
   #       Only the first execution of the tests might take longer if it needs to install SwiftGen first to be able to run the tests.
-  install_dir = "vendor/swiftgen/#{Fastlane::Helper::Ios::L10nHelper::SWIFTGEN_VERSION}"
+  install_dir = "vendor/swiftgen/#{Fastlane::Helper::Ios::L10nLinterHelper::SWIFTGEN_VERSION}"
   result = Fastlane::Actions::IosLintLocalizationsAction.run(
     install_path: install_dir,
     input_dir: @test_data_dir,


### PR DESCRIPTION
⚠️  This PR is built on top of https://github.com/wordpress-mobile/release-toolkit/pull/327 and is intended to be merged only after https://github.com/wordpress-mobile/release-toolkit/pull/327 is merged.
_(I decided to do individual PRs to make each step easier to review)_

## What

In preparation for the new actions to come to handle the various parts of the L10n project, this renames the `Ios::L10nHelper` to `Ios::L10nLinterHelper`.

## Why

This is because this helper is currently only containing/focused on methods about our SwiftGen-based iOS `.strings` file linter, and that helper is already quite large.

It seems like a good thing to keep all that's related to the linter in a dedicated helper like that, but given I plan to need more helper methods for other L10n-related things as part of my L10n tooling modernization project, and didn't want to add those future new L10n-but-non-linter-related helper methods in the same file, this PR renames that helper to make it clear that it's L10n-Linter-specific, that way we will be able to create a brand new and different `Ios::L10nHelper` file for everything else I plan to add there.