### PR TITLE
Update `DEFAULT_GIT_BRANCH` from `develop` to `trunk`

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -5,10 +5,8 @@ module Fastlane
     # Helper methods to execute git-related operations
     #
     module GitHelper
-      # Fallback default branch of the client repository. It's currently set to 'develop' for
-      # backwards compatibility.
-      # TODO: Set to 'trunk' for the next major release.
-      DEFAULT_GIT_BRANCH = 'develop'.freeze
+      # Fallback default branch of the client repository.
+      DEFAULT_GIT_BRANCH = 'trunk'.freeze
 
       # Checks if the given path, or current directory if no path is given, is
       # inside a Git repository


### PR DESCRIPTION
We're getting ready to ship a new major version, 3.0.0, which is the best time to introduce this breaking change, as the `TODO` comment suggested.

See also: https://github.com/wordpress-mobile/release-toolkit/pull/334#issuecomment-1029969292