### PR TITLE
Release 5.1.0 into `trunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,25 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 5.1.0
+
+### New Features
+
 * Allow using the `BUILDKITE_API_TOKEN` environment variable for the `buildkite_trigger_build` action. [#386]
 
 ### Bug Fixes
 
 - Fix metadata length computation logic [[#383](https://github.com/wordpress-mobile/release-toolkit/pull/383)]
-
-### Internal Changes
-
-_None_
 
 ## 5.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (5.0.0)
+    fastlane-plugin-wpmreleasetoolkit (5.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)
@@ -438,4 +438,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.9
+   2.3.18

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '5.0.0'
+    VERSION = '5.1.0'
   end
 end


### PR DESCRIPTION
New version 5.1.0. Be sure to create a GitHub Release and tag once this PR gets merged.

---

I need this to continue working on 92-gh-Automattic/pocket-casts-ios.

See also, https://github.com/wordpress-mobile/release-toolkit/pull/384.

---

Interestingly, today the `new_release` task worked, despite not having applied the "fixes" from #387. I started the automation to see how far it went and planned to continue manually because I really want the release out and also the fact that `bundle install` worked for me but the one from Rake didn't seemed fishy. Anyways, the automation went all the way to the end. 