### PR TITLE
Soft-wrap some previously hard-wrapped comments

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -17,8 +17,7 @@ module Fastlane
       end
 
       # Ensure the git repository at `~/.mobile-secrets` is up to date.
-      # If the secrets repo is in a detached HEAD state, skip the pull,
-      # since it will fail.
+      # If the secrets repo is in a detached HEAD state, skip the pull, since it will fail.
       def self.update_repository
         secrets_repo_branch = Fastlane::Helper::ConfigureHelper.repo_branch_name
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -15,8 +15,8 @@ module Fastlane
         # otherwise, the error messaging isn't as helpful.
         validate_that_secrets_repo_is_clean
 
-        # Update the repository to get the latest version of the configuration secrets – that's
-        # how we'll know if we're behind in subsequent validations
+        # Update the repository to get the latest version of the configuration secrets
+        # – that's how we'll know if we're behind in subsequent validations
         ConfigureDownloadAction.run
 
         validate_that_branches_match

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -8,14 +8,11 @@ module Fastlane
       # Fallback default branch of the client repository.
       DEFAULT_GIT_BRANCH = 'trunk'.freeze
 
-      # Checks if the given path, or current directory if no path is given, is
-      # inside a Git repository
+      # Checks if the given path, or current directory if no path is given, is inside a Git repository
       #
-      # @param [String] path An optional path where to check if a Git repo
-      #        exists.
+      # @param [String] path An optional path where to check if a Git repo exists.
       #
-      # @return [Bool] True if the current directory is the root of a git repo
-      #         (i.e. a local working copy) or a subdirectory of one.
+      # @return [Bool] True if the current directory is the root of a git repo (i.e. a local working copy) or a subdirectory of one.
       #
       def self.is_git_repo?(path: Dir.pwd)
         # If the path doesn't exist, find its first ancestor.
@@ -23,23 +20,19 @@ module Fastlane
         # Get the path's directory, so we can look in it for the Git folder
         dir = path.directory? ? path : path.dirname
 
-        # Recursively look for the Git folder until it's found or we read the
-        # the file system root
+        # Recursively look for the Git folder until it's found or we read the the file system root
         dir = dir.parent until Dir.entries(dir).include?('.git') || dir.root?
 
-        # If we reached the root, we haven't found a repo. (Technically, there
-        # could be a repo in the root of the system, but that's a usecase that
-        # we don't need to support at this time)
+        # If we reached the root, we haven't found a repo.
+        # (Technically, there could be a repo in the root of the system, but that's a usecase that we don't need to support at this time)
         return dir.root? == false
       end
 
-      # Travels back the hierarchy of the given path until it finds an existing
-      # ancestor, or it reaches the root of the file system.
+      # Travels back the hierarchy of the given path until it finds an existing ancestor, or it reaches the root of the file system.
       #
       # @param [String] path The path to inspect
       #
-      # @return [Pathname] The first existing ancestor, or `path` itself if it
-      #         exists
+      # @return [Pathname] The first existing ancestor, or `path` itself if it exists
       #
       def self.first_existing_ancestor_of(path:)
         p = Pathname(path).expand_path
@@ -106,7 +99,7 @@ module Fastlane
       #
       # @param [String] message The commit message to use
       # @param [String|Array<String>] files A file or array of files to git-add before creating the commit.
-      #        use `nil` or `[]` if you already added the files in a separate step and don't wan't this method to add any new file before commit.
+      #        Use `nil` or `[]` if you already added the files in a separate step and don't wan't this method to add any new file before commit.
       #        Also accepts the special symbol `:all` to add all the files (`git commit -a -m …`).
       # @param [Bool] push If true, will `git push` to `origin` after the commit has been created. Defaults to `false`.
       #
@@ -209,8 +202,7 @@ module Fastlane
         UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
       end
 
-      # Checks whether a given path is ignored by Git, relying on Git's
-      # `check-ignore` under the hood.
+      # Checks whether a given path is ignored by Git, relying on Git's `check-ignore` under the hood.
       #
       # @param [String] path The path to check against `.gitignore`
       #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
@@ -73,7 +73,7 @@ module Fastlane
           File.readlines(file).each_with_index do |line, line_no|
             line.chars.each_with_index do |c, col_no|
               # Handle escaped characters at a global level.
