### PR TITLE
Speed up Build & Test on CI

### DIFF
--- a/.buildkite/gem-push.sh
+++ b/.buildkite/gem-push.sh
@@ -1,12 +1,14 @@
 #!/bin/bash -eu
 
+GEM_NAME="fastlane-plugin-wpmreleasetoolkit"
+
 echo "--- :hammer: Build Gemspec"
-gem build fastlane-plugin-wpmreleasetoolkit.gemspec
+gem build "$GEM_NAME.gemspec" -o "$GEM_NAME.gem"
 
 echo "--- :sleuth_or_spy: Validate Gem Install"
-gem install --user-install fastlane-plugin-wpmreleasetoolkit-*.gem
+gem install --user-install "$GEM_NAME.gem"
 
 echo "--- :rubygems: Gem Push"
 echo ":rubygems_api_key: ${RUBYGEMS_API_KEY}" >>".gem-credentials"
 chmod 600 ".gem-credentials"
-gem push --config-file ".gem-credentials" fastlane-plugin-wpmreleasetoolkit-*.gem
+gem push --config-file ".gem-credentials" "$GEM_NAME.gem"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,8 +16,6 @@ common_params:
       environment:
         - "DANGER_GITHUB_API_TOKEN"
 
-agents:
-  queue: "default"
 
 steps:
   #################
@@ -38,6 +36,8 @@ steps:
     env: *xcode_image
     plugins:
       automattic/bash-cache#2.0.0: ~
+    agents:
+      queue: "mac"
 
   #################
   # Lint
@@ -49,6 +49,8 @@ steps:
       echo "--- :rubocop: Run Rubocop"
       bundle exec rubocop
     plugins: [*docker_plugin]
+    agents:
+      queue: "default"
 
   #################
   # Danger
@@ -60,6 +62,8 @@ steps:
       echo "--- :rubocop: Run Danger"
       bundle exec danger
     plugins: [*docker_plugin_with_danger_token]
+    agents:
+      queue: "default"
 
   #################
   # Push to RubyGems
@@ -76,3 +80,5 @@ steps:
     # BUILDKITE_COMMAND environment variable.
     command: .buildkite/gem-push.sh
     plugins: [*docker_plugin]
+    agents:
+      queue: "default"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,8 @@ common_params:
       environment:
         - "DANGER_GITHUB_API_TOKEN"
 
+agents:
+  queue: "default"
 
 steps:
   #################
@@ -24,10 +26,8 @@ steps:
   - label: "🧪 Build and Test"
     key: test
     command: |
-      # We only need this for tasks running on a Mac
-      brew install pkg-config git-lfs libxml2 imagemagick@6
-
       echo "--- :git: Setting up git-lfs"
+      brew install git-lfs
       git-lfs install
 
       echo "--- :rubygems: Setting up Gems"
@@ -38,8 +38,6 @@ steps:
     env: *xcode_image
     plugins:
       automattic/bash-cache#2.0.0: ~
-    agents:
-      queue: "mac"
 
   #################
   # Lint
@@ -51,8 +49,6 @@ steps:
       echo "--- :rubocop: Run Rubocop"
       bundle exec rubocop
     plugins: [*docker_plugin]
-    agents:
-      queue: "default"
 
   #################
   # Danger
@@ -64,8 +60,6 @@ steps:
       echo "--- :rubocop: Run Danger"
       bundle exec danger
     plugins: [*docker_plugin_with_danger_token]
-    agents:
-      queue: "default"
 
   #################
   # Push to RubyGems
@@ -82,5 +76,3 @@ steps:
     # BUILDKITE_COMMAND environment variable.
     command: .buildkite/gem-push.sh
     plugins: [*docker_plugin]
-    agents:
-      queue: "default"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+* Speed up our CI by removing now-useless installation of ImageMagick on CI to run the "Build and Test" step. [#348]
 
 ## 4.0.0
 


### PR DESCRIPTION
Make the "Build and Test" step stop installing `pkg-config` and `imagemagick`, since `drawText` has been removed from the repo and published as independent tool since 3.0.0 (via #312)

This should avoid all the time spent installing those 2 tools and thus speed up the CI on that "Build and Test" step.

---

PS: We still need to use a Mac agent for that step because it still requires `homebrew` to be able to `brew install git-lfs` (which is still required for some of our tests, at least so far).
We might consider getting rid of `git-lfs` and all the code and tests related to it in the future as I think it might not really be used anymore? But that's for another PR