### PR TITLE
Improve some log messages on L10n-related actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Improved logs and console output, to avoid `ios_download_strings_files_from_glotpress` to look like it's deadlocked while it takes some time to download all the exports of all the locales, and to avoid the log messages from `ios_extract_keys_from_strings_files` to be misleading. [#344]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -10,6 +10,7 @@ module Fastlane
 
         locales.each do |glotpress_locale, lproj_name|
           # Download the export in the proper `.lproj` directory
+          UI.message "Downloading translations for '#{lproj_name}' from GlotPress (#{glotpress_locale}) [#{params[:filters]}]..."
           lproj_dir = File.join(download_dir, "#{lproj_name}.lproj")
           destination = File.join(lproj_dir, "#{params[:table_basename]}.strings")
           FileUtils.mkdir(lproj_dir) unless Dir.exist?(lproj_dir)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_extract_keys_from_strings_files.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_extract_keys_from_strings_files.rb
@@ -16,9 +16,9 @@ module Fastlane
             next if target_strings_file == target_original_file # do not generate/overwrite the original locale itself
 
             keys_to_extract = keys_to_extract_per_target_file[target_original_file]
-            UI.message("Extracting #{keys_to_extract.count} keys into #{target_strings_file}...")
-
             extracted_translations = translations.slice(*keys_to_extract)
+            UI.message("Extracting #{extracted_translations.count} keys (out of #{keys_to_extract.count} expected) into #{target_strings_file}...")
+
             FileUtils.mkdir_p(File.dirname(target_strings_file)) # Ensure path up to parent dir exists, create it if not.
             Fastlane::Helper::Ios::L10nHelper.generate_strings_file_from_hash(translations: extracted_translations, output_path: target_strings_file)
           rescue StandardError => e


### PR DESCRIPTION
 - I forgot to put _any_ `UI.message` log in `ios_download_strings_files_from_glotpress` inside the loop which downloads each translation
    - This made the action look completely frozen (I actually really thought there was a deadlock or something when I tried it in WPiOS!) because each download can take some time, and we do multiple of them (one for each locale) in a loop.
    - So I added some logs in the loop to report progress and make it less look like it's deadlocked 😓 
 - While testing the `ios_extract_keys_from_strings_files`, I was thrown off by the logs telling me that it extracted 5 keys but in the resulting `InfoPlist.strings` files it created, there were no strings.
    - In practice it was because none of the expected keys were present in the various `*.lproj/Localizable.strings` files previously downloaded from GlotPress (simply because we haven't yet run a Sprint in which we'd have those merged then imported by GlotPress, so they are not there yet at the time I tested that in WPiOS), so not so surprising that my `InfoPlist.strings` files were empty in such context
    - But still, the log misleading me into thinking there were 5 keys extracted made me suspicious it was a bug with the action, instead of being because of the timing/context of missing translations.