### PR TITLE
Add optional `release_notes_file_path` arg to `update_release_notes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _None_
 
 - Add `tools:ignore="InconsistentArrays"` to `available_languages.xml` to avoid a linter warning on repos hosting multiple app flavors. [#390]
 - Add the ability to provide a custom message for builds triggered via `buildkite_trigger_build` action [#392]
+- Add optional `release_notes_file_path` to `ios_update_release_notes` and `android_update_release_notes` [#396]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -8,7 +8,7 @@ module Fastlane
         require_relative '../../helper/release_notes_helper'
         require_relative '../../helper/git_helper'
 
-        path = File.join(ENV['PROJECT_ROOT_FOLDER'] || '.', 'RELEASE-NOTES.txt')
+        path = params[:release_notes_file_path]
         next_version = Fastlane::Helper::Android::VersionHelper.calc_next_release_short_version(params[:new_version])
 
         Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
@@ -35,6 +35,11 @@ module Fastlane
                                        env_name: 'FL_ANDROID_UPDATE_RELEASE_NOTES_VERSION',
                                        description: 'The version we are currently freezing; An empty entry for the _next_ version after this one will be added to the release notes',
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :release_notes_file_path,
+                                       env_name: 'FL_ANDROID_UPDATE_RELEASE_NOTES_FILE_PATH',
+                                       description: 'The path to the release notes file to be updated',
+                                       is_string: true,
+                                       default_value: File.join(ENV['PROJECT_ROOT_FOLDER'] || '.', 'RELEASE-NOTES.txt')),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -8,7 +8,7 @@ module Fastlane
         require_relative '../../helper/release_notes_helper'
         require_relative '../../helper/git_helper'
 
-        path = File.join(ENV['PROJECT_ROOT_FOLDER'] || '.', 'RELEASE-NOTES.txt')
+        path = params[:release_notes_file_path]
         next_version = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(params[:new_version])
 
         Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
@@ -35,6 +35,11 @@ module Fastlane
                                        env_name: 'FL_IOS_UPDATE_RELEASE_NOTES_VERSION',
                                        description: 'The version we are currently freezing; An empty entry for the _next_ version after this one will be added to the release notes',
                                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :release_notes_file_path,
+                                       env_name: 'FL_IOS_UPDATE_RELEASE_NOTES_FILE_PATH',
+                                       description: 'The path to the release notes file to be updated',
+                                       is_string: true,
+                                       default_value: File.join(ENV['PROJECT_ROOT_FOLDER'] || '.', 'RELEASE-NOTES.txt')),
         ]
       end
 

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
   let(:release_notes_txt) { File.join(File.dirname(__FILE__), 'RELEASE-NOTES.txt') }
+  let(:changelog_md) { File.join(File.dirname(__FILE__), 'CHANGELOG.md') }
 
   after do
-    FileUtils.remove_entry release_notes_txt
+    FileUtils.rm([release_notes_txt, changelog_md], force: true)
   end
 
   describe '#android_update_release_notes' do
@@ -21,6 +22,21 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
 
       # Assert
       expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+    end
+
+    it 'adds a new section on the given file' do
+      # Arrange
+      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
+      File.write(changelog_md, '')
+
+      # Act
+      run_described_fastlane_action(
+        new_version: '1.0',
+        release_notes_file_path: changelog_md
+      )
+
+      # Assert
+      expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
     end
   end
 end

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
+  let(:release_notes_txt) { File.join(File.dirname(__FILE__), 'RELEASE-NOTES.txt') }
+
+  after do
+    FileUtils.remove_entry release_notes_txt
+  end
+
+  describe '#android_update_release_notes' do
+    it 'adds a new section on RELEASE-NOTES.txt' do
+      # Arrange
+
+      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
+      File.write(release_notes_txt, '')
+
+      # Act
+      run_described_fastlane_action(
+        new_version: '1.0'
+      )
+
+      # Assert
+      expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+    end
+  end
+end

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
+  after do
+    ENV['PROJECT_ROOT_FOLDER'] = nil
+  end
+
   describe '#android_update_release_notes' do
     it 'adds a new section on RELEASE-NOTES.txt' do
       in_tmp_dir do |tmp_dir|

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -5,13 +5,37 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
     ENV['PROJECT_ROOT_FOLDER'] = nil
   end
 
+  let(:new_section) do
+    <<~CONTENT
+      1.1
+      -----
+
+
+    CONTENT
+  end
+  let(:content) do
+    <<~CONTENT
+      1.0
+      -----
+      - Item 1 for v1.0
+      - Item 2 for v1.0
+
+      // Comment in the middle
+
+      0.9.0
+      -----
+      - Item 1 for v0.9.0
+      - Item 2 for v0.9.0
+    CONTENT
+  end
+
   describe '#android_update_release_notes' do
     it 'adds a new section on RELEASE-NOTES.txt' do
       in_tmp_dir do |tmp_dir|
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
-        File.write(release_notes_txt, ANDROID_FAKE_CONTENT)
+        File.write(release_notes_txt, content)
 
         # Act
         run_described_fastlane_action(
@@ -19,7 +43,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(release_notes_txt)).to eq(ANDROID_NEW_SECTION + ANDROID_FAKE_CONTENT)
+        expect(File.read(release_notes_txt)).to eq(new_section + content)
       end
     end
 
@@ -28,7 +52,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
-        File.write(changelog_md, ANDROID_FAKE_CONTENT)
+        File.write(changelog_md, content)
 
         # Act
         run_described_fastlane_action(
@@ -37,29 +61,8 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(changelog_md)).to eq(ANDROID_NEW_SECTION + ANDROID_FAKE_CONTENT)
+        expect(File.read(changelog_md)).to eq(new_section + content)
       end
     end
   end
 end
-
-ANDROID_FAKE_CONTENT = <<~CONTENT.freeze
-  1.0
-  -----
-  - Item 1 for v1.0
-  - Item 2 for v1.0
-
-  // Comment in the middle
-
-  0.9.0
-  -----
-  - Item 1 for v0.9.0
-  - Item 2 for v0.9.0
-CONTENT
-
-ANDROID_NEW_SECTION = <<~CONTENT.freeze
-  1.1
-  -----
-
-
-CONTENT

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
-        File.write(release_notes_txt, '')
+        File.write(release_notes_txt, FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -15,7 +15,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+        expect(File.read(release_notes_txt)).to eq(NEW_SECTION + FAKE_CONTENT)
       end
     end
 
@@ -24,7 +24,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
-        File.write(changelog_md, '')
+        File.write(changelog_md, FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -33,8 +33,29 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
+        expect(File.read(changelog_md)).to eq(NEW_SECTION + FAKE_CONTENT)
       end
     end
   end
+
+  FAKE_CONTENT = <<~CONTENT
+    1.0
+    -----
+    - Item 1 for v1.0
+    - Item 2 for v1.0
+
+    // Comment in the middle
+
+    0.9.0
+    -----
+    - Item 1 for v0.9.0
+    - Item 2 for v0.9.0
+  CONTENT
+
+  NEW_SECTION = <<~CONTENT
+    1.1
+    -----
+
+
+  CONTENT
 end

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
-        File.write(release_notes_txt, FAKE_CONTENT)
+        File.write(release_notes_txt, ANDROID_FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -15,7 +15,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(release_notes_txt)).to eq(NEW_SECTION + FAKE_CONTENT)
+        expect(File.read(release_notes_txt)).to eq(ANDROID_NEW_SECTION + ANDROID_FAKE_CONTENT)
       end
     end
 
@@ -24,7 +24,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
-        File.write(changelog_md, FAKE_CONTENT)
+        File.write(changelog_md, ANDROID_FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -33,13 +33,13 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(changelog_md)).to eq(NEW_SECTION + FAKE_CONTENT)
+        expect(File.read(changelog_md)).to eq(ANDROID_NEW_SECTION + ANDROID_FAKE_CONTENT)
       end
     end
   end
 end
 
-FAKE_CONTENT = <<~CONTENT.freeze
+ANDROID_FAKE_CONTENT = <<~CONTENT.freeze
   1.0
   -----
   - Item 1 for v1.0
@@ -53,7 +53,7 @@ FAKE_CONTENT = <<~CONTENT.freeze
   - Item 2 for v0.9.0
 CONTENT
 
-NEW_SECTION = <<~CONTENT.freeze
+ANDROID_NEW_SECTION = <<~CONTENT.freeze
   1.1
   -----
 

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -1,42 +1,40 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
-  let(:release_notes_txt) { File.join(File.dirname(__FILE__), 'RELEASE-NOTES.txt') }
-  let(:changelog_md) { File.join(File.dirname(__FILE__), 'CHANGELOG.md') }
-
-  after do
-    FileUtils.rm([release_notes_txt, changelog_md], force: true)
-  end
-
   describe '#android_update_release_notes' do
     it 'adds a new section on RELEASE-NOTES.txt' do
-      # Arrange
+      in_tmp_dir do |tmp_dir|
+        # Arrange
+        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
+        release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
+        File.write(release_notes_txt, '')
 
-      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
-      File.write(release_notes_txt, '')
+        # Act
+        run_described_fastlane_action(
+          new_version: '1.0'
+        )
 
-      # Act
-      run_described_fastlane_action(
-        new_version: '1.0'
-      )
-
-      # Assert
-      expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+        # Assert
+        expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+      end
     end
 
     it 'adds a new section on the given file' do
-      # Arrange
-      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
-      File.write(changelog_md, '')
+      in_tmp_dir do |tmp_dir|
+        # Arrange
+        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
+        changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
+        File.write(changelog_md, '')
 
-      # Act
-      run_described_fastlane_action(
-        new_version: '1.0',
-        release_notes_file_path: changelog_md
-      )
+        # Act
+        run_described_fastlane_action(
+          new_version: '1.0',
+          release_notes_file_path: changelog_md
+        )
 
-      # Assert
-      expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
+        # Assert
+        expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
+      end
     end
   end
 end

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
-  after do
-    ENV['PROJECT_ROOT_FOLDER'] = nil
-  end
-
   let(:new_section) do
     <<~CONTENT
       1.1
@@ -34,7 +30,6 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
     it 'adds a new section on RELEASE-NOTES.txt' do
       in_tmp_dir do |tmp_dir|
         # Arrange
-        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
         File.write(release_notes_txt, content)
 
@@ -51,7 +46,6 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
     it 'adds a new section on the given file' do
       in_tmp_dir do |tmp_dir|
         # Arrange
-        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
         File.write(changelog_md, content)
 

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -13,6 +13,7 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
 
     CONTENT
   end
+
   let(:content) do
     <<~CONTENT
       1.0

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -37,25 +37,25 @@ describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do
       end
     end
   end
-
-  FAKE_CONTENT = <<~CONTENT
-    1.0
-    -----
-    - Item 1 for v1.0
-    - Item 2 for v1.0
-
-    // Comment in the middle
-
-    0.9.0
-    -----
-    - Item 1 for v0.9.0
-    - Item 2 for v0.9.0
-  CONTENT
-
-  NEW_SECTION = <<~CONTENT
-    1.1
-    -----
-
-
-  CONTENT
 end
+
+FAKE_CONTENT = <<~CONTENT.freeze
+  1.0
+  -----
+  - Item 1 for v1.0
+  - Item 2 for v1.0
+
+  // Comment in the middle
+
+  0.9.0
+  -----
+  - Item 1 for v0.9.0
+  - Item 2 for v0.9.0
+CONTENT
+
+NEW_SECTION = <<~CONTENT.freeze
+  1.1
+  -----
+
+
+CONTENT

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
-        File.write(release_notes_txt, '')
+        File.write(release_notes_txt, FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -15,7 +15,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+        expect(File.read(release_notes_txt)).to eq(NEW_SECTION + FAKE_CONTENT)
       end
     end
 
@@ -24,7 +24,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
-        File.write(changelog_md, '')
+        File.write(changelog_md, FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -33,8 +33,29 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
+        expect(File.read(changelog_md)).to eq(NEW_SECTION + FAKE_CONTENT)
       end
     end
   end
+
+  FAKE_CONTENT = <<~CONTENT
+    1.0
+    -----
+    - Item 1 for v1.0
+    - Item 2 for v1.0
+
+    // Comment in the middle
+
+    0.9.0
+    -----
+    - Item 1 for v0.9.0
+    - Item 2 for v0.9.0
+  CONTENT
+
+  NEW_SECTION = <<~CONTENT
+    1.1
+    -----
+
+
+  CONTENT
 end

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe Fastlane::Actions::IosUpdateReleaseNotesAction do
   let(:release_notes_txt) { File.join(File.dirname(__FILE__), 'RELEASE-NOTES.txt') }
+  let(:changelog_md) { File.join(File.dirname(__FILE__), 'CHANGELOG.md') }
 
   after do
-    FileUtils.remove_entry release_notes_txt
+    FileUtils.rm([release_notes_txt, changelog_md], force: true)
   end
 
   describe '#ios_update_release_notes' do
     it 'adds a new section on RELEASE-NOTES.txt' do
       # Arrange
-
       ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
       File.write(release_notes_txt, '')
 
@@ -21,6 +21,21 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
 
       # Assert
       expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+    end
+
+    it 'adds a new section on the given file' do
+      # Arrange
+      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
+      File.write(changelog_md, '')
+
+      # Act
+      run_described_fastlane_action(
+        new_version: '1.0',
+        release_notes_file_path: changelog_md
+      )
+
+      # Assert
+      expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
     end
   end
 end

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IosUpdateReleaseNotesAction do
+  let(:release_notes_txt) { File.join(File.dirname(__FILE__), 'RELEASE-NOTES.txt') }
+
+  after do
+    FileUtils.remove_entry release_notes_txt
+  end
+
+  describe '#ios_update_release_notes' do
+    it 'adds a new section on RELEASE-NOTES.txt' do
+      # Arrange
+
+      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
+      File.write(release_notes_txt, '')
+
+      # Act
+      run_described_fastlane_action(
+        new_version: '1.0'
+      )
+
+      # Assert
+      expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+    end
+  end
+end

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -1,41 +1,40 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::IosUpdateReleaseNotesAction do
-  let(:release_notes_txt) { File.join(File.dirname(__FILE__), 'RELEASE-NOTES.txt') }
-  let(:changelog_md) { File.join(File.dirname(__FILE__), 'CHANGELOG.md') }
-
-  after do
-    FileUtils.rm([release_notes_txt, changelog_md], force: true)
-  end
-
   describe '#ios_update_release_notes' do
     it 'adds a new section on RELEASE-NOTES.txt' do
-      # Arrange
-      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
-      File.write(release_notes_txt, '')
+      in_tmp_dir do |tmp_dir|
+        # Arrange
+        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
+        release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
+        File.write(release_notes_txt, '')
 
-      # Act
-      run_described_fastlane_action(
-        new_version: '1.0'
-      )
+        # Act
+        run_described_fastlane_action(
+          new_version: '1.0'
+        )
 
-      # Assert
-      expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+        # Assert
+        expect(File.read(release_notes_txt)).to eq("1.1\n-----\n\n\n")
+      end
     end
 
     it 'adds a new section on the given file' do
-      # Arrange
-      ENV['PROJECT_ROOT_FOLDER'] = File.dirname(__FILE__)
-      File.write(changelog_md, '')
+      in_tmp_dir do |tmp_dir|
+        # Arrange
+        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
+        changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
+        File.write(changelog_md, '')
 
-      # Act
-      run_described_fastlane_action(
-        new_version: '1.0',
-        release_notes_file_path: changelog_md
-      )
+        # Act
+        run_described_fastlane_action(
+          new_version: '1.0',
+          release_notes_file_path: changelog_md
+        )
 
-      # Assert
-      expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
+        # Assert
+        expect(File.read(changelog_md)).to eq("1.1\n-----\n\n\n")
+      end
     end
   end
 end

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -37,25 +37,25 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
       end
     end
   end
-
-  FAKE_CONTENT = <<~CONTENT
-    1.0
-    -----
-    - Item 1 for v1.0
-    - Item 2 for v1.0
-
-    // Comment in the middle
-
-    0.9.0
-    -----
-    - Item 1 for v0.9.0
-    - Item 2 for v0.9.0
-  CONTENT
-
-  NEW_SECTION = <<~CONTENT
-    1.1
-    -----
-
-
-  CONTENT
 end
+
+FAKE_CONTENT = <<~CONTENT.freeze
+  1.0
+  -----
+  - Item 1 for v1.0
+  - Item 2 for v1.0
+
+  // Comment in the middle
+
+  0.9.0
+  -----
+  - Item 1 for v0.9.0
+  - Item 2 for v0.9.0
+CONTENT
+
+NEW_SECTION = <<~CONTENT.freeze
+  1.1
+  -----
+
+
+CONTENT

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::IosUpdateReleaseNotesAction do
-  after do
-    ENV['PROJECT_ROOT_FOLDER'] = nil
-  end
-
   let(:new_section) do
     <<~CONTENT
       1.1
@@ -34,7 +30,6 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
     it 'adds a new section on RELEASE-NOTES.txt' do
       in_tmp_dir do |tmp_dir|
         # Arrange
-        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
         File.write(release_notes_txt, content)
 
@@ -51,7 +46,6 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
     it 'adds a new section on the given file' do
       in_tmp_dir do |tmp_dir|
         # Arrange
-        ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
         File.write(changelog_md, content)
 

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::IosUpdateReleaseNotesAction do
+  after do
+    ENV['PROJECT_ROOT_FOLDER'] = nil
+  end
+
   describe '#ios_update_release_notes' do
     it 'adds a new section on RELEASE-NOTES.txt' do
       in_tmp_dir do |tmp_dir|

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -13,6 +13,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
 
     CONTENT
   end
+
   let(:content) do
     <<~CONTENT
       1.0

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -5,13 +5,37 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
     ENV['PROJECT_ROOT_FOLDER'] = nil
   end
 
+  let(:new_section) do
+    <<~CONTENT
+      1.1
+      -----
+
+
+    CONTENT
+  end
+  let(:content) do
+    <<~CONTENT
+      1.0
+      -----
+      - Item 1 for v1.0
+      - Item 2 for v1.0
+
+      // Comment in the middle
+
+      0.9.0
+      -----
+      - Item 1 for v0.9.0
+      - Item 2 for v0.9.0
+    CONTENT
+  end
+
   describe '#ios_update_release_notes' do
     it 'adds a new section on RELEASE-NOTES.txt' do
       in_tmp_dir do |tmp_dir|
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
-        File.write(release_notes_txt, IOS_FAKE_CONTENT)
+        File.write(release_notes_txt, content)
 
         # Act
         run_described_fastlane_action(
@@ -19,7 +43,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(release_notes_txt)).to eq(IOS_NEW_SECTION + IOS_FAKE_CONTENT)
+        expect(File.read(release_notes_txt)).to eq(new_section + content)
       end
     end
 
@@ -28,7 +52,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
-        File.write(changelog_md, IOS_FAKE_CONTENT)
+        File.write(changelog_md, content)
 
         # Act
         run_described_fastlane_action(
@@ -37,29 +61,8 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(changelog_md)).to eq(IOS_NEW_SECTION + IOS_FAKE_CONTENT)
+        expect(File.read(changelog_md)).to eq(new_section + content)
       end
     end
   end
 end
-
-IOS_FAKE_CONTENT = <<~CONTENT.freeze
-  1.0
-  -----
-  - Item 1 for v1.0
-  - Item 2 for v1.0
-
-  // Comment in the middle
-
-  0.9.0
-  -----
-  - Item 1 for v0.9.0
-  - Item 2 for v0.9.0
-CONTENT
-
-IOS_NEW_SECTION = <<~CONTENT.freeze
-  1.1
-  -----
-
-
-CONTENT

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         release_notes_txt = File.join(tmp_dir, 'RELEASE-NOTES.txt')
-        File.write(release_notes_txt, FAKE_CONTENT)
+        File.write(release_notes_txt, IOS_FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -15,7 +15,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(release_notes_txt)).to eq(NEW_SECTION + FAKE_CONTENT)
+        expect(File.read(release_notes_txt)).to eq(IOS_NEW_SECTION + IOS_FAKE_CONTENT)
       end
     end
 
@@ -24,7 +24,7 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         # Arrange
         ENV['PROJECT_ROOT_FOLDER'] = tmp_dir
         changelog_md = File.join(tmp_dir, 'CHANGELOG.md')
-        File.write(changelog_md, FAKE_CONTENT)
+        File.write(changelog_md, IOS_FAKE_CONTENT)
 
         # Act
         run_described_fastlane_action(
@@ -33,13 +33,13 @@ describe Fastlane::Actions::IosUpdateReleaseNotesAction do
         )
 
         # Assert
-        expect(File.read(changelog_md)).to eq(NEW_SECTION + FAKE_CONTENT)
+        expect(File.read(changelog_md)).to eq(IOS_NEW_SECTION + IOS_FAKE_CONTENT)
       end
     end
   end
 end
 
-FAKE_CONTENT = <<~CONTENT.freeze
+IOS_FAKE_CONTENT = <<~CONTENT.freeze
   1.0
   -----
   - Item 1 for v1.0
@@ -53,7 +53,7 @@ FAKE_CONTENT = <<~CONTENT.freeze
   - Item 2 for v0.9.0
 CONTENT
 
-NEW_SECTION = <<~CONTENT.freeze
+IOS_NEW_SECTION = <<~CONTENT.freeze
   1.1
   -----
 


### PR DESCRIPTION
Fixes #395 

This PR changes the fastlane actions `ios_update_release_notes` and `android_update_release_notes` to accept an optional `release_notes_file_path`. This way our projects are not forced to use `RELEASE-NOTES.txt`.

If a file path is not given, it will use `RELEASE-NOTES.txt` as it was before, not affecting any of the current projects that use it.

### To test

1. Run the tests added for this PR
2. Code review!