### PR TITLE
Update `extract_release_notes_for_version_action` details

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -58,7 +58,7 @@ module Fastlane
 
       def self.details
         # Optional:
-        'Creates a release and uploads the provided assets'
+        'Given a file containing release notes and a version, extracts the notes for that version into a dedicated file.'
       end
 
       def self.available_options


### PR DESCRIPTION
While testing 149-gh-Automattic/pocket-casts-ios, I noticed the `details` for this action were incorrect.