### PR TITLE
Fix test failure on ios_strings_file_validation_helper_spec

### DIFF
--- a/spec/ios_strings_file_validation_helper_spec.rb
+++ b/spec/ios_strings_file_validation_helper_spec.rb
@@ -42,7 +42,7 @@ describe Fastlane::Helper::Ios::StringsFileValidationHelper do
       # behaves correctly
       expect(
         described_class.find_duplicated_keys(
-          file: File.join(test_data_dir, 'ios_l10n_helper', 'expected-merged.strings')
+          file: File.join(test_data_dir, 'ios_l10n_helper', 'expected-merged-prefixed.strings')
         )
       ).to be_empty
       expect(
@@ -50,6 +50,17 @@ describe Fastlane::Helper::Ios::StringsFileValidationHelper do
           file: File.join(test_data_dir, 'ios_extract_keys_from_strings_files', 'Resources', 'en.lproj', 'Localizable.strings')
         )
       ).to be_empty
+    end
+  end
+
+  context 'when there are unquoted keys' do
+    it 'returns an error' do
+      # Unquoted strings are currently not supported by our validation helper in its current state, despite being a valid syntax, because we considered
+      # that it was not worth adding complexity to our state machine logic for this use case — we expect all the `.strings` files we plan to validate will
+      # come from GlotPress exports, and will thus always have their keys quoted.
+      # If support for unquoted strings is added to our validation helper in the future, feel free to update this test example accordingly.
+      expect { described_class.find_duplicated_keys(file: File.join(test_data_dir, 'ios_l10n_helper', 'expected-merged.strings')) }
+        .to raise_error(RuntimeError, 'Invalid character `I` found on line 21, col 1')
     end
   end
 end


### PR DESCRIPTION
After https://github.com/wordpress-mobile/release-toolkit/pull/342 was merged, this unit test started to fail on CI.

I'm not sure why that test failure was not detected by CI _before_ #342 was merged (and thus how we were allowed to merge it), but the result is that any PRs that we started to submit since then failed on this test and prevented CI from passing on any of those. This fixes the issue.

(See also https://github.com/wordpress-mobile/release-toolkit/pull/342#issuecomment-1097101886 for more detailed explanations on the test failure)

---

Once this PR lands in `trunk`, we'll be able to rebase all open PRs on top of it to benefit from the test failure fix which should finally make them go green again.