### PR TITLE
Release 4.1.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ---
 
-## Develop
+## Trunk
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 4.1.0
+
+### New Features
+
 * Add the option for `an_localize_libs` to provide a `source_id` for each library being merged.  
   If provided, that identifier will be added as an `a8c-src-lib` XML attribute to the `<string>` nodes being updated with strings from said library.
   This can be useful to help identify where each string come from in the resulting, merged `strings.xml`. [#351]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (4.0.0)
+    fastlane-plugin-wpmreleasetoolkit (4.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)
@@ -270,7 +270,6 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     minitest (5.14.4)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -280,8 +279,7 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.13.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -11,7 +11,7 @@ module Fastlane
       module LocalizeHelper
         LIB_SOURCE_XML_ATTR = 'a8c-src-lib'.freeze
 
-        # Checks if `string_node` has the content_override flag set
+        # Checks if `string_node` has the `content_override` flag set
         def self.skip_string_by_tag?(string_node)
           skip = string_node.attr('content_override') == 'true' unless string_node.attr('content_override').nil?
           if skip

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '4.0.0'
+    VERSION = '4.1.0'
   end
 end

--- a/rakelib/changelog_parser.rake
+++ b/rakelib/changelog_parser.rake
@@ -1,5 +1,5 @@
 class ChangelogParser
-  PENDING_SECTION_TITLE = 'Develop'.freeze
+  PENDING_SECTION_TITLE = 'Trunk'.freeze
   EMPTY_PLACEHOLDER = '_None_'.freeze
   SUBSECTIONS_SEMVER_MAP = { 'Breaking Changes': 3, 'New Features': 2, 'Bug Fixes': 1, 'Internal Changes': 1 }.freeze
 


### PR DESCRIPTION
New version 4.1.0. Be sure to create a GitHub Release and tag once this PR gets merged.