### PR TITLE
Add option to identify the source library when merging strings.xml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ _None_
 
 * Add the option for `an_localize_libs` to provide a `source_id` for each library being merged.  
   If provided, that identifier will be added as an `a8c-src-lib` XML attribute to the `<string>` nodes being updated with strings from said library.
-	This can be useful to help identify where each string come from in the resulting, merged `strings.xml`. [#351]
+  This can be useful to help identify where each string come from in the resulting, merged `strings.xml`. [#351]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ _None_
 
 ### New Features
 
-_None_
+* Add the option for `an_localize_libs` to provide a `source_id` for each library being merged.  
+  If provided, that identifier will be added as an `a8c-src-lib` XML attribute to the `<string>` nodes being updated with strings from said library.
+	This can be useful to help identify where each string come from in the resulting, merged `strings.xml`. [#351]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -32,6 +32,13 @@ module Fastlane
       end
 
       def self.available_options
+        libs_hash_description = <<~KEYS
+          - `:library`: The library display name
+          - `:strings_path`: The path to the `strings.xml` file of the library
+          - `:exclusions`: An optional `Array` of string keys to exclude from merging
+          - `:source_id`: An optional `String` which will be added as the `a8c-src-lib` XML attribute
+            to strings coming from this library, to help identify their source in the merged file.
+        KEYS
         [
           FastlaneCore::ConfigItem.new(key: :app_strings_path,
                                        description: 'The path of the main strings file',
@@ -41,10 +48,7 @@ module Fastlane
           # See `Fastlane::Helper::Android::LocalizeHelper.merge_lib`'s YARD doc for more details on the keys expected for each Hash.
           FastlaneCore::ConfigItem.new(key: :libs_strings_path,
                                        env_name: 'LOCALIZE_LIBS_STRINGS_PATH',
-                                       description: 'The list of libs to merge. ' \
-                                         + 'Each item in the provided array must be a Hash with the keys `:library` (The library display name),' \
-                                         + '`:strings_path` (The path to the `strings.xml` file of the library) and ' \
-                                         + '`:exclusions` (Array of string keys to exclude from merging)',
+                                       description: "The list of libs to merge. Each item in the provided array must be a Hash with the following keys:\n#{libs_hash_description}",
                                        optional: false,
                                        type: Array),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -24,7 +24,7 @@ module Fastlane
 
         # Checks if string_name is in the excluesion list
         def self.skip_string_by_exclusion_list(library, string_name)
-          return false unless library.key?(:exclusions)
+          return false if library[:exclusions].nil?
 
           skip = library[:exclusions].include?(string_name)
           if skip

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -9,6 +9,8 @@ module Fastlane
   module Helper
     module Android
       module LocalizeHelper
+        LIB_SOURCE_XML_ATTR = 'a8c-src-lib'.freeze
+
         # Checks if string_line has the content_override flag set
         def self.skip_string_by_tag(string_line)
           skip = string_line.attr('content_override') == 'true' unless string_line.attr('content_override').nil?
@@ -35,6 +37,7 @@ module Fastlane
         def self.merge_string(main_strings, library, string_line)
           string_name = string_line.attr('name')
           string_content = string_line.content
+          lib_src_id = library[:source_id]
 
           # Skip strings in the exclusions list
           return :skipped if skip_string_by_exclusion_list(library, string_name)
@@ -58,12 +61,14 @@ module Fastlane
               else
                 # It has the tools:ignore flag, so update the content without touching the other attributes
                 this_string.content = string_content
+                this_string[LIB_SOURCE_XML_ATTR] = lib_src_id unless lib_src_id.nil?
                 return result
               end
             end
           end
 
           # String not found, or removed because needing update and not in the exclusion list: add to the main file
+          string_line[LIB_SOURCE_XML_ATTR] = lib_src_id unless lib_src_id.nil?
           main_strings.xpath('//string').last().add_next_sibling("\n#{' ' * 4}#{string_line.to_xml().strip}")
           return result
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -15,7 +15,7 @@ module Fastlane
         def self.skip_string_by_tag(string_line)
           skip = string_line.attr('content_override') == 'true' unless string_line.attr('content_override').nil?
           if skip
-            puts " - Skipping #{string_line.attr('name')} string"
+            UI.message " - Skipping #{string_line.attr('name')} string"
             return true
           end
 
@@ -28,7 +28,7 @@ module Fastlane
 
           skip = library[:exclusions].include?(string_name)
           if skip
-            puts " - Skipping #{string_name} string"
+            UI.message " - Skipping #{string_name} string"
             return true
           end
         end
@@ -118,12 +118,12 @@ module Fastlane
             res = merge_string(main_strings, library, string_line)
             case res
             when :updated
-              puts "#{string_line.attr('name')} updated."
+              UI.verbose "#{string_line.attr('name')} updated."
               updated_count = updated_count + 1
             when :found
               untouched_count = untouched_count + 1
             when :added
-              puts "#{string_line.attr('name')} added."
+              UI.verbose "#{string_line.attr('name')} added."
               added_count = added_count + 1
             when :skipped
               skipped_count = skipped_count + 1


### PR DESCRIPTION
This improves the existing `an_localize_libs` action to adds support for the `source_id` option.

This option aims to helps identify which library each `<string>` merged into the main `strings.xml` came from.

## Why

 - This is prep work towards the plan drafted in paaHJt-3fg-p2
   - The future goal here would be to later update the merge logic to delete all the old entries that came from a previous merge of a library, before merging the new strings again. That way, keys deleted from the lib's `strings.xml` in a later version would properly be removed from the app's `strings.xml`, instead of being kept in the apps' `strings.xml` forever while not being used nor useful anymore
   - I decided to keep that deletion feature for later though, because implementing that feature would likely require a larger change in the current implementation and logic of the `an_localize_libs`'s helper code, and also might require a deeper analysis of potential consequences before going that route (e.g. what if a string is deleted from a lib later… but that key was still used by the app itself too?). Still, adding an attribute to identify the libs the strings were coming from still felt a useful first step anyway
 - But also, it will just help us (both the developers and the platform team) understand where each string from the `strings.xml` is coming from
   - This will be useful to developer to understand, when a string they see in the `WordPress/src/main/res/strings.xml`, where the source of truth for that string actually comes from (the app, or a lib?) and thus where to change that value if they need to (no point in changing the copy in the app's `strings.xml` file if the key will be re-overwritten by the next lib merge!)
   - It will also allow them to better reason about when to use `content_override` if they do want the key from the app's `strings.xml` to always take over and not be replace by the same key from a lib in the future (useful for example from a key like `app_name` not to be overwritten by a merge of the about library if it were to define one as well…)

## How

The action now accepts a new key in the `Hash` passed to its `libs_strings_path` parameter.
That new key is named `source_id` and allows the caller to provide an (optional) "identifier" string for the library. If provided, that identifier will be added as the value of a custom `a8c-src-lib` attribute of the `<string …>` XML nodes added or updated during the merging of the strings of said library.

You can see the result in action in [this draft WPAndroid PR](https://github.com/wordpress-mobile/WordPress-Android/pull/16280).

This PR also takes the occasion to:
 - Fix a crash if the caller provided a `nil` value for the `exclusions` key in the Hash
 - Use `UI.message` and `UI.verbose` instead of `puts` when the helper printed information about the strings being merged or updated.