-              # This is more straightforward than having a `TRANSITIONS` table that account for it.
+              # This is more straightforward than having to account for it in the `TRANSITIONS` table.
               if state.in_escaped_ctx || c == '\\'
                 # Just because we check for escaped characters at the global level, it doesn't mean we allow them in every context.
                 allowed_contexts_for_escaped_characters = %i[in_quoted_key in_quoted_value in_block_comment in_line_comment]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
@@ -60,8 +60,7 @@ module Fastlane
           }
         }.freeze
 
-        # Inspects the given `.strings` file for duplicated keys, returning them
-        # if any.
+        # Inspects the given `.strings` file for duplicated keys, returning them if any.
         #
         # @param [String] file The path to the file to inspect.
         # @return [Hash<String, Array<Int>] Hash with the dublipcated keys.
@@ -73,12 +72,10 @@ module Fastlane
 
           File.readlines(file).each_with_index do |line, line_no|
             line.chars.each_with_index do |c, col_no|
-              # Handle escaped characters at a global level. This is more
-              # straightforward than having a `TRANSITIONS` table that account
-              # for it.
+              # Handle escaped characters at a global level.
+              # This is more straightforward than having a `TRANSITIONS` table that account for it.
               if state.in_escaped_ctx || c == '\\'
-                # Just because we check for escaped characters at the global
-                # level, it doesn't mean we allow them in every context.
+                # Just because we check for escaped characters at the global level, it doesn't mean we allow them in every context.
                 allowed_contexts_for_escaped_characters = %i[in_quoted_key in_quoted_value in_block_comment in_line_comment]
                 raise "Found escaped character outside of allowed contexts on line #{line_no + 1} (current context: #{state.context})" unless allowed_contexts_for_escaped_characters.include?(state.context)
 
@@ -87,16 +84,14 @@ module Fastlane
                 next
               end
 
-              # Look at the transitions table for the current context, and find
-              # the first transition matching the current character
+              # Look at the transitions table for the current context, and find the first transition matching the current character
               (_, next_context) = TRANSITIONS[state.context].find { |regex, _| c.match?(regex) } || [nil, nil]
               raise "Invalid character `#{c}` found on line #{line_no + 1}, col #{col_no + 1}" if next_context.nil?
 
               state.context = next_context.is_a?(Proc) ? next_context.call(state, c) : next_context
               next unless state.found_key
 
-              # If we just exited the :in_quoted_key context and thus have found
-              # a new key, process it
+              # If we just exited the :in_quoted_key context and thus have found a new key, process it
               key = state.found_key.dup
               state.found_key = nil
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -12,8 +12,7 @@ module Fastlane
         @alternates = {}
       end
 
-      # Downloads data from GlotPress,
-      # in JSON format
+      # Downloads data from GlotPress, in JSON format
       def download(target_locale, glotpress_url, is_source)
         uri = URI(glotpress_url)
         response = Net::HTTP.get_response(uri)
@@ -80,8 +79,7 @@ module Fastlane
         end
       end
 
-      # Writes the downloaded content
-      # to the target file
+      # Writes the downloaded content to the target file
       def save_metadata(locale, file_name, content)
         file_path = get_target_file_path(locale, file_name)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -117,8 +117,7 @@ module Fastlane
       end
 
       def draw_screenshot_to_canvas(entry, canvas, device)
-        # Don't require a screenshot to be present – we can just skip
-        # this function if one doesn't exist.
+        # Don't require a screenshot to be present – we can just skip this function if one doesn't exist.
         return canvas if entry['screenshot'].nil?
 
         device_mask = device['screenshot_mask']

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
@@ -9,9 +9,11 @@ module Fastlane
       def self.add_new_section(path:, section_title:)
         lines = File.readlines(path)
 
-        # Find the index of the first non-empty line that is also NOT a comment. That way we keep commment headers as the very top of the file
+        # Find the index of the first non-empty line that is also NOT a comment.
+        # That way we keep commment headers as the very top of the file
         line_idx = lines.find_index { |l| !l.start_with?('***') && !l.start_with?('//') && !l.chomp.empty? }
-        # Put back the header, then the new entry, then the rest (note: '...' excludes the higher bound of the range, unlike '..')
+        # Put back the header, then the new entry, then the rest
+        # (note: '...' excludes the higher bound of the range, unlike '..')
         new_lines = lines[0...line_idx] + ["#{section_title}\n", "-----\n", "\n", "\n"] + lines[line_idx..]
 
         File.write(path, new_lines.join)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -40,11 +40,9 @@ module Fastlane
       end
 
       # "Applies" the instruction described in the instance to the file system.
