### PR TITLE
Move changelog for PR #396 under 5.3.0 New Features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _None_
 
 ### New Features
 
+- Add optional `release_notes_file_path` to `ios_update_release_notes` and `android_update_release_notes` [#396]
 - Adds support for custom milestone duration [#397]
 
 ## 5.2.0
@@ -32,7 +33,6 @@ _None_
 
 - Add `tools:ignore="InconsistentArrays"` to `available_languages.xml` to avoid a linter warning on repos hosting multiple app flavors. [#390]
 - Add the ability to provide a custom message for builds triggered via `buildkite_trigger_build` action [#392]
-- Add optional `release_notes_file_path` to `ios_update_release_notes` and `android_update_release_notes` [#396]
 
 ### Bug Fixes
 


### PR DESCRIPTION
Moves the [changelog entry](https://github.com/wordpress-mobile/release-toolkit/pull/396/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR29) for #396 from `5.2.0` to `5.3.0`.