### PR TITLE
[L10n Tooling: i3] Re-implement download-from-glotpress logic from .py and .swift scripts

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -146,6 +146,7 @@ RSpec/FilePath:
     - 'spec/ios_l10n_helper_spec.rb'
     - 'spec/ios_merge_strings_files_spec.rb'
     - 'spec/gp_update_metadata_source_spec.rb'
+    - 'spec/ios_download_strings_files_from_glotpress_spec.rb'
 
 # Offense count: 8
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### New Features
 
 * Introduce new `ios_merge_strings_files` action. [#329]
+* Introduce new `ios_download_strings_files_from_glotpress` action. [#331]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -30,16 +30,16 @@ module Fastlane
         return unless File.exist?(destination) # If the file failed to download, don't try to validate an non-existing file. We'd already have a separate error for the download failure anyway.
 
         translations = Fastlane::Helper::Ios::L10nHelper.read_strings_file_as_hash(path: destination)
-        empty_keys = translations.select { |_, value| value.nil? || value.empty? }.keys
+        empty_keys = translations.select { |_, value| value.nil? || value.empty? }.keys.sort
         unless empty_keys.empty?
           UI.error(
-            "Found empty translations in `#{destination}` for the following keys: #{empty_keys}.\n" \
+            "Found empty translations in `#{destination}` for the following keys: #{empty_keys.inspect}.\n" \
               + "This is likely a GlotPress bug, and will lead to copies replaced by empty text in the UI.\n" \
               + 'Please report this to the GlotPress team, and fix the file locally before continuing.'
           )
         end
       rescue StandardError => e
-        UI.error("Error while validating the file exported from GlotPress (`#{destination}`) - #{e.message}")
+        UI.error("Error while validating the file exported from GlotPress (`#{destination}`) - #{e.message.chomp}")
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -1,0 +1,105 @@
+module Fastlane
+  module Actions
+    class IosDownloadStringsFilesFromGlotPressAction < Action
+      def self.run(params)
+        # TODO: Once we introduce the `Locale` POD via #296, check if the param is an array of locales and if so convert it to Hash{glotpress=>lproj}
+        locales = params[:locales]
+
+        locales.each do |glotpress_locale, lproj_name|
+          # Download the export in the proper `.lproj` directory
+          destination = File.join(params[:download_dir], "#{lproj_name}.lproj", "#{params[:table_basename]}.strings")
+          Fastlane::Helper::Ios::L10nHelper.download_glotpress_export_file(
+            project_url: params[:project_url],
+            locale: glotpress_locale,
+            filters: params[:filters],
+            destination: destination
+          )
+          # Do a quick check of the downloaded `.strings` file to ensure it looks valid
+          validate_strings_file(destination) unless params[:skip_file_validation]
+        end
+      end
+
+      # Validate that a `.strings` file downloaded from GlotPress seems valid and does not contain empty translations
+      def self.validate_strings_file(destination)
+        translations = Fastlane::Helper::Ios::L10nHelper.read_strings_file_as_hash(destination)
+        empty_keys = translations.select { |_, value| value.nil? || value.empty? }.keys
+        unless empty_keys.empty?
+          UI.error(
+            "Found empty translations in `#{destination}` for the following keys: #{empty_keys}.\n" \
+              + "This is likely a GlotPress bug, and will lead to copies replaced by empty text in the UI.\n" \
+              + 'Please report this to the GlotPress team, and fix the file locally this continuing.'
+          )
+        end
+      rescue StandardError => e
+        UI.error("Error while validating the file exported from GlotPress (`#{destination}`) - #{e.message}")
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Downloads the `.strings` files from GlotPress for the various locales'
+      end
+
+      def self.details
+        <<~DETAILS
+          Downloads the `.strings` files from GlotPress for the various locales,
+          validates them, and saves them in the relevant `*.lproj` directories for each locale
+        DETAILS
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :project_url,
+                                       env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_PROJECT_URL',
+                                       description: 'URL to the GlotPress project',
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :locales,
+                                       env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_LOCALES',
+                                       description: 'The map of locales to download, each entry of the Hash corresponding to a { glotpress-locale-code => lproj-folder-basename } pair',
+                                       type: Hash), # TODO: also support an Array of `Locale` POD/struct type when we introduce it later (see #296)
+          FastlaneCore::ConfigItem.new(key: :download_dir,
+                                       env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_DOWNLOAD_DIR',
+                                       description: 'The parent directory containing all the `*.lproj` subdirectories in which the downloaded files will be saved',
+                                       type: Hash),
+          FastlaneCore::ConfigItem.new(key: :table_basename,
+                                       env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_TABLE_BASENAME',
+                                       description: 'The basename to save the `.strings` files under',
+                                       type: String,
+                                       optional: true,
+                                       default_value: 'Localizable'),
+          FastlaneCore::ConfigItem.new(key: :filters,
+                                       env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_FILTERS',
+                                       description: 'The GlotPress filters to use when requesting the translations export',
+                                       type: Hash,
+                                       optional: true,
+                                       default_value: { status: 'current' }),
+          FastlaneCore::ConfigItem.new(key: :skip_file_validation,
+                                       env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_SKIP_FILE_VALIDATION',
+                                       description: 'If true, skips the validation of `.strings` files after download',
+                                       type: Fastlane::Boolean,
+                                       optional: true,
+                                       default_value: false),
+        ]
+      end
+
+      def self.return_type
+        # Describes what type of data is expected to be returned
+        # see RETURN_TYPES in https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/action.rb
+      end
+
+      def self.return_value
+        # Textual description of what the return value is
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -27,7 +27,7 @@ module Fastlane
           UI.error(
             "Found empty translations in `#{destination}` for the following keys: #{empty_keys}.\n" \
               + "This is likely a GlotPress bug, and will lead to copies replaced by empty text in the UI.\n" \
-              + 'Please report this to the GlotPress team, and fix the file locally this continuing.'
+              + 'Please report this to the GlotPress team, and fix the file locally before continuing.'
           )
         end
       rescue StandardError => e

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -24,7 +24,9 @@ module Fastlane
 
       # Validate that a `.strings` file downloaded from GlotPress seems valid and does not contain empty translations
       def self.validate_strings_file(destination)
