### PR TITLE
Support custom milestone duration

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -12,11 +12,12 @@ module Fastlane
         last_stone = Fastlane::Helper::GithubHelper.get_last_milestone(repository)
         UI.message("Last detected milestone: #{last_stone[:title]} due on #{last_stone[:due_on]}.")
         milestone_duedate = last_stone[:due_on]
-        newmilestone_duration = params[:milestone_duration]
-        newmilestone_duedate = (milestone_duedate.to_datetime.next_day(newmilestone_duration).to_time).utc
+        milestone_duration = params[:milestone_duration]
+        newmilestone_duedate = (milestone_duedate.to_datetime.next_day(milestone_duration).to_time).utc
         newmilestone_number = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(last_stone[:title])
+        number_of_days_from_code_freeze_to_release = params[:number_of_days_from_code_freeze_to_release]
         UI.message("Next milestone: #{newmilestone_number} due on #{newmilestone_duedate}.")
-        Fastlane::Helper::GithubHelper.create_milestone(repository, newmilestone_number, newmilestone_duedate, newmilestone_duration, params[:need_appstore_submission])
+        Fastlane::Helper::GithubHelper.create_milestone(repository, newmilestone_number, newmilestone_duedate, milestone_duration, number_of_days_from_code_freeze_to_release, params[:need_appstore_submission])
       end
 
       def self.description
@@ -52,6 +53,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :milestone_duration,
                                        env_name: 'GHHELPER_MILESTONE_DURATION',
                                        description: 'Milestone duration in number of days',
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: 14),
+          FastlaneCore::ConfigItem.new(key: :number_of_days_from_code_freeze_to_release,
+                                       env_name: 'GHHELPER_NUMBER_OF_DAYS_FROM_CODE_FREEZE_TO_RELEASE',
+                                       description: 'Number of days from code freeze to release',
                                        optional: true,
                                        is_string: false,
                                        default_value: 14),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -12,10 +12,11 @@ module Fastlane
         last_stone = Fastlane::Helper::GithubHelper.get_last_milestone(repository)
         UI.message("Last detected milestone: #{last_stone[:title]} due on #{last_stone[:due_on]}.")
         milestone_duedate = last_stone[:due_on]
-        newmilestone_duedate = (milestone_duedate.to_datetime.next_day(14).to_time).utc
+        newmilestone_duration = params[:milestone_duration]
+        newmilestone_duedate = (milestone_duedate.to_datetime.next_day(newmilestone_duration).to_time).utc
         newmilestone_number = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(last_stone[:title])
         UI.message("Next milestone: #{newmilestone_number} due on #{newmilestone_duedate}.")
-        Fastlane::Helper::GithubHelper.create_milestone(repository, newmilestone_number, newmilestone_duedate, params[:need_appstore_submission])
+        Fastlane::Helper::GithubHelper.create_milestone(repository, newmilestone_number, newmilestone_duedate, newmilestone_duration, params[:need_appstore_submission])
       end
 
       def self.description
@@ -48,6 +49,12 @@ module Fastlane
                                        optional: true,
                                        is_string: false,
                                        default_value: false),
+          FastlaneCore::ConfigItem.new(key: :milestone_duration,
+                                       env_name: 'GHHELPER_MILESTONE_DURATION',
+                                       description: 'Milestone duration in number of days',
+                                       optional: true,
+                                       is_string: false,
+                                       default_value: 14),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -80,9 +80,13 @@ module Fastlane
         last_stone
       end
 
-      def self.create_milestone(repository, newmilestone_number, newmilestone_duedate, need_submission)
-        submission_date = need_submission ? newmilestone_duedate.to_datetime.next_day(11) : newmilestone_duedate.to_datetime.next_day(14)
-        release_date = newmilestone_duedate.to_datetime.next_day(14)
+      def self.create_milestone(repository, newmilestone_number, newmilestone_duedate, newmilestone_duration, need_submission)
+        # If there is a review process, we want to submit the binary 3 days before its release
+        #
+        # Using 3 days is mostly for historical reasons where we release the apps on Monday and submit them on Friday.
+        days_until_submission = need_submission ? (newmilestone_duration - 3) : newmilestone_duration
+        submission_date = newmilestone_duedate.to_datetime.next_day(days_until_submission)
+        release_date = newmilestone_duedate.to_datetime.next_day(newmilestone_duration)
         comment = "Code freeze: #{newmilestone_duedate.to_datetime.strftime('%B %d, %Y')} App Store submission: #{submission_date.strftime('%B %d, %Y')} Release: #{release_date.strftime('%B %d, %Y')}"
 
         options = {}

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -80,13 +80,13 @@ module Fastlane
         last_stone
       end
 
-      def self.create_milestone(repository, newmilestone_number, newmilestone_duedate, newmilestone_duration, need_submission)
+      def self.create_milestone(repository, newmilestone_number, newmilestone_duedate, newmilestone_duration, number_of_days_from_code_freeze_to_release, need_submission)
         # If there is a review process, we want to submit the binary 3 days before its release
         #
         # Using 3 days is mostly for historical reasons where we release the apps on Monday and submit them on Friday.
-        days_until_submission = need_submission ? (newmilestone_duration - 3) : newmilestone_duration
+        days_until_submission = need_submission ? (number_of_days_from_code_freeze_to_release - 3) : newmilestone_duration
         submission_date = newmilestone_duedate.to_datetime.next_day(days_until_submission)
-        release_date = newmilestone_duedate.to_datetime.next_day(newmilestone_duration)
+        release_date = newmilestone_duedate.to_datetime.next_day(number_of_days_from_code_freeze_to_release)
         comment = "Code freeze: #{newmilestone_duedate.to_datetime.strftime('%B %d, %Y')} App Store submission: #{submission_date.strftime('%B %d, %Y')} Release: #{release_date.strftime('%B %d, %Y')}"
 
         options = {}


### PR DESCRIPTION
For Woo apps we are experimenting with weekly releases where we code freeze on Fridays and release on Mondays. This PR updates the `create_new_milestone` action and its helper to support a custom `milestone_duration` and `number_of_days_from_code_freeze_to_release`.

If I worked on this feature from scratch, I'd not implement it this way, but I wanted to avoid a breaking change so the changes are mostly replacing the hardcoded values with optional parameter values.

Unfortunately this action and its helper didn't have any unit tests and I don't currently have the bandwidth to implement them.

**To test**

Follow the testing instructions from https://github.com/woocommerce/woocommerce-android/pull/7173 or https://github.com/woocommerce/woocommerce-ios/pull/7458.