### PR TITLE
Use Automattic as the Gem and Fastlane action author

### DIFF
--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -5,8 +5,8 @@ require 'fastlane/plugin/wpmreleasetoolkit/version'
 Gem::Specification.new do |spec|
   spec.name          = 'fastlane-plugin-wpmreleasetoolkit'
   spec.version       = Fastlane::Wpmreleasetoolkit::VERSION
-  spec.author        = 'Lorenzo Mattei'
-  spec.email         = 'lore.mattei@gmail.com'
+  spec.author        = 'Automattic'
+  spec.email         = 'mobile@automattic.com'
 
   spec.summary       = 'GitHub helper functions'
   spec.homepage      = 'https://github.com/wordpress-mobile/release-toolkit'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -21,7 +21,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -160,7 +160,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
@@ -26,7 +26,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -98,7 +98,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -73,7 +73,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb
@@ -43,7 +43,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -51,7 +51,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -43,7 +43,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -55,7 +55,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -69,7 +69,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -75,7 +75,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -57,7 +57,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
@@ -52,7 +52,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
@@ -35,7 +35,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_file_by_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_file_by_version.rb
@@ -68,7 +68,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
@@ -104,7 +104,7 @@ module Fastlane
       end
 
       def self.authors
-        ['AliSoftware']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -60,7 +60,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
@@ -33,7 +33,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
@@ -33,7 +33,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
@@ -33,7 +33,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
@@ -67,7 +67,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_send_app_size_metrics.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_send_app_size_metrics.rb
@@ -270,7 +270,7 @@ module Fastlane
       end
 
       def self.authors
-        ['automattic']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -45,7 +45,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_for_toolkit_updates_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_for_toolkit_updates_action.rb
@@ -60,7 +60,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Olivier Halligon']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_translation_progress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_translation_progress.rb
@@ -136,7 +136,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/circleci_trigger_job_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/circleci_trigger_job_action.rb
@@ -52,7 +52,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -21,7 +21,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -23,7 +23,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -37,7 +37,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -49,7 +49,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_list_action.rb
@@ -26,7 +26,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -79,7 +79,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -159,7 +159,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -123,7 +123,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
@@ -22,7 +22,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
@@ -21,7 +21,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Lorenzo Mattei']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
@@ -73,7 +73,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Jeremy Massel']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -113,7 +113,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Jeremy Massel']
+        ['Automattic']
       end
 
       def self.details

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -33,7 +33,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Jeremy Massel']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
@@ -63,7 +63,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Jeremy Massel']
+        ['Automattic']
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -124,7 +124,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Jeremy Massel']
+        ['Automattic']
       end
 
       def self.details

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -119,7 +119,7 @@ module Fastlane
       end
 
       def self.authors
-        ['Jeremy Massel']
+        ['Automattic']
       end
 
       def self.details

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -66,7 +66,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['jkmassel']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -68,7 +68,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['jkmassel']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -87,7 +87,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -63,7 +63,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -67,7 +67,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -71,7 +71,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -80,7 +80,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -51,7 +51,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -49,7 +49,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -65,7 +65,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -52,7 +52,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
@@ -29,7 +29,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -41,7 +41,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -36,7 +36,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
@@ -49,7 +49,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['AliSoftware']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -110,7 +110,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ['AliSoftware']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
@@ -67,7 +67,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_localize_project.rb
@@ -32,7 +32,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_strings_files.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_strings_files.rb
@@ -68,7 +68,7 @@ module Fastlane
       end
 
       def self.authors
-        ['automattic']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_send_app_size_metrics.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_send_app_size_metrics.rb
@@ -159,7 +159,7 @@ module Fastlane
       end
 
       def self.authors
-        ['automattic']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
@@ -33,7 +33,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
@@ -29,7 +29,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -70,7 +70,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -45,7 +45,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
@@ -35,7 +35,7 @@ module Fastlane
       end
 
       def self.authors
-        ['loremattei']
+        ['Automattic']
       end
 
       def self.is_supported?(platform)


### PR DESCRIPTION
I was looking at an action and noticed Lore was the hardcoded author. Seemed no longer appropriate given he has left 😢 

I took a couple of minutes to update everything to use "Automattic," which is the standard name we've been using for a while.