### PR TITLE
Add `tools:ignore="InconsistentArrays"` to `available_languages.xml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Add `tools:ignore="InconsistentArrays"` to `available_languages.xml` to avoid a linter warning on repos hosting multiple app flavors. [#390]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -212,8 +212,8 @@ module Fastlane
         def self.create_available_languages_file(res_dir:, locale_codes:)
           doc = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
             xml.comment('Warning: Auto-generated file, do not edit.')
-            xml.resources do
-              xml.send(:'string-array', name: 'available_languages', translatable: 'false') do
+            xml.resources('xmlns:tools': 'http://schemas.android.com/tools') do
+              xml.send(:'string-array', name: 'available_languages', translatable: 'false', 'tools:ignore': 'InconsistentArrays') do
                 locale_codes.each { |code| xml.item(code.gsub('-r', '_')) }
               end
             end

--- a/spec/test-data/translations/glotpress-download/expected/values/available_languages.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values/available_languages.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Warning: Auto-generated file, do not edit.-->
-<resources>
-  <string-array name="available_languages" translatable="false">
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string-array name="available_languages" translatable="false" tools:ignore="InconsistentArrays">
     <item>en_US</item>
     <item>es</item>
     <item>pt_BR</item>


### PR DESCRIPTION
This should address the lint issue on repos using multiple flavors for multiple apps, and thus needing multiple `available-languages.xml`, like WP vs JP do.

See also p8Qyks-351-p2#comment-1298 and https://github.com/wordpress-mobile/WordPress-Android/commit/35103522f8c410f0d4aa81906e97bfd42377f4e9