### PR TITLE
Introduce specs for upload_to_s3 action

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -126,28 +126,7 @@ RSpec/DescribedClass:
 # Include: **/*_spec*rb*, **/spec/**/*
 RSpec/FilePath:
   Exclude:
-    - 'spec/android_localize_helper_spec.rb'
-    - 'spec/android_merge_translators_strings_spec.rb'
-    - 'spec/android_version_helper_spec.rb'
-    - 'spec/an_localize_libs_action_spec.rb'
-    - 'spec/an_metadata_update_helper_spec.rb'
-    - 'spec/an_update_metadata_source_spec.rb'
-    - 'spec/configuration_spec.rb'
-    - 'spec/configure_helper_spec.rb'
-    - 'spec/encryption_helper_spec.rb'
-    - 'spec/git_helper_spec.rb'
-    - 'spec/github_helper_spec.rb'
-    - 'spec/ios_git_helper_spec.rb'
-    - 'spec/ios_lint_localizations_spec.rb'
-    - 'spec/ios_merge_translators_strings_spec.rb'
-    - 'spec/release_notes_helper_spec.rb'
-    - 'spec/check_localization_progress_spec.rb'
-    - 'spec/ios_generate_strings_file_from_code_spec.rb'
-    - 'spec/ios_l10n_helper_spec.rb'
-    - 'spec/ios_merge_strings_files_spec.rb'
-    - 'spec/gp_update_metadata_source_spec.rb'
-    - 'spec/ios_download_strings_files_from_glotpress_spec.rb'
-    - 'spec/ios_extract_keys_from_strings_files_spec.rb'
+    - 'spec/*_spec.rb'
 
 # Offense count: 8
 # Cop supports --auto-correct.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -16,8 +16,8 @@ module Fastlane
         bucket = params[:bucket]
         key = params[:key]
 
-        UI.user_error!("You must provide a valid bucket name") if bucket.empty?
-        UI.user_error!("You must provide a valid key") if key.is_a?(String) && key.empty?
+        UI.user_error!('You must provide a valid bucket name') if bucket.empty?
+        UI.user_error!('You must provide a valid key') if key.is_a?(String) && key.empty?
 
         key = file_name if key.nil?
 
@@ -35,7 +35,7 @@ module Fastlane
             body: file,
             bucket: bucket,
             key: key
-        )
+          )
         rescue Aws::S3::Errors::ServiceError => e
           UI.crash!("Unable to upload file to S3: #{e.message}")
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -16,8 +16,13 @@ module Fastlane
         bucket = params[:bucket]
         key = params[:key]
 
+        UI.user_error!("You must provide a valid bucket name") if bucket.empty?
+        UI.user_error!("You must provide a valid key") if key.is_a?(String) && key.empty?
+
+        key = file_name if key.nil?
+
         if params[:auto_prefix] == true
-          file_name_hash = Digest::SHA1.base64digest(file_name)
+          file_name_hash = Digest::SHA1.hexdigest(file_name)
           key = [file_name_hash, key].join('/')
         end
 
@@ -26,11 +31,11 @@ module Fastlane
         UI.message("Uploading #{file_path} to: #{key}")
 
         File.open(file_path, 'rb') do |file|
-          Aws::S3::Client.new().put_object({
-                                             body: file,
-                                             bucket: bucket,
-                                             key: key
-                                           })
+          Aws::S3::Client.new().put_object(
+            body: file,
+            bucket: bucket,
+            key: key
+        )
         rescue Aws::S3::Errors::ServiceError => e
           UI.crash!("Unable to upload file to S3: #{e.message}")
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,7 @@ end
 # Executes the given block with a temporary file
 def with_tmp_file_path
   in_tmp_dir do |tmp_dir|
-    file_name = ('a'..'z').to_a.shuffle[0,8].join #8-character random file name
+    file_name = ('a'..'z').to_a.sample(8).join # 8-character random file name
     file_path = File.join(tmp_dir, file_name)
 
     File.write(file_path, '')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,3 +75,26 @@ def in_tmp_dir
     end
   end
 end
