### PR TITLE
Clarify expectation on XML indentation in `AnLocalizeLibsAction` spec

### DIFF
--- a/spec/an_localize_libs_action_spec.rb
+++ b/spec/an_localize_libs_action_spec.rb
@@ -26,13 +26,10 @@ describe Fastlane::Actions::AnLocalizeLibsAction do
         ]
       )
 
-      # Notice the extra indentation in the library strings. The action doesn't
-      # modify the app's strings content indentation, but it applies its own
-      # standard to the values read from the given library strings
       expected = <<~XML
         <string name="a_string">test from app</string>
-          <string name="a_lib1_string">test from lib 1</string>
-          <string name="a_lib2_string">test from lib 2</string>
+        <string name="a_lib1_string">test from lib 1</string>
+        <string name="a_lib2_string">test from lib 2</string>
       XML
       expect(File.read(app_strings_path)).to eq(android_xml_with_content(expected))
     end
@@ -40,10 +37,17 @@ describe Fastlane::Actions::AnLocalizeLibsAction do
 end
 
 def android_xml_with_content(content)
+  # Under the hood, the code hardcodes the generated XML indentation as 4
+  # spaces. Let's "force" it to be the same in here for consistency.
+  #
+  # See
+  # https://github.com/wordpress-mobile/release-toolkit/blob/da405f2c5ca90d696857ba2ad01da2753daa60dc/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb#L67
+  default_indentation = ' ' * 4
+
   # I couldn't find a way to interpolate a multiline string preserving its
   # indentation in the heredoc below, so I hacked the following transformation
   # of the input that adds the desired indentation to all lines.
-  indented_content = content.chomp.lines.map { |l| "  #{l}" }.join
+  indented_content = content.chomp.lines.map { |l| "#{default_indentation}#{l}" }.join
 
   return <<~XML
     <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/an_localize_libs_action_spec.rb
+++ b/spec/an_localize_libs_action_spec.rb
@@ -43,7 +43,7 @@ def android_xml_with_content(content)
   #
   # The desired indentation is 4 spaces to stay aligned with the production
   # code applies when merging the XMLs.
-  indented_content = content.chomp.lines.map { |l| "    #{default_indentation}#{l}" }.join
+  indented_content = content.chomp.lines.map { |l| "    #{l}" }.join
 
   return <<~XML
     <?xml version="1.0" encoding="UTF-8"?>

--- a/spec/an_localize_libs_action_spec.rb
+++ b/spec/an_localize_libs_action_spec.rb
@@ -37,17 +37,13 @@ describe Fastlane::Actions::AnLocalizeLibsAction do
 end
 
 def android_xml_with_content(content)
-  # Under the hood, the code hardcodes the generated XML indentation as 4
-  # spaces. Let's "force" it to be the same in here for consistency.
-  #
-  # See
-  # https://github.com/wordpress-mobile/release-toolkit/blob/da405f2c5ca90d696857ba2ad01da2753daa60dc/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb#L67
-  default_indentation = ' ' * 4
-
   # I couldn't find a way to interpolate a multiline string preserving its
   # indentation in the heredoc below, so I hacked the following transformation
   # of the input that adds the desired indentation to all lines.
-  indented_content = content.chomp.lines.map { |l| "#{default_indentation}#{l}" }.join
+  #
+  # The desired indentation is 4 spaces to stay aligned with the production
+  # code applies when merging the XMLs.
+  indented_content = content.chomp.lines.map { |l| "    #{default_indentation}#{l}" }.join
 
   return <<~XML
     <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This hopefully makes the test clearer. See discussion at https://github.com/wordpress-mobile/release-toolkit/pull/330#discussion_r796838599