### PR TITLE
Fixes milestones being compared as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _None_
 _None_
 
 ### Bug Fixes
+* Fixes milestones being compared as strings instead of integers in `github_helper.get_last_milestone` [#391]
 
 _None_
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -70,7 +70,7 @@ module Fastlane
           else
             begin
               last_vcomps = last_stone[:title].split[0].split('.')
-              last_stone = mile if mile_vcomps[0] > last_vcomps[0] || mile_vcomps[1] > last_vcomps[1]
+              last_stone = mile if Integer(mile_vcomps[0]) > Integer(last_vcomps[0]) || Integer(mile_vcomps[1]) > Integer(last_vcomps[1])
             rescue StandardError
               puts 'Found invalid milestone'
             end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -92,6 +92,30 @@ describe Fastlane::Helper::GithubHelper do
     end
   end
 
+  describe 'get_last_milestone' do
+    let(:test_repo) { 'repo-test/project-test' }
+    let(:last_stone) { mock_milestone('10.0') }
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: ['9.8 ❄️', '9.9'].map { |title| mock_milestone(title) }.append(last_stone)
+      )
+    end
+
+    before do
+      allow(described_class).to receive(:github_client).and_return(client)
+    end
+
+    it 'returns correct milestone' do
+      expect(client).to receive(:list_milestones)
+      expect(described_class.get_last_milestone(repository: test_repo)).to eq(last_stone)
+    end
+
+    def mock_milestone(title)
+      { title: title }
+    end
+  end
+
   describe 'comment_on_pr' do
     let(:client) do
       instance_double(


### PR DESCRIPTION
We had a few failures in `create_new_milestone` in WCiOS and WCAndroid returning `already_exists` error. This was due to `get_last_milestone` returning `9.9` as the last milestone when in fact `10.0` is the last one. It turns out we have been doing a string comparison for the parts of milestone instead of an integer one and Ruby says `"10" > "9" = false`, so 🤷 

This PR updates the milestone comparison to an integer one and introduces a unit test that fails without this fix.

**To test:**
* Revert `8d7bd7c19a59433ea3611d0c2c11f9a5991a43f6` and run the new unit test and verify that it fails
* Run the unit test again and verify that it succeeds (this is also covered by CI)