### PR TITLE
Release 4.2.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,6 @@ _None_
 * The `ios_lint_localizations` action now also checks for duplicated keys in the `.strings` files.
   The behavior is optional via the `check_duplicate_keys` parameter and enabled by default. [#360]
 
-_None_
-
 ### Bug Fixes
 
 * Update GlotPress `export-translations` requests to avoid rate limiting. [#361] [#362]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 4.2.0
+
+### New Features
+
 * The `ios_lint_localizations` action now also checks for duplicated keys in the `.strings` files.
   The behavior is optional via the `check_duplicate_keys` parameter and enabled by default. [#360]
 
@@ -19,10 +33,6 @@ _None_
 
 * Update GlotPress `export-translations` requests to avoid rate limiting. [#361] [#362]
 * Fix bugs with the shell command in `promo_screenshots_helper`. [#366]
-
-### Internal Changes
-
-_None_
 
 ## 4.1.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (4.1.0)
+    fastlane-plugin-wpmreleasetoolkit (4.2.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)
@@ -427,4 +427,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.33
+   2.3.11

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '4.1.0'
+    VERSION = '4.2.0'
   end
 end


### PR DESCRIPTION
New version 4.2.0. Be sure to create a GitHub Release and tag once this PR gets merged.