+
+# Executes the given block with a temporary file with the given `file_name`
+def with_tmp_file_path_for_file_named(file_name)
+  in_tmp_dir do |tmp_dir|
+    file_path = File.join(tmp_dir, file_name)
+
+    File.write(file_path, '')
+    yield file_path
+    File.delete(file_path)
+  end
+end
+
+# Executes the given block with a temporary file
+def with_tmp_file_path
+  in_tmp_dir do |tmp_dir|
+    file_name = ('a'..'z').to_a.shuffle[0,8].join #8-character random file name
+    file_path = File.join(tmp_dir, file_name)
+
+    File.write(file_path, '')
+    yield file_path
+    File.delete(file_path)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,12 @@ def allow_fastlane_action_sh
   allow(FastlaneCore::Helper).to receive(:sh_enabled?).and_return(true)
 end
 
+# Allow us to do `.with` matching against a `File` instance to a particular path in RSpec expectations
+# Because `File.open(path)` returns a different instance of `File` for the same path on each call)
+RSpec::Matchers.define :file_instance_of do |path|
+  match { |actual| actual.is_a?(File) && actual.path == path }
+end
+
 # Allows to assert if an `Action.sh` command has been triggered by the action under test.
 # Requires `allow_fastlane_action_sh` to have been called so that `Action.sh` actually calls `Open3.popen2e`
 #

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -45,16 +45,16 @@ describe Fastlane::Actions::UploadToS3Action do
 
     it 'generates a prefix for the key when using auto_prefix:true' do
       in_tmp_dir do |tmp_dir|
-        file_path = File.join(tmp_dir, 'input_file_1')
+        file_path = File.join(tmp_dir, 'input_file_2')
         File.write(file_path, 'Dummy content')
-        expected_key = 'k5w5OY2yQF55HiBXeP9w+F3/Yg4=/subdir/a8c-key1'
+        expected_key = 'i94aegQwDfJ7UvQ4PcmX5fu/8YA=/subdir/a8c-key2'
 
         stub_s3_head_request(expected_key, 0) # File does not exist in S3
         expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
 
         return_value = run_described_fastlane_action(
           bucket: test_bucket,
-          key: 'subdir/a8c-key1',
+          key: 'subdir/a8c-key2',
           file: file_path,
           auto_prefix: true
         )

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -16,12 +16,6 @@ describe Fastlane::Actions::UploadToS3Action do
       .and_return(Aws::S3::Types::HeadObjectOutput.new(content_length: content_length))
   end
 
