### PR TITLE
Allow using BUILDKITE_API_TOKEN as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+* Allow using the `BUILDKITE_API_TOKEN` environment variable for the `buildkite_trigger_build` action. [#386]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -36,7 +36,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :buildkite_token,
-            env_name: 'BUILDKITE_TOKEN',
+            env_names: %w[BUILDKITE_TOKEN BUILDKITE_API_TOKEN],
             description: 'Buildkite Personal Access Token',
             type: String,
             sensitive: true


### PR DESCRIPTION
This change allows using `BUILDKITE_API_TOKEN` environment variable for the `buildkite_trigger_build` action. This is [the default that's expected by Buildkit](https://github.com/Shopify/buildkit/blob/742e2e2ad8fc255f1e26143bf5502b017d754da9/lib/buildkit/client.rb#L44), so we should allow both.