-      # That is, copies the content of the source `file` to the `destination`
-      # path.
+      # That is, copies the content of the source `file` to the `destination` path.
       #
-      # @raise [StandardError] For security reasons, it will raise if
-      # `destination` is not ignored under Git.
+      # @raise [StandardError] For security reasons, it will raise if `destination` is not ignored under Git.
       def apply
         # Only decrypt the file if the destination is ignored in Git
         unless Fastlane::Helper::GitHelper.is_ignored?(path: destination_file_path)

--- a/spec/an_localize_libs_action_spec.rb
+++ b/spec/an_localize_libs_action_spec.rb
@@ -1,12 +1,9 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AnLocalizeLibsAction do
-  # This test is more of a way of ensuring `run_described_fastlane_action` handles array
-  # of hashes properly than a comprehensive test for the
-  # `an_localize_libs_action` action.
+  # This test is more of a way of ensuring `run_described_fastlane_action` handles array of hashes properly than a comprehensive test for the `an_localize_libs_action` action.
   #
-  # Please consider expanding this test if you'll find yourself working on its
-  # action.
+  # Please consider expanding this test if you'll find yourself working on its action.
   it 'merges the strings from the given array into the given main strings file' do
     in_tmp_dir do |tmp_dir|
       app_strings_path = File.join(tmp_dir, 'app.xml')
@@ -37,12 +34,9 @@ describe Fastlane::Actions::AnLocalizeLibsAction do
 end
 
 def android_xml_with_content(content)
-  # I couldn't find a way to interpolate a multiline string preserving its
-  # indentation in the heredoc below, so I hacked the following transformation
-  # of the input that adds the desired indentation to all lines.
+  # I couldn't find a way to interpolate a multiline string preserving its indentation in the heredoc below, so I hacked the following transformation of the input that adds the desired indentation to all lines.
   #
-  # The desired indentation is 4 spaces to stay aligned with the production
-  # code applies when merging the XMLs.
+  # The desired indentation is 4 spaces to stay aligned with the production code applies when merging the XMLs.
   indented_content = content.chomp.lines.map { |l| "    #{l}" }.join
 
   return <<~XML

--- a/spec/an_metadata_update_helper_spec.rb
+++ b/spec/an_metadata_update_helper_spec.rb
@@ -17,11 +17,9 @@ describe Fastlane::Helper::StandardMetadataBlock do
       output_io = StringIO.new
       described_class.new('any-key', input_path).generate_block(output_io)
 
-      # Ensure the output matches the expectation: the trailing new line has
-      # been stripped.
+      # Ensure the output matches the expectation: the trailing new line has been stripped.
       #
-      # Note that the final new line is intentional. It's part of the
-      # formatting at the time of writing.
+      # Note that the final new line is intentional. It's part of the formatting at the time of writing.
       expect(output_io.string).to eq <<~EXP
         msgctxt "any-key"
         msgid "Single line message with new line"
@@ -39,13 +37,11 @@ describe Fastlane::Helper::StandardMetadataBlock do
       input_path = File.join(dir, 'input')
       File.write(input_path, input)
 
-      # Write the .pot block in a StringIO to bypass the filesystem and have
-      # faster tests
+      # Write the .pot block in a StringIO to bypass the filesystem and have faster tests
       output_io = StringIO.new
       described_class.new('any-key', input_path).generate_block(output_io)
 
-      # Note that the new line after `msgstr` is intentional. It's part of the
-      # formatting at the time of writing.
+      # Note that the new line after `msgstr` is intentional. It's part of the formatting at the time of writing.
       expect(output_io.string).to eq <<~'EXP'
         msgctxt "any-key"
         msgid ""

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -10,12 +10,9 @@ describe Fastlane::Helper::ConfigureHelper do
           .with(path: destination)
           .and_return(false)
 
-        # Currently, we need a Git repository to exists in the hierarchy
-        # containing the call site otherwise the tests will end up stuck in
-        # some kind of loop (which I haven't fully inspected). That's a
-        # reasonable enough assumption to make for the real world usage of this
-        # tool. Still, it would be nice to have proper handling of that
-        # scenario at some point.
+        # Currently, we need a Git repository to exists in the hierarchy containing the call site otherwise the tests will end up stuck in some kind of loop (which I haven't fully inspected).
+        # That's a reasonable enough assumption to make for the real world usage of this tool.
+        # Still, it would be nice to have proper handling of that scenario at some point.
         `git init --initial-branch main || git init`
 
         expect(Fastlane::UI).to receive(:user_error!)

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -135,11 +135,10 @@ describe Fastlane::Helper::GitHelper do
 
     context 'when the path is in the .gitignore' do
       it 'returns true when the .gitignore has uncommitted changes' do
