### PR TITLE
Refactor `.po` generation – Part 1 of `n`

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -1,4 +1,3 @@
-require 'fastlane/action'
 require_relative '../../helper/metadata_update_helper'
 
 module Fastlane

--- a/spec/ios_update_metadata_source_spec.rb
+++ b/spec/ios_update_metadata_source_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 require 'shared_examples_for_update_metadata_source_action'
 
 describe Fastlane::Actions::IosUpdateMetadataSourceAction do
-  before {
+  before do
     # This works around the `ensure_git_status_clean` call within the action.
     # It would be quite cumbersome to iterate on the code if we had to commit
     # every change _before_ running the tests...
     allow(Fastlane::Actions::EnsureGitStatusCleanAction).to receive(:run)
-  }
+  end
 
   include_examples 'update_metadata_source_action', whats_new_fails: false
 end

--- a/spec/ios_update_metadata_source_spec.rb
+++ b/spec/ios_update_metadata_source_spec.rb
@@ -4,8 +4,13 @@ require 'shared_examples_for_update_metadata_source_action'
 describe Fastlane::Actions::IosUpdateMetadataSourceAction do
   before do
     # This works around the `ensure_git_status_clean` call within the action.
-    # It would be quite cumbersome to iterate on the code if we had to commit
-    # every change _before_ running the tests...
+    #
+    # We can't easily remove the need to stub the call here without removing the check in the action.
+    # In the tests, we move into a temp folder, but then create files in that directory.
+    # So, `ensure_git_status_clean` will fail anyway, unless we add more cruft to the tests.
+    #
+    # See also conversation in
+    # https://github.com/wordpress-mobile/release-toolkit/pull/352
     allow(Fastlane::Actions::EnsureGitStatusCleanAction).to receive(:run)
   end
 

--- a/spec/ios_update_metadata_source_spec.rb
+++ b/spec/ios_update_metadata_source_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'shared_examples_for_update_metadata_source_action'
+
+describe Fastlane::Actions::IosUpdateMetadataSourceAction do
+  before {
+    # This works around the `ensure_git_status_clean` call within the action.
+    # It would be quite cumbersome to iterate on the code if we had to commit
+    # every change _before_ running the tests...
+    allow(Fastlane::Actions::EnsureGitStatusCleanAction).to receive(:run)
+  }
+
+  include_examples 'update_metadata_source_action', whats_new_fails: false
+end

--- a/spec/shared_examples_for_update_metadata_source_action.rb
+++ b/spec/shared_examples_for_update_metadata_source_action.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.shared_examples 'update_metadata_source_action' do |options|
   it 'updates any block in a given .po file with the values from the given sources' do
-    Dir.mktmpdir do |dir|
+    in_tmp_dir do |dir|
       output_path = File.join(dir, 'output.po')
       dummy_text = <<~PO
         msgctxt "key1"
@@ -45,7 +45,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
   it 'combines the given `release_version` and `whats_new` parameter into a new block' do
     pending 'this currently fails; in the long run, we might consolidate `whats_new` with `release_notes`' if options[:whats_new_fails]
 
-    Dir.mktmpdir do |dir|
+    in_tmp_dir do |dir|
       output_path = File.join(dir, 'output.po')
       dummy_text = <<~PO
         msgctxt "v1.0-whats-new"
@@ -80,7 +80,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
   it 'adds entries passed as input even if not part of the original `.po` file' do
     pending 'this currently fails and will be addressed as part of the upcoming refactor/rewrite of the functionality'
 
-    Dir.mktmpdir do |dir|
+    in_tmp_dir do |dir|
       output_path = File.join(dir, 'output.po')
       dummy_text = <<~PO
         msgctxt "key1"
@@ -119,7 +119,7 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
   end
 
   it 'combines the given `release_version` and `release_notes` in a new block, keeps the n-1 ones, and deletes the others' do
-    Dir.mktmpdir do |dir|
+    in_tmp_dir do |dir|
       output_path = File.join(dir, 'output.po')
       dummy_text = <<~PO
         msgctxt "release_note_0122"


### PR DESCRIPTION
I didn't get to write an RFC today as I was hoping, but I wanted to at least track a tiny bit of self-contained work I've done while wrapping my head around the current structure.

- Adds a spec for the `ios_update_metadata_source` action
- Removes an unnecessary `require` (where by unnecessary I mean the tests pass anyway without it)