### PR TITLE
Update GlotPress `export-translations` requests to avoid rate limiting

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -282,7 +282,7 @@ module Fastlane
         #
         def self.download_glotpress_export_file(project_url:, locale:, filters:)
           query_params = filters.transform_keys { |k| "filters[#{k}]" }.merge(format: 'android')
-          uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations?#{URI.encode_www_form(query_params)}")
+          uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations/?#{URI.encode_www_form(query_params)}")
           begin
             uri.open { |f| Nokogiri::XML(f.read.gsub("\t", '    '), nil, Encoding::UTF_8.to_s) }
           rescue StandardError => e

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -283,8 +283,12 @@ module Fastlane
         def self.download_glotpress_export_file(project_url:, locale:, filters:)
           query_params = filters.transform_keys { |k| "filters[#{k}]" }.merge(format: 'android')
           uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations/?#{URI.encode_www_form(query_params)}")
+
+          # Set an unambiguous User Agent so GlotPress won't rate-limit us
+          options = { 'User-Agent' => 'Automattic App Release Automator; https://github.com/wordpress-mobile/release-toolkit/' }
+
           begin
-            uri.open { |f| Nokogiri::XML(f.read.gsub("\t", '    '), nil, Encoding::UTF_8.to_s) }
+            uri.open(options) { |f| Nokogiri::XML(f.read.gsub("\t", '    '), nil, Encoding::UTF_8.to_s) }
           rescue StandardError => e
             UI.error "Error downloading #{locale} - #{e.message}"
             return nil

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -285,7 +285,7 @@ module Fastlane
           uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations/?#{URI.encode_www_form(query_params)}")
 
           # Set an unambiguous User Agent so GlotPress won't rate-limit us
-          options = { 'User-Agent' => 'Automattic App Release Automator; https://github.com/wordpress-mobile/release-toolkit/' }
+          options = { 'User-Agent' => Wpmreleasetoolkit::USER_AGENT }
 
           begin
             uri.open(options) { |f| Nokogiri::XML(f.read.gsub("\t", '    '), nil, Encoding::UTF_8.to_s) }

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -146,7 +146,7 @@ module Fastlane
           uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations/?#{URI.encode_www_form(query_params)}")
 
           # Set an unambiguous User Agent so GlotPress won't rate-limit us
-          options = { 'User-Agent' => 'Automattic App Release Automator; https://github.com/wordpress-mobile/release-toolkit/' }
+          options = { 'User-Agent' => Wpmreleasetoolkit::USER_AGENT }
 
           begin
             IO.copy_stream(uri.open(options), destination)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -144,8 +144,12 @@ module Fastlane
         def self.download_glotpress_export_file(project_url:, locale:, filters:, destination:)
           query_params = (filters || {}).transform_keys { |k| "filters[#{k}]" }.merge(format: 'strings')
           uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations/?#{URI.encode_www_form(query_params)}")
+
+          # Set an unambiguous User Agent so GlotPress won't rate-limit us
+          options = { 'User-Agent' => 'Automattic App Release Automator; https://github.com/wordpress-mobile/release-toolkit/' }
+
           begin
-            IO.copy_stream(uri.open, destination)
+            IO.copy_stream(uri.open(options), destination)
           rescue StandardError => e
             UI.error "Error downloading locale `#{locale}` — #{e.message}"
             return nil

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -143,7 +143,7 @@ module Fastlane
         #
         def self.download_glotpress_export_file(project_url:, locale:, filters:, destination:)
           query_params = (filters || {}).transform_keys { |k| "filters[#{k}]" }.merge(format: 'strings')
-          uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations?#{URI.encode_www_form(query_params)}")
+          uri = URI.parse("#{project_url.chomp('/')}/#{locale}/default/export-translations/?#{URI.encode_www_form(query_params)}")
           begin
             IO.copy_stream(uri.open, destination)
           rescue StandardError => e

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/user_agent.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/user_agent.rb
@@ -1,0 +1,5 @@
+module Fastlane
+  module Wpmreleasetoolkit
+    USER_AGENT = 'Automattic App Release Automator; https://github.com/wordpress-mobile/release-toolkit/'.freeze
+  end
+end