-  # Allow us to do `.with` matching against a `File` instance to a particular path in RSpec expectations
-  # Because `File.open(path)` returns a different instance of `File` for the same path on each call)
-  RSpec::Matchers.define :file_instance_of do |path|
-    match { |actual| actual.is_a?(File) && actual.path == path }
-  end
-
   describe 'uploading a file' do
     it 'generates a prefix for the key by default' do
       in_tmp_dir do |tmp_dir|

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -1,0 +1,55 @@
+require 'tempfile'
+require_relative './spec_helper'
+
+describe Fastlane::Actions::UploadToS3Action do
+  let(:client) { instance_double(Aws::S3::Client) }
+  let(:test_bucket) { 'a8c-wpmrt-unit-tests-bucket' }
+
+  before do
+    allow(Aws::S3::Client).to receive(:new).and_return(client)
+  end
+
+  # Stub head_object to return a specific content_length
+  def stub_s3_head_request(key, content_length)
+    allow(client).to receive(:head_object)
+      .with(bucket: test_bucket, key: key)
+      .and_return(Aws::S3::Types::HeadObjectOutput.new(content_length: content_length))
+  end
+
+  # Allow us to do `.with` matching against a `File` instance to a particular path in RSpec expectations
+  # Because `File.open(path)` returns a different instance of `File` for the same path on each call)
+  RSpec::Matchers.define :file_instance_of do |path|
+    match { |actual| actual.is_a?(File) && actual.path == path }
+  end
+
+  describe 'happy path' do
+    it 'generates a prefix for the key when using auto_prefix:true' do
+      in_tmp_dir do |tmp_dir|
+        file_path = File.join(tmp_dir, 'input_file_1')
+        File.write(file_path, 'Dummy content')
+        expected_key = 'k5w5OY2yQF55HiBXeP9w+F3/Yg4=/subdir/a8c-key1'
+
+        stub_s3_head_request(expected_key, 0) # File does not exist in S3
+        expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
+
+        return_value = run_described_fastlane_action(
+          bucket: test_bucket,
+          key: 'subdir/a8c-key1',
+          file: file_path
+        )
+
+        expect(return_value).to eq(expected_key)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
+      end
+    end
+
+    it 'uses the provided key verbatim when using auto_prefix:false'
+  end
+
+  describe 'error reporting' do
+    it 'errors if bucket is empty or nil'
+    it 'errors if key is nil' # Or should it auto-generate a key based on the filename or something instead in that case?
+    it 'errors if local file to upload does not exist'
+    it 'reports an error if the file already exists on S3'
+  end
+end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -22,12 +22,74 @@ describe Fastlane::Actions::UploadToS3Action do
     match { |actual| actual.is_a?(File) && actual.path == path }
   end
 
-  describe 'happy path' do
+  describe 'uploading a file' do
     it 'generates a prefix for the key by default' do
       in_tmp_dir do |tmp_dir|
         file_path = File.join(tmp_dir, 'input_file_1')
-        File.write(file_path, 'Dummy content')
-        expected_key = 'k5w5OY2yQF55HiBXeP9w+F3/Yg4=/subdir/a8c-key1'
+        File.write(file_path, '')
+        expected_key = '939c39398db2405e791e205778ff70f85dff620e/a8c-key1'
+
+        stub_s3_head_request(expected_key, 0) # File does not exist in S3
+        expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
+
+        return_value = run_described_fastlane_action(
+          bucket: test_bucket,
+          key: 'a8c-key1',
+          file: file_path
+        )
+
+        expect(return_value).to eq(expected_key)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
+      end
+    end
+
+    it 'generates a prefix for the key when using auto_prefix:true' do
+      in_tmp_dir do |tmp_dir|
+        file_path = File.join(tmp_dir, 'input_file_2')
+        File.write(file_path, '')
+        expected_key = '8bde1a7a04300df27b52f4383dc997e5fbbff180/a8c-key2'
+
+        stub_s3_head_request(expected_key, 0) # File does not exist in S3
+        expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
+
+        return_value = run_described_fastlane_action(
+          bucket: test_bucket,
+          key: 'a8c-key2',
+          file: file_path,
+          auto_prefix: true
+        )
+
+        expect(return_value).to eq(expected_key)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
+      end
+    end
+
+    it 'uses the provided key verbatim when using auto_prefix:false' do
+      in_tmp_dir do |tmp_dir|
+        file_path = File.join(tmp_dir, 'input_file_1')
+        File.write(file_path, '')
+        expected_key = 'a8c-key1'
+
+        stub_s3_head_request(expected_key, 0) # File does not exist in S3
+        expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
+
+        return_value = run_described_fastlane_action(
+          bucket: test_bucket,
+          key: 'a8c-key1',
+          file: file_path,
+          auto_prefix: false
+        )
+
+        expect(return_value).to eq(expected_key)
+        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
+      end
+    end
+
+    it 'correctly appends the key if it contains subdirectories' do
+      in_tmp_dir do |tmp_dir|
+        file_path = File.join(tmp_dir, 'input_file_1')
+        File.write(file_path, '')
+        expected_key = '939c39398db2405e791e205778ff70f85dff620e/subdir/a8c-key1'
 
         stub_s3_head_request(expected_key, 0) # File does not exist in S3
         expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