-        translations = Fastlane::Helper::Ios::L10nHelper.read_strings_file_as_hash(destination)
+        return unless File.exist?(destination) # If the file failed to download, don't try to validate an non-existing file. We'd already have a separate error for the download failure anyway.
+
+        translations = Fastlane::Helper::Ios::L10nHelper.read_strings_file_as_hash(path: destination)
         empty_keys = translations.select { |_, value| value.nil? || value.empty? }.keys
         unless empty_keys.empty?
           UI.error(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -4,10 +4,13 @@ module Fastlane
       def self.run(params)
         # TODO: Once we introduce the `Locale` POD via #296, check if the param is an array of locales and if so convert it to Hash{glotpress=>lproj}
         locales = params[:locales]
+        download_dir = params[:download_dir]
+
+        UI.user_error!("The parent directory `#{download_dir}` (which contains all the `*.lproj` subdirectories) must already exist") unless Dir.exist?(download_dir)
 
         locales.each do |glotpress_locale, lproj_name|
           # Download the export in the proper `.lproj` directory
-          lproj_dir = File.join(params[:download_dir], "#{lproj_name}.lproj")
+          lproj_dir = File.join(download_dir, "#{lproj_name}.lproj")
           destination = File.join(lproj_dir, "#{params[:table_basename]}.strings")
           FileUtils.mkdir(lproj_dir) unless Dir.exist?(lproj_dir)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -65,7 +65,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :download_dir,
                                        env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_DOWNLOAD_DIR',
                                        description: 'The parent directory containing all the `*.lproj` subdirectories in which the downloaded files will be saved',
-                                       type: Hash),
+                                       type: String),
           FastlaneCore::ConfigItem.new(key: :table_basename,
                                        env_name: 'FL_IOS_DOWNLOAD_STRINGS_FILES_FROM_GLOTPRESS_TABLE_BASENAME',
                                        description: 'The basename to save the `.strings` files under',

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -7,7 +7,10 @@ module Fastlane
 
         locales.each do |glotpress_locale, lproj_name|
           # Download the export in the proper `.lproj` directory
-          destination = File.join(params[:download_dir], "#{lproj_name}.lproj", "#{params[:table_basename]}.strings")
+          lproj_dir = File.join(params[:download_dir], "#{lproj_name}.lproj")
+          destination = File.join(lproj_dir, "#{params[:table_basename]}.strings")
+          FileUtils.mkdir(lproj_dir) unless Dir.exist?(lproj_dir)
+
           Fastlane::Helper::Ios::L10nHelper.download_glotpress_export_file(
             project_url: params[:project_url],
             locale: glotpress_locale,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    class IosDownloadStringsFilesFromGlotPressAction < Action
+    class IosDownloadStringsFilesFromGlotpressAction < Action
       def self.run(params)
         # TODO: Once we introduce the `Locale` POD via #296, check if the param is an array of locales and if so convert it to Hash{glotpress=>lproj}
         locales = params[:locales]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -120,15 +120,10 @@ module Fastlane
 
         # Downloads the export from GlotPress for a given locale and given filters.
         #
-        # Also post-process the downloaded content to comment out any potential line with an empty (`""`) translation,
-        # to ensure those would fall back to the English/Base locale at runtime instead. These case should theoretically
-        # never happen as GlotPress should not include empty translations in its exports, but we've seen issues in the
-        # past, so better safe than sorry.
-        #
         # @param [String] project_url The URL to the GlotPress project to export from, e.g. `"https://translate.wordpress.org/projects/apps/ios/dev"`
         # @param [String] locale The GlotPress locale code to download strings for.
         # @param [Hash{Symbol=>String}] filters The hash of filters to apply when exporting from GlotPress.
-        #                               Typical examples include `{ status: 'current' }` (the default) or `{ status: 'review' }`.
+        #                               Typical examples include `{ status: 'current' }` or `{ status: 'review' }`.
         # @param [String, IO] destination The path or `IO`-like instance, where to write the downloaded file on disk.
         #
         def self.download_glotpress_export_file(project_url:, locale:, filters:, destination:)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -131,7 +131,7 @@ module Fastlane
         #                               Typical examples include `{ status: 'current' }` (the default) or `{ status: 'review' }`.
         # @param [String, IO] destination The path or `IO`-like instance, where to write the downloaded file on disk.
         #
-        def self.download_glotpress_export_file(project_url:, locale:, destination:, filters: { status: 'current' })
+        def self.download_glotpress_export_file(project_url:, locale:, filters:, destination:)
           query_params = (filters || {}).transform_keys { |k| "filters[#{k}]" }.merge(format: 'strings')
           uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations?#{URI.encode_www_form(query_params)}")
           begin

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -1,15 +1,64 @@
 require 'spec_helper'
 require 'tmpdir'
 
-Locale = Struct.new(:name)
-
 describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
   let(:test_data_dir) { File.join(File.dirname(__FILE__), 'test-data', 'translations', 'ios_generate_strings_file_from_code') }
 
   describe 'downloading export files from GlotPress' do
-    it 'downloads all the locales into the expected directories'
-    it 'uses the proper filters when exporting the files from GlotPress'
-    it 'uses a custom table name for the `.strings` files if provided'
+    let(:gp_fake_url) { 'https://stub.glotpress.com/rspec-fake-project' }
+    let(:locales_subset) { {'fr-FR': 'fr', 'zh-cn': 'zh-Hans' } }
+
+    def gp_stub(locale:, query:)
+      stub_request(:get, "#{gp_fake_url}/#{locale}/default/export-translations").with(query: query)
+    end
+
+    def test_gp_download(filters:, tablename:, expected_gp_params:)
+      Dir.mktmpdir('a8c-release-toolkit-tests-') do |tmp_dir|
+        # Arrange
+        stub_fr = gp_stub(locale: 'fr-FR', query: expected_gp_params).to_return(body: '"key" = "fr-copy";')
+        stub_zh = gp_stub(locale: 'zh-cn', query: expected_gp_params).to_return(body: '"key" = "zh-copy";')
+
+        # Act
+        run_described_fastlane_action({
+          project_url: gp_fake_url,
+          locales: locales_subset,
+          download_dir: tmp_dir,
+          table_basename: tablename,
+          filters: filters
+        }.compact)
+
+        # Assert
+        expect(stub_fr).to have_been_made.once
+        file_fr = File.join(tmp_dir, 'fr.lproj', "#{tablename || 'Localizable'}.strings")
+        expect(File).to exist(file_fr)
+        expect(File.read(file_fr)).to eq('"key" = "fr-copy";')
+
+        expect(stub_zh).to have_been_made.once
+        file_zh = File.join(tmp_dir, 'zh-Hans.lproj', "#{tablename || 'Localizable'}.strings")
+        expect(File).to exist(file_zh)
+        expect(File.read(file_zh)).to eq('"key" = "zh-copy";')
+      end
+    end
+
+    it 'downloads all the locales into the expected directories' do
+      test_gp_download(filters: nil, tablename: nil, expected_gp_params: { 'filters[status]': 'current', format: 'strings' })
+    end
+
+    it 'uses the proper filters when exporting the files from GlotPress' do
+      test_gp_download(
+        filters: { term: 'foo', status: 'review' },
+        tablename: nil,
+        expected_gp_params: { 'filters[term]': 'foo', 'filters[status]': 'review', format: 'strings' }
+      )
+    end
+
+    it 'uses a custom table name for the `.strings` files if provided' do
+      test_gp_download(
+        filters: nil,
+        tablename: "MyApp",
+        expected_gp_params: { 'filters[status]': 'current', format: 'strings' }
+      )
+    end
   end
 
   describe 'error handling' do

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -3,7 +3,7 @@ require 'tmpdir'
 
 Locale = Struct.new(:name)
 
-describe Fastlane::Actions::IosDownloadStringsFilesFromGlotPressAction do
+describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
   let(:test_data_dir) { File.join(File.dirname(__FILE__), 'test-data', 'translations', 'ios_generate_strings_file_from_code') }
 
   describe 'downloading export files from GlotPress' do

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'tmpdir'
+
+Locale = Struct.new(:name)
+
+describe Fastlane::Actions::IosDownloadStringsFilesFromGlotPressAction do
+  let(:test_data_dir) { File.join(File.dirname(__FILE__), 'test-data', 'translations', 'ios_generate_strings_file_from_code') }
+
+  describe 'downloading export files from GlotPress' do
+    it 'downloads all the locales into the expected directories'
+    it 'uses the proper filters when exporting the files from GlotPress'
+    it 'uses a custom table name for the `.strings` files if provided'
+  end
+
+  describe 'error handling' do
+    it 'shows an error if an invalid locale is provided (404)'
+    it 'shows an error if the file cannot be written in the destination'
+    it 'reports if a downloaded file is invalid by default'
+    it 'does not report invalid downloaded files if skip_file_validation:true'
+  end
+end

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -118,8 +118,9 @@ describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
         expect(stub).to have_been_made.once
         file = File.join(tmp_dir, 'fr.lproj', 'Localizable.strings')
         expect(File).to exist(file)
-        expected_error = 'Property List error: Unexpected character s at line 1 / JSON error: JSON text did not start with array or object and option to allow fragments not set. around line 1, column 0.'
-        expect(error_messages).to eq(["Error while validating the file exported from GlotPress (`#{file}`) - #{file}: #{expected_error}"])
+        expected_error = 'Property List error: Unexpected character s at line 1 / JSON error: JSON text did not start with array or object and option to allow fragments not set.'
+        expect(error_messages.count).to eq(1)
+        expect(error_messages.first).to start_with("Error while validating the file exported from GlotPress (`#{file}`) - #{file}: #{expected_error}") # Different versions of `plutil` might append the line/column as well, but not all.
       end
     end
 

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -77,8 +77,7 @@ describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
 
         # Assert
         expect(stub).to have_been_made.once
-        file = File.join(tmp_dir, 'Base.lproj', 'Localizable.strings')
-        expect(File).not_to exist(file)
+        expect(File).not_to exist(File.join(tmp_dir, 'Base.lproj', 'Localizable.strings'))
         expect(error_messages).to eq(['Error downloading locale `unknown-locale` — 404 Not Found'])
       end
     end

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -18,6 +18,9 @@ describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
         stub_zh = gp_stub(locale: 'zh-cn', query: expected_gp_params).to_return(body: '"key" = "zh-copy";')
 
         # Act
+        # Note: The use of `.compact` here allows us to remove the keys (like `table_basename` and `filters`) from the `Hash` whose values are `nil`,
+        # so that we don't include those parameters at all in the action's call site -- making them use the default value from their respective
+        # `ConfigItem` (as opposed to passing a value of `nil` explicitly and overwrite the default value, which is not what we want to test).
         run_described_fastlane_action({
           project_url: gp_fake_url,
           locales: locales_subset,
@@ -96,6 +99,7 @@ describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
       end
 
       # Assert
+      # Note: FastlaneError is the exception raised by UI.user_error!
       expect { act.call }.to raise_error(FastlaneCore::Interface::FastlaneError, "The parent directory `#{download_dir}` (which contains all the `*.lproj` subdirectories) must already exist")
     end
 

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -195,7 +195,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
         Dir.mktmpdir('a8c-release-toolkit-tests-') do |tmp_dir|
           # Arrange
           # Note: in practice it seems that GlotPress's `.strings` exports are using UTF-8 (but served as `application/octet-stream`)
-          #       but it does not hurt to ensure the download to a file can work with UTF-16 ()and copy the binary stream verbatim)
+          #       but it does not hurt to ensure the download to a file can work with UTF-16 (and copy the binary stream verbatim)
           body = File.read(fixture('Localizable-utf16.strings'))
           stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings").to_return(body: body)
           dest = File.join(tmp_dir, 'export.strings')

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -194,8 +194,8 @@ describe Fastlane::Helper::Ios::L10nHelper do
       it 'accepts a String (path)' do
         Dir.mktmpdir('a8c-release-toolkit-tests-') do |tmp_dir|
           # Arrange
-          # Note: in practice it seems that GlotPress's `.strings` exports are using UTF8 (but served as `application/octet-stream`)
-          #       but it does not hurt to ensure the download to a file can work with UTF16 ()and copy the binary stream verbatim)
+          # Note: in practice it seems that GlotPress's `.strings` exports are using UTF-8 (but served as `application/octet-stream`)
+          #       but it does not hurt to ensure the download to a file can work with UTF-16 ()and copy the binary stream verbatim)
           body = File.read(fixture('Localizable-utf16.strings'))
           stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings").to_return(body: body)
           dest = File.join(tmp_dir, 'export.strings')

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -165,12 +165,12 @@ describe Fastlane::Helper::Ios::L10nHelper do
     let(:gp_fake_url) { 'https://stub.glotpress.com/rspec-fake-project' }
 
     describe 'the request query parameters' do
-      it 'passes the expected params when filters are forced to nil' do
+      it 'passes the expected params when no filters are provided' do
         # Arrange
         stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings").to_return(body: 'content')
         dest = StringIO.new
         # Act
-        described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', destination: dest, filters: nil)
+        described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: nil, destination: dest)
         # Assert
         expect(stub).to have_been_made.once
         expect(dest.string).to eq('content')
@@ -181,7 +181,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
         stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings&filters%5Bstatus%5D=current&filters%5Bterm%5D=foobar").to_return(body: 'content')
         dest = StringIO.new
         # Act
-        described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', destination: dest, filters: { status: 'current', term: 'foobar' })
+        described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: { status: 'current', term: 'foobar' }, destination: dest)
         # Assert
         expect(stub).to have_been_made.once
         expect(dest.string).to eq('content')
@@ -189,12 +189,12 @@ describe Fastlane::Helper::Ios::L10nHelper do
 
       it 'prints UI.error if passed a non-existing locale (or any other 404)' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/invalid/default/export-translations?format=strings&filters%5Bstatus%5D=current").to_return(status: [404, 'Not Found'])
+        stub = stub_request(:get, "#{gp_fake_url}/invalid/default/export-translations?format=strings").to_return(status: [404, 'Not Found'])
         error_messages = []
         allow(FastlaneCore::UI).to receive(:error) { |message| error_messages.append(message) }
         dest = StringIO.new
         # Act
-        described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'invalid', destination: dest)
+        described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'invalid', filters: nil, destination: dest)
         # Assert
         expect(stub).to have_been_made.once
         expect(error_messages).to eq(['Error downloading locale `invalid` — 404 Not Found'])