--- a/spec/android_localize_helper_spec.rb
+++ b/spec/android_localize_helper_spec.rb
@@ -61,7 +61,7 @@ describe Fastlane::Helper::Android::LocalizeHelper do
         Dir[File.join(stubs_dir, '*.xml')].each do |path|
           # Each file in stubs_dir is a `{locale_code}.xml` whose content is what we want to use as stub for glotpress requests to `locale_code`
           locale_code = File.basename(path, '.xml')
-          url = "#{gp_fake_url.chomp('/')}/#{locale_code}/default/export-translations?filters%5Bstatus%5D=current&format=android"
+          url = "#{gp_fake_url.chomp('/')}/#{locale_code}/default/export-translations/?filters%5Bstatus%5D=current&format=android"
           stub_request(:get, url).to_return(status: 200, body: File.read(path))
         end
 
@@ -215,7 +215,7 @@ describe Fastlane::Helper::Android::LocalizeHelper do
 
         # Arrange: Prepare request stubs
         custom_gp_urls = TEST_LOCALES_MAP.map do |locale|
-          "#{gp_fake_url.chomp('/')}/#{locale[:glotpress]}/default/export-translations?filters%5Bstatus%5D=custom-status&filters%5Bwarnings%5D=yes&format=android"
+          "#{gp_fake_url.chomp('/')}/#{locale[:glotpress]}/default/export-translations/?filters%5Bstatus%5D=custom-status&filters%5Bwarnings%5D=yes&format=android"
         end
         custom_gp_urls.each do |url|
           stub_request(:get, url)
@@ -244,7 +244,7 @@ describe Fastlane::Helper::Android::LocalizeHelper do
         statuses = %w[current waiting fuzzy]
         statuses.each do |status|
           stub_path = File.join(fixtures_dir, 'filters', "#{status}.xml")
-          stub_request(:get, "#{gp_fake_url.chomp('/')}/fakegploc/default/export-translations?filters%5Bstatus%5D=#{status}&format=android")
+          stub_request(:get, "#{gp_fake_url.chomp('/')}/fakegploc/default/export-translations/?filters%5Bstatus%5D=#{status}&format=android")
             .to_return(status: 200, body: File.read(stub_path))
         end
 

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
   let(:locales_subset) { { 'fr-FR': 'fr', 'zh-cn': 'zh-Hans' } }
 
   def gp_stub(locale:, query:)
-    stub_request(:get, "#{gp_fake_url}/#{locale}/default/export-translations").with(query: query)
+    stub_request(:get, "#{gp_fake_url}/#{locale}/default/export-translations/").with(query: query)
   end
 
   describe 'downloading export files from GlotPress' do

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -190,7 +190,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
     describe 'request query parameters' do
       it 'passes the expected params when no filters are provided' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations").with(query: { format: 'strings' }).to_return(body: 'content')
+        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations/").with(query: { format: 'strings' }).to_return(body: 'content')
         dest = StringIO.new
         # Act
         described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: nil, destination: dest)
@@ -201,7 +201,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
 
       it 'passes the expected params when a list of filters is provided' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations")
+        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations/")
                .with(query: { format: 'strings', 'filters[status]': 'current', 'filters[term]': 'foobar' }).to_return(body: 'content')
         dest = StringIO.new
         # Act
@@ -221,7 +221,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
           # Note: in practice it seems that GlotPress's `.strings` exports are using UTF-8 (but served as `application/octet-stream`)
           #       but it does not hurt to ensure the download to a file can work with UTF-16 (and copy the binary stream verbatim)
           body = File.read(fixture('Localizable-utf16.strings'))