@@ -43,20 +105,16 @@ describe Fastlane::Actions::UploadToS3Action do
       end
     end
 
-    it 'generates a prefix for the key when using auto_prefix:true' do
-      in_tmp_dir do |tmp_dir|
-        file_path = File.join(tmp_dir, 'input_file_2')
-        File.write(file_path, 'Dummy content')
-        expected_key = 'i94aegQwDfJ7UvQ4PcmX5fu/8YA=/subdir/a8c-key2'
+    it 'uses the filename as the key if one is not provided' do
+      expected_key = 'c125bd799c6aad31092b02e440a8fae25b45a2ad/test_file_1'
 
+      with_tmp_file_path_for_file_named('test_file_1') do |file_path|
         stub_s3_head_request(expected_key, 0) # File does not exist in S3
         expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
 
         return_value = run_described_fastlane_action(
           bucket: test_bucket,
-          key: 'subdir/a8c-key2',
-          file: file_path,
-          auto_prefix: true
+          file: file_path
         )
 
         expect(return_value).to eq(expected_key)
@@ -64,32 +122,53 @@ describe Fastlane::Actions::UploadToS3Action do
       end
     end
 
-    it 'uses the provided key verbatim when using auto_prefix:false' do
-      in_tmp_dir do |tmp_dir|
-        file_path = File.join(tmp_dir, 'input_file_1')
-        File.write(file_path, 'Dummy content')
-        expected_key = 'subdir/a8c-key1'
+    it 'fails if bucket is empty or nil' do
+      expect do
+        with_tmp_file_path do |file_path|
+          run_described_fastlane_action(
+            bucket: '',
+            key: 'key',
+            file: file_path
+          )
+        end
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'You must provide a valid bucket name')
+    end
 
-        stub_s3_head_request(expected_key, 0) # File does not exist in S3
-        expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
+    it 'fails if an empty key is provided' do
+      expect do
+        with_tmp_file_path do |file_path|
+          run_described_fastlane_action(
+            bucket: test_bucket,
+            key: '',
+            file: file_path
+          )
+        end
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'You must provide a valid key')
+    end
 
-        return_value = run_described_fastlane_action(
+    it 'fails if local file does not exist' do
+      expect do
+        run_described_fastlane_action(
           bucket: test_bucket,
-          key: 'subdir/a8c-key1',
-          file: file_path,
-          auto_prefix: false
+          key: 'key',
+          file: 'this-file-does-not-exist.txt'
         )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Unable to read file at this-file-does-not-exist.txt')
+    end
 
-        expect(return_value).to eq(expected_key)
-        expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
+    it 'fails if the file already exists on S3' do
+      expected_key = 'a62f2225bf70bfaccbc7f1ef2a397836717377de/key'
+      stub_s3_head_request(expected_key, 1) # File already exists on S3
+
+      with_tmp_file_path_for_file_named('key') do |file_path|
+        expect do
+          run_described_fastlane_action(
+            bucket: test_bucket,
+            key: 'key',
+            file: file_path
+          )
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists at #{expected_key}")
       end
     end
-  end
-
-  describe 'error reporting' do
-    it 'errors if bucket is empty or nil'
-    it 'errors if key is nil' # Or should it auto-generate a key based on the filename or something instead in that case?
-    it 'errors if local file to upload does not exist'
-    it 'reports an error if the file already exists on S3'
   end
 end


### PR DESCRIPTION
This is built on top of https://github.com/wordpress-mobile/release-toolkit/pull/339, to add a couple of unit tests on the new action.

Feel free to push new commits to this PR to implement the remaining tests.

This PR can be merged either in `add/s3-binary-upload` first, _before_ we merge #339 tun `trunk`, or it can be merged in `trunk` _after_ #339 lands if we don't want to block #339.

## To Test

 - Run `be rspec spec/upload_to_s3_spec.rb` to focus on running just those new tests
 - Alternatively, just let CI run `rspec` tests
