### PR TITLE
Release 5.0.1 into `trunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Fix metadata length computation logic [[#383](https://github.com/wordpress-mobile/release-toolkit/pull/383)]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 5.0.1
+
+### Bug Fixes
+
+- Fix metadata length computation logic [[#383](https://github.com/wordpress-mobile/release-toolkit/pull/383)]
 
 ## 5.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (5.0.0)
+    fastlane-plugin-wpmreleasetoolkit (5.0.1)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)
@@ -272,7 +272,6 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     minitest (5.14.4)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -282,8 +281,7 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.13.7)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.7-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -438,4 +436,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.9
+   2.3.16

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '5.0.0'
+    VERSION = '5.0.1'
   end
 end


### PR DESCRIPTION
New version 5.0.1. Be sure to create a GitHub Release and tag once this PR gets merged.

---

I need this to continue working on 92-gh-Automattic/pocket-casts-ios