### PR TITLE
Screenshots: Fix blocking errors in promo screenshots helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _None_
 ### Bug Fixes
 
 * Update GlotPress `export-translations` requests to avoid rate limiting. [#361] [#362]
+* Fix bugs with the shell command in `promo_screenshots_helper`. [#366]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -234,7 +234,7 @@ module Fastlane
         begin
           tempTextFile = Tempfile.new()
 
-          Action.sh('drawText', "html=\"#{text}\"", "maxWidth=#{width}", "maxHeight=#{height}", "output=\"#{tempTextFile.path}\"", "fontSize=#{font_size}", "stylesheet=\"#{stylesheet_path}\"", "alignment=\"#{position}\"")
+          Action.sh('drawText', "html=#{text}", "maxWidth=#{width}", "maxHeight=#{height}", "output=#{tempTextFile.path}", "fontSize=#{font_size}", "stylesheet=#{stylesheet_path}", "alignment=#{position}")
 
           text_content = open_image(tempTextFile.path).trim
           text_frame = create_image(width, height)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -234,7 +234,7 @@ module Fastlane
         begin
           tempTextFile = Tempfile.new()
 
-          sh('drawText', "html=\"#{text}\"", "maxWidth=#{width}", "maxHeight=#{height}", "output=\"#{tempTextFile.path}\"", "fontSize=#{font_size}", "stylesheet=\"#{stylesheet_path}\"", "alignment=\"#{position}\"")
+          Action.sh('drawText', "html=\"#{text}\"", "maxWidth=#{width}", "maxHeight=#{height}", "output=\"#{tempTextFile.path}\"", "fontSize=#{font_size}", "stylesheet=\"#{stylesheet_path}\"", "alignment=\"#{position}\"")
 
           text_content = open_image(tempTextFile.path).trim
           text_frame = create_image(width, height)


### PR DESCRIPTION
Related: pdnsEh-hU-p2

## Description

This PR resolves errors with the `drawText` shell command in the promo screenshots helper, which were blocking screenshot generation.

Many thanks to @AliSoftware for the help investigating and resolving this!

## Changes

* Calls `Action.sh` instead of `sh` to resolve an unknown method error for the `drawText` shell command.
* Removes the escaped quotes in the `drawText` shell command. These quotes are not needed since the parameters are being passed separately, and instead cause errors as they are taken as verbatim quote characters.

## Testing

You can test these changes in Woo iOS with the testing steps in https://github.com/woocommerce/woocommerce-ios/pull/6933.