### PR TITLE
Add duplicate keys detection to `ios_lint_localization` action – Optional, but active by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ _None_
 
 ### New Features
 
+* The `ios_lint_localizations` action now also checks for duplicated keys in the `.strings` files.
+  The behavior is optional via the `check_duplicate_keys` parameter and enabled by default [#360]
+
 _None_
 
 ### Bug Fixes

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -6,6 +6,7 @@ module Fastlane
 
         loop do
           violations = self.run_linter(params)
+          report(violations: violations, base_lang: params[:base_lang])
           break unless !violations.empty? && params[:allow_retry] && UI.confirm(RETRY_MESSAGE)
         end
 
@@ -44,17 +45,18 @@ module Fastlane
           install_path: resolve_path(params[:install_path]),
           version: params[:version]
         )
-        all_violations = helper.run(
+
+        helper.run(
           input_dir: resolve_path(params[:input_dir]),
           base_lang: params[:base_lang],
           only_langs: params[:only_langs]
         )
+      end
 
-        all_violations.each do |lang, lang_violations|
-          UI.error "Inconsistencies found between '#{params[:base_lang]}' and '#{lang}':\n\n#{lang_violations.join("\n")}\n"
+      def self.report(violations:, base_lang:)
+        violations.each do |lang, lang_violations|
+          UI.error "Inconsistencies found between '#{base_lang}' and '#{lang}':\n\n#{lang_violations.join("\n")}\n"
         end
-
-        all_violations
       end
 
       RETRY_MESSAGE = <<~MSG

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -2,10 +2,12 @@ module Fastlane
   module Actions
     class IosLintLocalizationsAction < Action
       def self.run(params)
-        violations = {}
+        violations = Hash.new([])
 
         loop do
-          violations = self.run_linter(params)
+          # If we did `violations = self.run...` we'd lose the default value for missing key being `[]` that we set above with `Hash.new`.
+          # We want that default value so that we can use `+=` when adding the duplicate keys violations below.
+          violations = violations.merge(self.run_linter(params))
 
           if params[:check_duplicate_keys]
             find_duplicated_keys(params).each do |language, duplicates|

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -8,9 +8,8 @@ module Fastlane
           violations = self.run_linter(params)
 
           if params[:check_duplicate_keys]
-            find_duplicated_keys(params).each do |language, _|
-              # if we're in here, there's violations
-              violations[language] += ['there were duplicates']
+            find_duplicated_keys(params).each do |language, duplicates|
+              violations[language] += duplicates
             end
           end
 
@@ -59,7 +58,7 @@ module Fastlane
 
         files_to_lint.each do |file|
           duplicates = Fastlane::Helper::Ios::StringsFileValidationHelper.find_duplicated_keys(file: file[:path])
-          duplicate_keys[file[:language]] = duplicates unless duplicates.empty?
+          duplicate_keys[file[:language]] = duplicates.map { |key, value| "`#{key}` was found at multiple lines: #{value.join(', ')}" } unless duplicates.empty?
         end
 
         duplicate_keys

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -54,7 +54,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
   end
 
   context 'Linter' do
-    def run_l10n_linter_test(data_file)
+    def run_l10n_linter_test(data_file:)
       # Arrange: Prepare test files
       test_file = File.join(File.dirname(__FILE__), 'test-data', 'translations', "test-lint-ios-#{data_file}.yaml")
       yml = YAML.load_file(test_file)
@@ -88,23 +88,23 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
     end
 
     it 'succeeds when there are no violations' do
-      run_l10n_linter_test('no-violations')
+      run_l10n_linter_test(data_file: 'no-violations')
     end
 
     it 'detects inconsistent placeholder count' do
-      run_l10n_linter_test('wrong-placeholder-count')
+      run_l10n_linter_test(data_file: 'wrong-placeholder-count')
     end
 
     it 'detects inconsistent placeholder types' do
-      run_l10n_linter_test('wrong-placeholder-types')
+      run_l10n_linter_test(data_file: 'wrong-placeholder-types')
     end
 
     it 'properly handles misleading characters and placeholders in RTL languages' do
-      run_l10n_linter_test('tricky-chars')
+      run_l10n_linter_test(data_file: 'tricky-chars')
     end
 
     it 'does not fail if a locale does not have any Localizable.strings' do
-      run_l10n_linter_test('no-strings')
+      run_l10n_linter_test(data_file: 'no-strings')
     end
 
     after(:each) do

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -76,11 +76,12 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
       #       remove this after the test ends, so that further executions of the test run faster.
       #       Only the first execution of the tests might take longer if it needs to install SwiftGen first to be able to run the tests.
       install_dir = "vendor/swiftgen/#{Fastlane::Helper::Ios::L10nLinterHelper::SWIFTGEN_VERSION}"
-      result = run_described_fastlane_action(
+      parameters = {
         install_path: install_dir,
         input_dir: @test_data_dir,
         base_lang: 'en'
-      )
+      }
+      result = run_described_fastlane_action(parameters)
 
       # Assert
       expect(result).to eq(yml['result'])

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -117,6 +117,10 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
       run_l10n_linter_test(data_file: 'violations-and-duplicate-keys')
     end
 
+    it 'when there are only duplications, it reports them' do
+      run_l10n_linter_test(data_file: 'duplicate-keys-only')
+    end
+
     it 'detects both inconsistencies and duplicated strings when asked to do so' do
       run_l10n_linter_test(data_file: 'violations-and-duplicate-keys', check_duplicate_keys: true)
     end

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -113,7 +113,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
     end
 
     it 'detects both inconsistencies and duplicated strings by default' do
-      # "by defaul" = don't explicitly set the `:check_duplicate_keys` parameter
+      # "by default" = don't explicitly set the `:check_duplicate_keys` parameter
       run_l10n_linter_test(data_file: 'violations-and-duplicate-keys')
     end
 

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -117,7 +117,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
       run_l10n_linter_test(data_file: 'violations-and-duplicate-keys')
     end
 
-    it 'when there are only duplications, it reports them' do
+    it 'detects when there are only duplications and reports them' do
       run_l10n_linter_test(data_file: 'duplicate-keys-only')
     end
 

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -54,6 +54,10 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
   end
 
   context 'Linter' do
+    # Helper function that DRYs the code running each test.
+    #
+    # @param [String] data_file The name, without extension or "test-lint-ios-" prefix, of the YML file containing the test input and expected output.
+    #
     def run_l10n_linter_test(data_file:)
       # Arrange: Prepare test files
       test_file = File.join(File.dirname(__FILE__), 'test-data', 'translations', "test-lint-ios-#{data_file}.yaml")

--- a/spec/test-data/translations/test-lint-ios-duplicate-keys-only.yaml
+++ b/spec/test-data/translations/test-lint-ios-duplicate-keys-only.yaml
@@ -1,0 +1,28 @@
+test_data:
+  en: |
+    "okay_key" = "value";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+    "yet_another_duplicate_key" = "yet another value";
+    "other_okay_key" = "other value";
+  fr: |
+    "okay_key" = "value";
+    "duplicate_key" = "value";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+    "other_okay_key" = "other value";
+  it: |
+    "okay_key" = "value";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+    "other_duplicate_key" = "other value";
+    "yet_another_duplicate_key" = "yet another value";
+    "yet_another_duplicate_key" = "yet another value";
+    "other_okay_key" = "other value";
+
+result:
+  fr:
+    - "`duplicate_key` was found at multiple lines: 2, 3"
+  it:
+    - "`other_duplicate_key` was found at multiple lines: 3, 4"
+    - "`yet_another_duplicate_key` was found at multiple lines: 5, 6"

--- a/spec/test-data/translations/test-lint-ios-violations-and-duplicate-keys-reporting-violations-only.yaml
+++ b/spec/test-data/translations/test-lint-ios-violations-and-duplicate-keys-reporting-violations-only.yaml
@@ -1,0 +1,23 @@
+test_data:
+  en: |
+    "string_no_pos" = "String %@ here.";
+    "repeated_placeholder" = "String %1$@, yes, I repeat, that's %1$@ indeed, I said %@.";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+  fr: |
+    "string_no_pos" = "String %@ here and %@ here too.";
+    "duplicate_key" = "value";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+  it: |
+    "string_no_pos" = "String %@ here.";
+    "repeated_placeholder" = "String %1$@, yes, and not %2%@, I repeat, that's not %2$@.";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+    "other_duplicate_key" = "other value";
+
+result:
+  fr:
+    - "`string_no_pos` expected placeholders for [String] but found [String,String] instead."
+  it:
+    - "`repeated_placeholder` expected placeholders for [String] but found [String,String] instead."

--- a/spec/test-data/translations/test-lint-ios-violations-and-duplicate-keys.yaml
+++ b/spec/test-data/translations/test-lint-ios-violations-and-duplicate-keys.yaml
@@ -1,0 +1,25 @@
+test_data:
+  en: |
+    "string_no_pos" = "String %@ here.";
+    "repeated_placeholder" = "String %1$@, yes, I repeat, that's %1$@ indeed, I said %@.";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+  fr: |
+    "string_no_pos" = "String %@ here and %@ here too.";
+    "duplicate_key" = "value";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+  it: |
+    "string_no_pos" = "String %@ here.";
+    "repeated_placeholder" = "String %1$@, yes, and not %2%@, I repeat, that's not %2$@.";
+    "duplicate_key" = "value";
+    "other_duplicate_key" = "other value";
+    "other_duplicate_key" = "other value";
+
+result:
+  fr:
+    - "`string_no_pos` expected placeholders for [String] but found [String,String] instead."
+    - "there were duplicates"
+  it:
+    - "`repeated_placeholder` expected placeholders for [String] but found [String,String] instead."
+    - "there were duplicates"

--- a/spec/test-data/translations/test-lint-ios-violations-and-duplicate-keys.yaml
+++ b/spec/test-data/translations/test-lint-ios-violations-and-duplicate-keys.yaml
@@ -4,6 +4,7 @@ test_data:
     "repeated_placeholder" = "String %1$@, yes, I repeat, that's %1$@ indeed, I said %@.";
     "duplicate_key" = "value";
     "other_duplicate_key" = "other value";
+    "yet_another_duplicate_key" = "yet another value";
   fr: |
     "string_no_pos" = "String %@ here and %@ here too.";
     "duplicate_key" = "value";
@@ -15,11 +16,14 @@ test_data:
     "duplicate_key" = "value";
     "other_duplicate_key" = "other value";
     "other_duplicate_key" = "other value";
+    "yet_another_duplicate_key" = "yet another value";
+    "yet_another_duplicate_key" = "yet another value";
 
 result:
   fr:
     - "`string_no_pos` expected placeholders for [String] but found [String,String] instead."
-    - "there were duplicates"
+    - "`duplicate_key` was found at multiple lines: 2, 3"
   it:
     - "`repeated_placeholder` expected placeholders for [String] but found [String,String] instead."
-    - "there were duplicates"
+    - "`other_duplicate_key` was found at multiple lines: 4, 5"
+    - "`yet_another_duplicate_key` was found at multiple lines: 6, 7"


### PR DESCRIPTION
Adds duplicate keys detection to the `ios_lint_localization`.

I tested it via https://github.com/wordpress-mobile/WordPress-iOS/pull/18465. And I'm really glad I did because I found the bug which [`9f21958`](https://github.com/wordpress-mobile/release-toolkit/pull/360/commits/9f219588d37ef86dd2f5282d74b321c786ba6534) addresses.

Pointing to this branch:

1. Updated the strings in [wordpress-mobile/WordPress-iOS@`0423c76` (#18465)](https://github.com/wordpress-mobile/WordPress-iOS/pull/18465/commits/0423c760947adba330510137c7d6f3ac9ebf643c) just to reduce the lint noise because we fixed a bunch of things recently
2. Added some violations to the `.strings` in [wordpress-mobile/WordPress-iOS@`1744149` (#18465)](https://github.com/wordpress-mobile/WordPress-iOS/pull/18465/commits/1744149ec80cdcad8995cf9d6c352f0002395204) and [wordpress-mobile/WordPress-iOS@`b8be225` (#18465)](https://github.com/wordpress-mobile/WordPress-iOS/pull/18465/commits/b8be22505d3e4a0f20de7da736b3be1a161e4893)
3. Run `bundle exec fastlane run ios_lint_localizations`

The result was

```
[21:16:27]: Inconsistencies found between 'en' and 'es':

`%1$@ to fix threats.` expected placeholders for [String] but found [] instead.

[21:16:27]: Inconsistencies found between 'en' and 'it':

` \/ year` was found at multiple lines: 19, 21
`\"Lazy-load\" images` was found at multiple lines: 24, 26

[21:16:27]: Inconsistencies found between 'en' and 'ro':

`Edit sharing buttons` was found at multiple lines: 2683, 2686


[!] Inconsistencies found during Localization linting. Aborting.
```

The `ro` duplicated key was unintentional. 😄 our new tooling already paying off. – I asked for help removing it here pxLjZ-71k-p2