### PR TITLE
Revert changes from #348

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,8 +24,10 @@ steps:
   - label: "🧪 Build and Test"
     key: test
     command: |
+      # We only need this for tasks running on a Mac
+      brew install pkg-config git-lfs libxml2 imagemagick@6
+
       echo "--- :git: Setting up git-lfs"
-      brew install git-lfs
       git-lfs install
 
       echo "--- :rubygems: Setting up Gems"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-* Speed up our CI by removing now-useless installation of ImageMagick on CI to run the "Build and Test" step. [#348]
+_None_
 
 ## 4.0.0
 


### PR DESCRIPTION
Turns out `brew install imagemagick` is still necessary after all on CI, if not for running the tests themselves, at least for installing the gems from the Gemfile.

# Why is `imagemagick` still needed?

This is because:
 - Our `Gemfile` includes the `gemspec` directive, which includes all the gem dependencies declared in our `.gemspec` as part of the `Gemfile`.
   This is typical in a gem repo like here, as the goal is to ensure that working on and testing the codebase would always use the same dependencies as the gem itself uses.
 - Our `.gemspec` contains `rmagick` as one of its dependency
 - Which in turn needs the `imagemagick` formula/library to be installed (via `brew`), otherwise we will get an error during `bundle install`.

So in short, running `bundle install` will try to install all the gems from the `Gemfile`, which is a superset of the dependecies from the `.gemspec` and thus will try to install the `rmagick` gem, which requires `imagemagick` to be installed.

# Why didn't the CI detect the issue in #348?

As @mokagio pointed out in https://github.com/wordpress-mobile/release-toolkit/pull/341#issuecomment-1072027535, this is very likely because when CI ran the build in #348, there was no change in the `Gemfile.lock`, so the CI used its cache for the gems instead of actually trying to install the gems from scratch.

Then only when another PR — namely https://github.com/wordpress-mobile/release-toolkit/pull/341 — did an update on `Gemfile.lock`, forcing the CI to rebuild the cache and install the gems from scratch, did the error start to pop up

# Alternatives Considered

Given that we currently don't really run any test using `rmagick`, we could consider trying to make `rmagic` be a dependency that would only be needed when _using_ the gem but not when developing it or running the tests on it.

## 1. Only install rmagick if gem used, but not during development?

At first I thought that we could maybe play with `spec.add_development_dependency` vs `spec.add_dependency` (which is [an alias for `spec.add_runtime_dependency`](https://apidock.com/ruby/Gem/Specification/add_dependency)) to make that distinction but:
 - Then I saw that `rmagick` was added with `add_development_dependency`, which [according to the doc](https://guides.rubygems.org/specification-reference/#add_development_dependency) (and to what the name of the method suggests) would not add `rmagick` as a dependency by default when the gem is installed…
 - While given that definition and the difference I understand from the doc between `add_runtime_dependency` and `add_development_dependency`, since we do need `rmagick` as a dependency to _run_ some actions in the toolkit, I'd have expected `rmagick` to be a runtime dependency, not a development one 🤔 
 - Also, then I'm not sure what's the point of `add_development_dependency` in the `.gemspec` vs just adding "a dependency that is only needed for development on the gem" directly in the `Gemfile` (with `:group => :development`) instead…

See also [doc details of what the `gemspec` keyword does when used in a `Gemfile`](https://bundler.io/man/gemfile.5.html#GEMSPEC)

Bottom line, runtime dependencies always get installed in both scenarios of "using the gem" and "developing the gem", and development dependencies are only installed in the "developing the gem" scenario… but we don't have an easy option to "install rmagick only in scenario of using the gem… but not when developing (and testing) it", So that's probably not a solution.

## 2. Move `rmagick` as a runtime dependency but with optional install?

If fact, it seems odd that `rmagick` was declared with `add_development_dependency` in our `.gemspec` given that it's necessary at runtime — to run the screenshot-related actions at least — so should probably be a `add_runtime_dependency`.

The issue is, doing so would make it a required dependency every time we install the toolkit… and thus force us to install `imagemagic`… even if we don't intend to run any of the screenshot-related actions that needs it. What a waste.

I'm actually pretty sure that's actually the very reason why we made it a `development_dependency` in the `.gemspec` instead, and then require the client apps to explicitly add `rmagick` as an additional dependency themselves, [so that they can do that conditionally using gem groups and `--with screenshots`](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/fastlane/Pluginfile#L5-L7).

**PS: If that's indeed the whole rationale behind that decitions, then too bad that rationale was not documented as a doc comment in the `.gemspec`** to save me all that time digging into it…

I also wondered if such a logic of "optional dependencies via groups" could not be declared in some way in the `.gemspec` instead of the `Gemfile`, and then in the `gem '…-wpmreleasetoolkit'` line in the consumer app's `Gemfile` specify which group we want  — in a similar way to how CocoaPods use subspecs to bring optional features… but [from what I see in the gemspec reference](https://guides.rubygems.org/specification-reference/) I don't see such a possibility existing in Ruby's gemspecs… 😢 