### PR TITLE
Bumped to version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 ### Breaking Changes
 
-* Update the API of `ios_merge_strings_files` and `ios_extract_keys_from_strings_files` to support using prefixes for string keys when merging/splitting the files.
-  The actions now expect a `Hash` (instead of an `Array`) for the list of files to provide an associated prefix (or `nil` or `''` when none) for each file to merge/split. [#345]
+_None_
 
 ### New Features
 
@@ -15,11 +14,22 @@ _None_
 
 ### Bug Fixes
 
-* Improved logs and console output, to avoid `ios_download_strings_files_from_glotpress` to look like it's deadlocked while it takes some time to download all the exports of all the locales, and to avoid the log messages from `ios_extract_keys_from_strings_files` to be misleading. [#344]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 4.0.0
+
+### Breaking Changes
+
+* Update the API of `ios_merge_strings_files` and `ios_extract_keys_from_strings_files` to support using prefixes for string keys when merging/splitting the files.
+  The actions now expect a `Hash` (instead of an `Array`) for the list of files to provide an associated prefix (or `nil` or `''` when none) for each file to merge/split. [#345]
+
+### Bug Fixes
+
+* Improved logs and console output, to avoid `ios_download_strings_files_from_glotpress` to look like it's deadlocked while it takes some time to download all the exports of all the locales, and to avoid the log messages from `ios_extract_keys_from_strings_files` to be misleading. [#344]
 
 ## 3.1.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (3.1.0)
+    fastlane-plugin-wpmreleasetoolkit (4.0.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.4)
@@ -270,7 +270,6 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     minitest (5.14.4)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -280,8 +279,7 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.13.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '3.1.0'
+    VERSION = '4.0.0'
   end
 end


### PR DESCRIPTION
New version 4.0.0 ready to be shipped!

The only reason it's a breaking change is because the API for `ios_merge_strings_files` (introduced in `3.0.0`) and `ios_extract_keys_from_strings_files` (introduced in `3.1.0`) have changed.

PS: Those actions were not used by any client app yet (since [the PR to adopt them in WPiOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/18061) was waiting for this new release to land), so the fact that it is still strictly speaking a breaking change (as per SemVer) should not really have an impact on current consumers of the release-toolkit in practice, making that update in client apps not requiring any change of their Fastfiles anyway.