### PR TITLE
Remove custom check for CI in favor of using Fastlane's one

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -10,10 +10,7 @@ module Fastlane
       end
 
       def source_contents
-        # TODO: This works only on CircleCI. I chose this variable because it's the one checked by Fastlane::is_ci.
-        # Fastlane::is_ci doesn't work here, so reimplementing the code has been necessary.
-        # (This should be updated if we change CI or if fastlane is updated.)
-        return File.read(secrets_repository_file_path) unless self.encrypt || ENV.key?('CIRCLECI')
+        return File.read(secrets_repository_file_path) unless self.encrypt || FastlaneCore::Helper.is_ci?
         return nil unless File.file?(encrypted_file_path)
 
         encrypted = File.read(encrypted_file_path)

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -69,19 +69,17 @@ describe Fastlane::Configuration::FileReference do
 
     describe '#source_contents' do
       it 'gets the contents from the secrets repo' do
-        set_circle_env(false) do
-          allow(File).to receive(:read).with(subject.secrets_repository_file_path).and_return('source contents')
-          expect(subject.source_contents).to eq('source contents')
-        end
+        allow(FastlaneCore::Helper).to receive(:is_ci?).and_return(false)
+        allow(File).to receive(:read).with(subject.secrets_repository_file_path).and_return('source contents')
+        expect(subject.source_contents).to eq('source contents')
       end
     end
 
     describe '#source_contents on ci' do
       it 'gets the contents from the secrets repo' do
-        set_circle_env(true) do
-          allow(File).to receive(:read).with(subject.secrets_repository_file_path).and_return('source contents')
-          expect(subject.source_contents).to eq(nil)
-        end
+        allow(FastlaneCore::Helper).to receive(:is_ci?).and_return(true)
+        allow(File).to receive(:read).with(subject.secrets_repository_file_path).and_return('source contents')
+        expect(subject.source_contents).to eq(nil)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,24 +25,6 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
 end
 
-def set_circle_env(define_ci)
-  is_ci = ENV.key?('CIRCLECI')
-  orig_circle_ci = ENV['CIRCLECI']
-  if define_ci
-    ENV['CIRCLECI'] = 'true'
-  else
-    ENV.delete 'CIRCLECI'
-  end
-
-  yield
-ensure
-  if is_ci
-    ENV['CIRCLECI'] = orig_circle_ci
-  else
-    ENV.delete 'CIRCLECI'
-  end
-end
-
 # Allows Action.sh to be executed even when running in a test environment (where Fastlane's code disables it by default)
 #
 def allow_fastlane_action_sh


### PR DESCRIPTION
Addresses a small `TODO` comment as we prepare for a new release. See also https://github.com/wordpress-mobile/release-toolkit/pull/334#issuecomment-1029969292.