@@ -211,7 +211,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
           stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings").to_return(body: body)
           dest = File.join(tmp_dir, 'export.strings')
           # Act
-          described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', destination: dest, filters: nil)
+          described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: nil, destination: dest)
           # Assert
           expect(stub).to have_been_made.once
           expect(File).to exist(dest)

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -167,7 +167,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
     describe 'request query parameters' do
       it 'passes the expected params when no filters are provided' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings").to_return(body: 'content')
+        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations").with(query: { format: 'strings' }).to_return(body: 'content')
         dest = StringIO.new
         # Act
         described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: nil, destination: dest)
@@ -178,7 +178,8 @@ describe Fastlane::Helper::Ios::L10nHelper do
 
       it 'passes the expected params when a list of filters is provided' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings&filters%5Bstatus%5D=current&filters%5Bterm%5D=foobar").to_return(body: 'content')
+        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations")
+               .with(query: { format: 'strings', 'filters[status]': 'current', 'filters[term]': 'foobar' }).to_return(body: 'content')
         dest = StringIO.new
         # Act
         described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: { status: 'current', term: 'foobar' }, destination: dest)
@@ -197,7 +198,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
           # Note: in practice it seems that GlotPress's `.strings` exports are using UTF-8 (but served as `application/octet-stream`)
           #       but it does not hurt to ensure the download to a file can work with UTF-16 (and copy the binary stream verbatim)
           body = File.read(fixture('Localizable-utf16.strings'))
