### PR TITLE
Add the ability for the `buildkite_trigger_build` action to provide a custom message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _None_
 ### New Features
 
 - Add `tools:ignore="InconsistentArrays"` to `available_languages.xml` to avoid a linter warning on repos hosting multiple app flavors. [#390]
+- Add the ability to provide a custom message for builds triggered via `buildkite_trigger_build` action [#392]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -9,8 +9,6 @@ module Fastlane
         pipeline_name = {
           PIPELINE: params[:pipeline_file]
         }
-
-        client = Buildkit.new(token: params[:buildkite_token])
         options = {
           branch: params[:branch],
           commit: params[:commit],
@@ -18,6 +16,7 @@ module Fastlane
           message: params[:message]
         }.compact # remove entries with `nil` values from the Hash, if any
 
+        client = Buildkit.new(token: params[:buildkite_token])
         response = client.create_build(
           params[:buildkite_organization],
           params[:buildkite_pipeline],

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -11,14 +11,17 @@ module Fastlane
         }
 
         client = Buildkit.new(token: params[:buildkite_token])
+        options = {
+          branch: params[:branch],
+          commit: params[:commit],
+          env: params[:environment].merge(pipeline_name),
+          message: params[:message]
+        }.compact # remove entries with `nil` values from the Hash, if any
+
         response = client.create_build(
           params[:buildkite_organization],
           params[:buildkite_pipeline],
-          {
-            branch: params[:branch],
-            commit: params[:commit],
-            env: params[:environment].merge(pipeline_name)
-          }
+          options
         )
 
         response.state == 'scheduled' ? UI.message('Done!') : UI.crash!("Failed to start job\nError: [#{response}]")
@@ -63,6 +66,13 @@ module Fastlane
             description: 'The commit hash you want to build',
             type: String,
             default_value: 'HEAD'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :message,
+            description: 'A custom message to show for the build in Buildkite\'s UI',
+            type: String,
+            optional: true,
+            default_value: nil
           ),
           FastlaneCore::ConfigItem.new(
             key: :pipeline_file,


### PR DESCRIPTION
In particular, this will allow is to provide a custom message like "Create Release Builds" when we trigger a Buildkite build from the API during release management, instead of having those builds default to using the commit's message.

### To Test

I've created a test PR in https://github.com/wordpress-mobile/WordPress-Android/pull/17013 which points to this branch and uses the new `message:` option, and ran `fastlane new_beta_release` in there — then immediately canceled the build that this call created in Buildkite, to avoid it going to completion.

This confirmed that the new message parameter was used and the new build showed a nicer title for those:

![](https://user-images.githubusercontent.com/216089/183141565-66bb11ed-a3d9-4422-bbea-08fe0c223775.png)