### PR TITLE
Print URLs that failed to download from GlotPress

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -151,7 +151,7 @@ module Fastlane
           begin
             IO.copy_stream(uri.open(options), destination)
           rescue StandardError => e
-            UI.error "Error downloading locale `#{locale}` — #{e.message}"
+            UI.error "Error downloading locale `#{locale}` — #{e.message} (#{uri})"
             return nil
           end
         end

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -81,7 +81,7 @@ describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
         # Assert
         expect(stub).to have_been_made.once
         expect(File).not_to exist(File.join(tmp_dir, 'Base.lproj', 'Localizable.strings'))
-        expect(error_messages).to eq(['Error downloading locale `unknown-locale` — 404 Not Found'])
+        expect(error_messages).to eq(["Error downloading locale `unknown-locale` — 404 Not Found (#{gp_fake_url}/unknown-locale/default/export-translations/?filters%5Bstatus%5D=current&format=strings)"])
       end
     end
 

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -265,7 +265,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
         described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'invalid', filters: nil, destination: dest)
         # Assert
         expect(stub).to have_been_made.once
-        expect(error_messages).to eq(['Error downloading locale `invalid` — 404 Not Found'])
+        expect(error_messages).to eq(["Error downloading locale `invalid` — 404 Not Found (#{gp_fake_url}/invalid/default/export-translations/?format=strings)"])
       end
 
       it 'prints an `UI.error` if the destination cannot be written to' do
@@ -279,7 +279,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
         # Assert
         expect(stub).to have_been_made.once
         expect(File).not_to exist(dest)
-        expect(error_messages).to eq(["Error downloading locale `fr` — No such file or directory @ rb_sysopen - #{dest}"])
+        expect(error_messages).to eq(["Error downloading locale `fr` — No such file or directory @ rb_sysopen - #{dest} (#{gp_fake_url}/fr/default/export-translations/?format=strings)"])
       end
     end
   end


### PR DESCRIPTION
I wanted to make this part of https://github.com/wordpress-mobile/release-toolkit/pull/361, but I'm not too happy with the implementation, so here's a dedicated PR for it and we can iterate.

I'm not happy with the implementation because the tests look odd and rigid with all those hardcoded URLs.