-          stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings").to_return(body: body)
+          stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations").with(query: { format: 'strings' }).to_return(body: body)
           dest = File.join(tmp_dir, 'export.strings')
           # Act
           described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: nil, destination: dest)
@@ -212,7 +213,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
     describe 'invalid parameters' do
       it 'prints an `UI.error` if passed a non-existing locale (or any other 404)' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/invalid/default/export-translations?format=strings").to_return(status: [404, 'Not Found'])
+        stub = stub_request(:get, "#{gp_fake_url}/invalid/default/export-translations").with(query: { format: 'strings' }).to_return(status: [404, 'Not Found'])
         error_messages = []
         allow(FastlaneCore::UI).to receive(:error) { |message| error_messages.append(message) }
         dest = StringIO.new
@@ -225,7 +226,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
 
       it 'prints an `UI.error` if the destination cannot be written to' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations?format=strings").to_return(body: 'content')
+        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations").with(query: { format: 'strings' }).to_return(body: 'content')
         error_messages = []
         allow(FastlaneCore::UI).to receive(:error) { |message| error_messages.append(message) }
         dest = '/these/are/not/the/droids/you/are/looking/for.strings'


### PR DESCRIPTION
Part of the L10n Modernization project paaHJt-2Ib-p2, especially item [i3].

