### PR TITLE
Switch to running `an_` and `gp_` metadata actions via Fastfile parsing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -131,6 +131,7 @@ RSpec/FilePath:
     - 'spec/android_localize_helper_spec.rb'
     - 'spec/android_merge_translators_strings_spec.rb'
     - 'spec/android_version_helper_spec.rb'
+    - 'spec/an_localize_libs_action_spec.rb'
     - 'spec/an_metadata_update_helper_spec.rb'
     - 'spec/an_update_metadata_source_spec.rb'
     - 'spec/configuration_spec.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _None_
 
 * Ensure that the `gem push` step only runs on CI if lint, test and danger steps passed before it. [#325]
 * Rename internal `Ios::L10nHelper` to `Ios::L10nLinterHelper`. [#328]
+* Provide new `run_described_fastlane_action` to run Fastlane actions more thoroughly in unit tests [#330]
 
 ## 2.3.0
 

--- a/spec/an_localize_libs_action_spec.rb
+++ b/spec/an_localize_libs_action_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::AnLocalizeLibsAction do
+  # This test is more of a way of ensuring `run_described_action` handles array
+  # of hashes properly than a comprehensive test for the
+  # `an_localize_libs_action` action.
+  #
+  # Please consider expanding this test if you'll find yourself working on its
+  # action.
+  it 'merges the strings from the given array into the given main strings file' do
+    in_tmp_dir do |tmp_dir|
+      app_strings_path = File.join(tmp_dir, 'app.xml')
+      File.write(app_strings_path, android_xml_with_content('<string name="a_string">test from app</string>'))
+
+      lib1_strings_path = File.join(tmp_dir, 'lib1.xml')
+      File.write(lib1_strings_path, android_xml_with_content('<string name="a_lib1_string">test from lib 1</string>'))
+
+      lib2_strings_path = File.join(tmp_dir, 'lib2.xml')
+      File.write(lib2_strings_path, android_xml_with_content('<string name="a_lib2_string">test from lib 2</string>'))
+
+      run_described_action(
+        app_strings_path: app_strings_path,
+        libs_strings_path: [
+          { library: 'lib_1', strings_path: lib1_strings_path, exclusions: [] },
+          { library: 'lib_2', strings_path: lib2_strings_path, exclusions: [] },
+        ]
+      )
+
+      # Notice the extra indentation in the library strings. The action doesn't
+      # modify the app's strings content indentation, but it applies its own
+      # standard to the values read from the given library strings
+      expected = <<~XML
+        <string name="a_string">test from app</string>
+          <string name="a_lib1_string">test from lib 1</string>
+          <string name="a_lib2_string">test from lib 2</string>
+      XML
+      expect(File.read(app_strings_path)).to eq(android_xml_with_content(expected))
+    end
+  end
+end
+
+def android_xml_with_content(content)
+  # I couldn't find a way to interpolate a multiline string preserving its
+  # indentation in the heredoc below, so I hacked the following transformation
+  # of the input that adds the desired indentation to all lines.
+  indented_content = content.chomp.lines.map { |l| "  #{l}" }.join
+
+  return <<~XML
+    <?xml version="1.0" encoding="UTF-8"?>
+    <resources xmlns:tools="http://schemas.android.com/tools">
+    #{indented_content}
+    </resources>
+  XML
+end

--- a/spec/an_localize_libs_action_spec.rb
+++ b/spec/an_localize_libs_action_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AnLocalizeLibsAction do
-  # This test is more of a way of ensuring `run_described_action` handles array
+  # This test is more of a way of ensuring `run_described_fastlane_action` handles array
   # of hashes properly than a comprehensive test for the
   # `an_localize_libs_action` action.
   #
@@ -18,7 +18,7 @@ describe Fastlane::Actions::AnLocalizeLibsAction do
       lib2_strings_path = File.join(tmp_dir, 'lib2.xml')
       File.write(lib2_strings_path, android_xml_with_content('<string name="a_lib2_string">test from lib 2</string>'))
 
-      run_described_action(
+      run_described_fastlane_action(
         app_strings_path: app_strings_path,
         libs_strings_path: [
           { library: 'lib_1', strings_path: lib1_strings_path, exclusions: [] },

--- a/spec/android_merge_translators_strings_spec.rb
+++ b/spec/android_merge_translators_strings_spec.rb
@@ -35,7 +35,7 @@ end
 def amts_run_test(script)
   test_script = @amtsTestUtils.get_test_from_file(script)
   @amtsTestUtils.create_test_data(test_script)
-  Fastlane::Actions::AndroidMergeTranslatorsStringsAction.run(strings_folder: @amtsTestUtils.test_folder_path)
+  run_described_fastlane_action(strings_folder: @amtsTestUtils.test_folder_path)
   expect(@amtsTestUtils.read_result_data(test_script)).to eq(test_script['result']['content'])
 end
 

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -23,7 +23,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
           expect(FileUtils).to receive(:cp_r)
           expect_shell_command("#{install_dir}/bin/swiftgen", 'config', 'run', '--config', anything)
 
-          Fastlane::Actions::IosLintLocalizationsAction.run(
+          run_described_fastlane_action(
             install_path: install_dir,
             input_dir: empty_dataset,
             base_lang: 'en'
@@ -43,7 +43,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
           # Second run: ensure we only run SwiftGen directly, without a call to curl nor unzip beforehand
           expect_shell_command("#{install_dir}/bin/swiftgen", 'config', 'run', '--config', anything)
 
-          Fastlane::Actions::IosLintLocalizationsAction.run(
+          run_described_fastlane_action(
             install_path: install_dir,
             input_dir: empty_dataset,
             base_lang: 'en'
@@ -103,7 +103,7 @@ def run_l10n_linter_test(data_file)
   #       remove this after the test ends, so that further executions of the test run faster.
   #       Only the first execution of the tests might take longer if it needs to install SwiftGen first to be able to run the tests.
   install_dir = "vendor/swiftgen/#{Fastlane::Helper::Ios::L10nLinterHelper::SWIFTGEN_VERSION}"
-  result = Fastlane::Actions::IosLintLocalizationsAction.run(
+  result = run_described_fastlane_action(
     install_path: install_dir,
     input_dir: @test_data_dir,
     base_lang: 'en'

--- a/spec/ios_merge_strings_files_spec.rb
+++ b/spec/ios_merge_strings_files_spec.rb
@@ -19,7 +19,7 @@ describe Fastlane::Actions::IosMergeStringsFilesAction do
 
         # Act
         result = Dir.chdir(tmpdir) do
-          run_described_action(
+          run_described_fastlane_action(
             paths: [inputs[0], inputs[1]],
             destination: 'output.strings'
           )

--- a/spec/ios_merge_strings_files_spec.rb
+++ b/spec/ios_merge_strings_files_spec.rb
@@ -1,41 +1,39 @@
-describe Fastlane do
-  describe Fastlane::FastFile do
-    let(:test_data_dir) { File.join(File.dirname(__FILE__), 'test-data', 'translations', 'ios_l10n_helper') }
+describe Fastlane::Actions::IosMergeStringsFilesAction do
+  let(:test_data_dir) { File.join(File.dirname(__FILE__), 'test-data', 'translations', 'ios_l10n_helper') }
 
-    def fixture(name)
-      File.join(test_data_dir, name)
-    end
+  def fixture(name)
+    File.join(test_data_dir, name)
+  end
 
-    describe '#ios_merge_strings_files' do
-      it 'calls the action with the proper parameters and warn and return duplicate keys' do
-        # Arrange
-        messages = []
-        allow(FastlaneCore::UI).to receive(:important) do |message|
-          messages.append(message)
+  describe '#ios_merge_strings_files' do
+    it 'calls the action with the proper parameters and warn and return duplicate keys' do
+      # Arrange
+      messages = []
+      allow(FastlaneCore::UI).to receive(:important) do |message|
+        messages.append(message)
+      end
+      inputs = ['Localizable-utf16.strings', 'non-latin-utf16.strings']
+
+      Dir.mktmpdir('a8c-release-toolkit-tests-') do |tmpdir|
+        inputs.each { |f| FileUtils.cp(fixture(f), tmpdir) }
+
+        # Act
+        result = Dir.chdir(tmpdir) do
+          run_described_action(
+            paths: [inputs[0], inputs[1]],
+            destination: 'output.strings'
+          )
         end
-        inputs = ['Localizable-utf16.strings', 'non-latin-utf16.strings']
 
-        Dir.mktmpdir('a8c-release-toolkit-tests-') do |tmpdir|
-          inputs.each { |f| FileUtils.cp(fixture(f), tmpdir) }
-
-          # Act
-          result = Dir.chdir(tmpdir) do
-            described_class.new.parse("lane :test do
-              ios_merge_strings_files(
-                paths: ['#{inputs[0]}', '#{inputs[1]}'],
-                destination: 'output.strings'
-              )
-            end").runner.execute(:test)
-          end
-
-          # Assert
-          expect(File).to exist(File.join(tmpdir, 'output.strings'))
-          expect(result).to eq(%w[key1 key2])
-          expect(messages).to eq([
-                                   'Duplicate key found while merging the `.strings` files: `key1`',
-                                   'Duplicate key found while merging the `.strings` files: `key2`',
-                                 ])
-        end
+        # Assert
+        expect(File).to exist(File.join(tmpdir, 'output.strings'))
+        expect(result).to eq(%w[key1 key2])
+        expect(messages).to eq(
+          [
+            'Duplicate key found while merging the `.strings` files: `key1`',
+            'Duplicate key found while merging the `.strings` files: `key2`',
+          ]
+        )
       end
     end
   end

--- a/spec/ios_merge_translators_strings_spec.rb
+++ b/spec/ios_merge_translators_strings_spec.rb
@@ -35,7 +35,7 @@ end
 def imts_run_test(script)
   test_script = @imtsTestUtils.get_test_from_file(script)
   @imtsTestUtils.create_test_data(test_script)
-  Fastlane::Actions::IosMergeTranslatorsStringsAction.run(strings_folder: @imtsTestUtils.test_folder_path)
+  run_described_fastlane_action(strings_folder: @imtsTestUtils.test_folder_path)
   expect(@imtsTestUtils.read_result_data(test_script)).to eq(test_script['result']['content'])
 end
 

--- a/spec/shared_examples_for_update_metadata_source_action.rb
+++ b/spec/shared_examples_for_update_metadata_source_action.rb
@@ -19,7 +19,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       file_2_path = File.join(dir, '2.txt')
       File.write(file_2_path, 'value 2')
 
-      run_described_action(
+      run_described_fastlane_action(
         po_file_path: output_path,
         release_version: '1.0',
         source_files: {
@@ -57,7 +57,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       whats_new_path = File.join(dir, 'whats_new.txt')
       File.write(whats_new_path, "- something new\n- something else new")
 
-      run_described_action(
+      run_described_fastlane_action(
         po_file_path: output_path,
         release_version: '1.23',
         source_files: {
@@ -95,7 +95,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       file_2_path = File.join(dir, '2.txt')
       File.write(file_2_path, 'value 2')
 
-      run_described_action(
+      run_described_fastlane_action(
         po_file_path: output_path,
         release_version: '1.0',
         source_files: {
@@ -137,7 +137,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       release_notes_path = File.join(dir, 'release_notes.txt')
       File.write(release_notes_path, "- release notes\n- more release notes")
 
-      run_described_action(
+      run_described_fastlane_action(
         po_file_path: output_path,
         release_version: '1.23',
         source_files: {

--- a/spec/shared_examples_for_update_metadata_source_action.rb
+++ b/spec/shared_examples_for_update_metadata_source_action.rb
@@ -19,8 +19,9 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       file_2_path = File.join(dir, '2.txt')
       File.write(file_2_path, 'value 2')
 
-      described_class.run(
+      run_described_action(
         po_file_path: output_path,
+        release_version: '1.0',
         source_files: {
           key1: file_1_path,
           key2: file_2_path
@@ -56,7 +57,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       whats_new_path = File.join(dir, 'whats_new.txt')
       File.write(whats_new_path, "- something new\n- something else new")
 
-      described_class.run(
+      run_described_action(
         po_file_path: output_path,
         release_version: '1.23',
         source_files: {
@@ -94,8 +95,9 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       file_2_path = File.join(dir, '2.txt')
       File.write(file_2_path, 'value 2')
 
-      described_class.run(
+      run_described_action(
         po_file_path: output_path,
+        release_version: '1.0',
         source_files: {
           key1: file_1_path,
           key2: file_2_path
@@ -135,7 +137,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       release_notes_path = File.join(dir, 'release_notes.txt')
       File.write(release_notes_path, "- release notes\n- more release notes")
 
-      described_class.run(
+      run_described_action(
         po_file_path: output_path,
         release_version: '1.23',
         source_files: {
@@ -158,4 +160,30 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       expect(File.read(output_path).inspect).to eq(expected.inspect)
     end
   end
+end
+
+def run_described_action(parameters)
+  lane_name = 'test'
+  lane = <<~LANE
+    lane :#{lane_name} do
+      #{described_class.action_name}(
+        #{stringify_for_fastlane(parameters)}
+      )
+    end
+  LANE
+  Fastlane::FastFile.new.parse(lane).runner.execute(lane_name.to_sym)
+end
+
+def stringify_for_fastlane(hash)
+  hash.map do |key, value|
+    # rubocop:disable Style/CaseLikeIf
+    if value.is_a?(Hash)
+      "#{key}: {\n#{stringify_for_fastlane(value)}\n}"
+    elsif value.is_a?(String)
+      "#{key}: \"#{value}\""
+    else
+      "#{key}: #{value}"
+    end
+    # rubocop:enable Style/CaseLikeIf
+  end.join(",\n")
 end

--- a/spec/shared_examples_for_update_metadata_source_action.rb
+++ b/spec/shared_examples_for_update_metadata_source_action.rb
@@ -161,29 +161,3 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
     end
   end
 end
-
-def run_described_action(parameters)
-  lane_name = 'test'
-  lane = <<~LANE
-    lane :#{lane_name} do
-      #{described_class.action_name}(
-        #{stringify_for_fastlane(parameters)}
-      )
-    end
-  LANE
-  Fastlane::FastFile.new.parse(lane).runner.execute(lane_name.to_sym)
-end
-
-def stringify_for_fastlane(hash)
-  hash.map do |key, value|
-    # rubocop:disable Style/CaseLikeIf
-    if value.is_a?(Hash)
-      "#{key}: {\n#{stringify_for_fastlane(value)}\n}"
-    elsif value.is_a?(String)
-      "#{key}: \"#{value}\""
-    else
-      "#{key}: #{value}"
-    end
-    # rubocop:enable Style/CaseLikeIf
-  end.join(",\n")
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,7 @@ end
 # If the `described_class` of a spec is a `Fastlane::Action` subclass, it runs
 # it with the given parameters.
 #
-def run_described_action(parameters, lane_name = 'test')
+def run_described_fastlane_action(parameters, lane_name = 'test')
   expect(described_class).to be < Fastlane::Action, "Only call `#{__callee__}` from a spec describing a `Fastlane::Action` subclass."
 
   lane = <<~LANE

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,6 +71,8 @@ end
 # it with the given parameters.
 #
 def run_described_action(parameters, lane_name = 'test')
+  expect(described_class).to be < Fastlane::Action, "Only call `#{__callee__}` from a spec describing a `Fastlane::Action` subclass."
+
   lane = <<~LANE
     lane :#{lane_name} do
       #{described_class.action_name}(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,17 +70,19 @@ end
 # If the `described_class` of a spec is a `Fastlane::Action` subclass, it runs
 # it with the given parameters.
 #
-def run_described_fastlane_action(parameters, lane_name = 'test')
-  expect(described_class).to be < Fastlane::Action, "Only call `#{__callee__}` from a spec describing a `Fastlane::Action` subclass."
+def run_described_fastlane_action(parameters)
+  raise "Only call `#{__callee__}` from a spec describing a `Fastlane::Action` subclass." unless Fastlane::Actions.is_class_action?(described_class)
 
+  # Avoid logging messages about deprecated actions while running tests on them
+  allow(Fastlane::Actions).to receive(:is_deprecated?).and_return(false)
   lane = <<~LANE
-    lane :#{lane_name} do
+    lane :test do
       #{described_class.action_name}(
         #{parameters.inspect}
       )
     end
   LANE
-  Fastlane::FastFile.new.parse(lane).runner.execute(lane_name.to_sym)
+  Fastlane::FastFile.new.parse(lane).runner.execute(:test)
 end
 
 # Executes the given block within an ad hoc temporary directory.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,7 +76,7 @@ def run_described_action(parameters, lane_name = 'test')
   lane = <<~LANE
     lane :#{lane_name} do
       #{described_class.action_name}(
-        #{stringify_for_fastlane(parameters)}
+        #{parameters.inspect}
       )
     end
   LANE
@@ -90,20 +90,4 @@ def in_tmp_dir
       yield tmpdir
     end
   end
-end
-
-private
-
-def stringify_for_fastlane(hash)
-  hash.map do |key, value|
-    # rubocop:disable Style/CaseLikeIf
-    if value.is_a?(Hash)
-      "#{key}: {\n#{stringify_for_fastlane(value)}\n}"
-    elsif value.is_a?(String)
-      "#{key}: \"#{value}\""
-    else
-      "#{key}: #{value}"
-    end
-    # rubocop:enable Style/CaseLikeIf
-  end.join(",\n")
 end


### PR DESCRIPTION
Built on top of @AliSoftware's experiment to test actions by running them via a just-in-time `Fastfile` as opposed to via a `run` call to add an extra level of checks for the `ConfigItem`s parsing from https://github.com/wordpress-mobile/release-toolkit/pull/326#pullrequestreview-866044937.

This PR aims to extracts the boilerplate into a shared helper method to make calling the action in the tests straightforward.