-          stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations").with(query: { format: 'strings' }).to_return(body: body)
+          stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations/").with(query: { format: 'strings' }).to_return(body: body)
           dest = File.join(tmp_dir, 'export.strings')
           # Act
           described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'fr', filters: nil, destination: dest)
@@ -236,7 +236,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
     describe 'invalid parameters' do
       it 'prints an `UI.error` if passed a non-existing locale (or any other 404)' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/invalid/default/export-translations").with(query: { format: 'strings' }).to_return(status: [404, 'Not Found'])
+        stub = stub_request(:get, "#{gp_fake_url}/invalid/default/export-translations/").with(query: { format: 'strings' }).to_return(status: [404, 'Not Found'])
         error_messages = []
         allow(FastlaneCore::UI).to receive(:error) { |message| error_messages.append(message) }
         dest = StringIO.new
@@ -249,7 +249,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
 
       it 'prints an `UI.error` if the destination cannot be written to' do
         # Arrange
-        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations").with(query: { format: 'strings' }).to_return(body: 'content')
+        stub = stub_request(:get, "#{gp_fake_url}/fr/default/export-translations/").with(query: { format: 'strings' }).to_return(body: 'content')
         error_messages = []
         allow(FastlaneCore::UI).to receive(:error) { |message| error_messages.append(message) }
         dest = '/these/are/not/the/droids/you/are/looking/for.strings'


### PR DESCRIPTION
~~Left to do: Make the "Error downloading locale..." print the URL used for the download, to make it easier to triage.~~ See #362.

---


Starting yesterday, both I and @AliSoftware have been experiencing rate-liming when trying to download translations for the iOS app via this tooling:

```
[05:56:38]: -------------------------------------------------------
[05:56:38]: --- Step: ios_download_strings_files_from_glotpress ---
[05:56:38]: -------------------------------------------------------
[05:56:38]: Downloading translations for 'ar' from GlotPress (ar) [{:status=>"current"}]...
[05:56:39]: Error downloading locale `ar` — 429 Too Many Requests
[05:56:39]: Downloading translations for 'bg' from GlotPress (bg) [{:status=>"current"}]...
[05:56:40]: Error downloading locale `bg` — 429 Too Many Requests
...
```

I [reached out in the WordPress.org Slack](https://wordpress.slack.com/archives/C02RP50LK/p1651607938132789) and the issue was identified as genuine rate-limiting applied to our requests (I still don't know why it started only recently, though).

@dd32 [suggested in the WordPress.org Slack](https://wordpress.slack.com/archives/C02RP50LK/p1651640726217119?thread_ts=1651607938.132789&cid=C02RP50LK) to:

> - Set the user agent
> - Fix the URI you’re requesting, you need to request …./export-translations/?… otherwise you’re doubling the requests needed (It doesn’t include a trailing slash at present)
> - Check if your SSL dependancies are up-to-date, older SSL libraries might trigger some new checks

This PR address the first two points. Regarding SSL, we don't have any specific dependency, so I'm guessing it's all up to the `URI.open` implementation from the Ruby runtime on which the tooling runs. We try to keep those fairly up to date. Our major apps are all on Ruby 2.7.4 (not the latest, but fairly recent still)

- [WooCommerce Android](https://github.com/woocommerce/woocommerce-android/blob/d1d41b3de1debc47e8f5b7ab1b017e78f43b38cf/.ruby-version)
- [WooCommerce iOS](https://github.com/woocommerce/woocommerce-ios/blob/df682188bca96766594fc2c77090bdc20acef251/.ruby-version)
- [WordPress Android](https://github.com/wordpress-mobile/WordPress-Android/blob/64101c4cb0ed2e4806a6e7f39dbbc9bb551c9460/.ruby-version)
- [WordPress iOS](https://github.com/wordpress-mobile/WordPress-iOS/blob/d51d3f7d864e69c9c2df2e2616a600d6e020bff4/.ruby-version)