-        # For some reason, I was expecting the underlying `git check-ignore`
-        # command to fail in this case, but I'm clearly wrong.
+        # For some reason, I was expecting the underlying `git check-ignore` command to fail in this case, but I'm clearly wrong.
         #
-        # I think there's value in keeping this behavior explicity documented
-        # and verified here. – Gio
+        # I think there's value in keeping this behavior explicity documented and verified here.
+        # – Gio
         setup_git_repo(
           dummy_file_path: path,
           add_file_to_gitignore: true,
@@ -158,9 +157,8 @@ describe Fastlane::Helper::GitHelper do
       end
     end
 
-    # This test ensures we support the usecase of the `configure` tool, which
-    # can create new files by decrypting secrets. We need the ability to tell
-    # if a path result is ignored, regardless of whether it exists yet.
+    # This test ensures we support the usecase of the `configure` tool, which can create new files by decrypting secrets.
+    # We need the ability to tell if a path result is ignored, regardless of whether it exists yet.
     it 'returns false for files not yet created but part of the repository' do
       setup_git_repo()
       expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be false
@@ -174,10 +172,8 @@ describe Fastlane::Helper::GitHelper do
       expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be true
     end
 
-    # This is sort of redundant given the previous example already ensures the
-    # same logic. But, we'll be using paths starting with `~` as part of our
-    # configurations, so it felt appopriate to explicitly ensure this important
-    # use case is respected.
+    # This is sort of redundant given the previous example already ensures the same logic.
+    # But, we'll be using paths starting with `~` as part of our configurations, so it felt appopriate to explicitly ensure this important use case is respected.
     it 'returns true when the path is in the home folder ' do
       path = '~/a/path'
       expect(Fastlane::Helper::GitHelper.is_ignored?(path: path)).to be true
@@ -190,8 +186,8 @@ def setup_git_repo(dummy_file_path: nil, add_file_to_gitignore: false, commit_gi
   `touch .gitignore`
   `git add .gitignore && git commit -m 'Add .gitignore'`
 
-  # If we don't have a path for the file, we don't care the values of the two
-  # flag arguments are irrelevant. We can just finish here.
+  # If we don't have a path for the file, we don't care the values of the two flag arguments are irrelevant.
+  # We can just finish here.
   return if dummy_file_path.nil?
 
   `echo abc > #{dummy_file_path}`

--- a/spec/ios_strings_file_validation_helper_spec.rb
+++ b/spec/ios_strings_file_validation_helper_spec.rb
@@ -38,8 +38,7 @@ describe Fastlane::Helper::Ios::StringsFileValidationHelper do
 
   context 'when there are no duplicated keys' do
     it 'returns an empty array' do
-      # Piggy back on some of the `.strings` from other tests to ensure this
-      # behaves correctly
+      # Piggy back on some of the `.strings` from other tests to ensure this behaves correctly
       expect(
         described_class.find_duplicated_keys(
           file: File.join(test_data_dir, 'ios_l10n_helper', 'expected-merged-prefixed.strings')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,8 +55,7 @@ def expect_shell_command(*command, exitstatus: 0, output: '')
   expect(Open3).to receive(:popen2e).with(*command).and_yield(mock_input, mock_output, mock_thread)
 end
 
-# If the `described_class` of a spec is a `Fastlane::Action` subclass, it runs
-# it with the given parameters.
+# If the `described_class` of a spec is a `Fastlane::Action` subclass, it runs it with the given parameters.
 #
 def run_described_fastlane_action(parameters)
   raise "Only call `#{__callee__}` from a spec describing a `Fastlane::Action` subclass." unless Fastlane::Actions.is_class_action?(described_class)


### PR DESCRIPTION
See discussion at https://github.com/wordpress-mobile/release-toolkit/pull/342#discussion_r843929362.

I use a script with `awk awk 'length>70 && length<81'`. Some of the results were comments starting with `##` or `###`. I ignored those under the assumption they'll get addressed at some point in a dedicated PR that converts them to `#` (or organically disappear)

--- 

The CI failure is unrelated to this PR.