## What

This introduces a new `ios_download_strings_files_from_glotpress` action, which is mostly the re-implementation of:
 - The `Scripts/update-translations.rb` ruby script currently hosted in WPiOS/WCiOS repos
 - The `Scripts/fix-translation` swift script currently hosted in WPiOS/WCiOS repos

PS: Obviously, once this lands and the client repos have migrated to use the future new version of the toolkit including that action and start using it, we will completely delete the scripts it replaces from the client repos' `Scripts/` folders.

## Handling invalid files and empty translations

I've decided to only _warn_ (using a `UI.error`) about the potential case of having empty translations in downloaded exports — as opposed to trying to fix it ourselves like the previous `Scripts/fix-translation` script was trying to do. There are multiple reasons for this choice:
 1. The issue that led us to have some empty translations (`"key" = "";`) in exports in the past seems to have been resolved a long time ago and not be present anymore, at least to my experience and smoke checks in our Mag16 locales
 2. [The logic to check if there were any empty translations remaining after the fix](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/Scripts/update-translations.rb#L160) seemed to assume the `.strings` files (downloaded from GlotPress then fixed) were in UTF16 (given the bytes used on the `grep`), while in practice all the downloaded files are all in UTF-8 nowadays (`find WordPress/Resources -name 'Localizable.strings' -exec file {} \;` in WPiOS only lists the one from `en.lproj`, aka the original, to be UTF16, and all others downloaded from GlotPress to be UTF8). Which shows how the check was outdated and not even checking correctly what we expected it to fix (as the `grep` would not find those UTF16 bytes in the UTF-8 files anyway)
 3. The fix back in the way it was implemented by `Scripts/fix-translations` consisted in [replacing the empty `"key" = "";` with `"key" = "key";`](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/Scripts/fix-translation#L16); but given we want to be open to the possibility of (and start actually adopting) using keys that are different to the English copy (see Project Thread explanations), this would not have been the correct fix anymore, as that would not have been the correct fallback anymore for those cases.
 4. A potential fix would have instead be to replace lines matching `/= "";$/` with empty lines, or comment those lines out, so that the fallback would instead be to use the `value:` parameter from `NSLocalizedString(_ key:, value:, comment:)` in the codebase (which would be the English copy, as opposed to the key). But manipulating the textual `.strings` file in that way starts raising risks and issues when trying to deal with text encodings (and GlotPress serves those files as `application/octet-stream`, without explicitly exposing the actual encoding used, even if by experience it looks like UTF8 but we shouldn't make such an assumption if we want our code to be resilient)

Given that the bug seems to have been fixed since a long time I figured better avoid trying to fix something that does not exist — and risk messing things up rather than improving them — and instead just detect in case it reappears one day. If we end up seeing it reappear, it will always be time to try to implement a workaround in the action's code, but… YAGNI.

## What's next

While this implements most of what's needed to cover item [i3] of the plan (paaHJt-2Ib-p2), we will still need to add another action on top of this one (in a separate, future PR) to re-implement the logic from `Scripts/extract-framework-translations.swift` in a separate fastlane action in order to finally complete [i3] (and [i6]). Most of the logic to do that last step is already present in the `ios_l10n_helper` so that future PR should be straightforward though.

