### PR TITLE
Support Bulk Download from GlotPress

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_strings_file_writer.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_strings_file_writer.rb
@@ -1,0 +1,29 @@
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+
+module Fastlane
+  module Helper
+    module Android
+      module StringsFileWriter
+        # @param [String] dir path to destination directory
+        # @param [Locale] locale the locale to write the file for
+        # @param [File, IO] io The File IO containing the translations downloaded from GlotPress
+        def self.write_app_translations_file(dir:, locale:, io:)
+          # `dir` is typically `src/main/res/` here
+          return unless Locale.valid?(locale, :android)
+
+          dest = File.join(dir, locale.android_path)
+          FileUtils.mkdir_p(File.dirname(dest))
+
+          # TODO: reorder XML nodes alphabetically, for easier diffs
+          #   xml = Nokogiri::XML(io, nil, Encoding::UTF_8.to_s)
+          #   # … reorder nodes …
+          #   File.open(main, 'w:UTF-8') { |f| f.write(xml.to_xml(indent: 4)) }
+          # FIXME: For now, just copy blindly until we get time to implement node reordering
+          UI.message("Writing: #{dest}")
+          IO.copy_stream(io, dest)
+        end
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/fastlane_metadata_file_writer.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/fastlane_metadata_file_writer.rb
@@ -1,0 +1,48 @@
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+
+module Fastlane
+  module Helper
+    module MetadataFilesWriter
+
+      # @note If the translation for `key` exceeds the specified `max_len`, we will try to find an alternate key named `#{key}_short` by convention.
+      MetadataRule = Struct.new(:key, :max_len, :filename) do
+        def self.android_rules(version_name:, version_code:)
+          suffix = version_name.gsub('.', '')
+          [
+            MetadataRule.new("release_note_#{suffix}", 500, File.join('changelogs', "#{version_code}.txt")),
+            MetadataRule.new('play_store_app_title', 30, 'title.txt'),
+            MetadataRule.new('play_store_promo', 80, 'short_description.txt'),
+            MetadataRule.new('play_store_desc', 4000, 'full_description.txt'),
+          ]
+        end
+
+        def self.ios_rules(version_name:)
+          suffix = version_name.gsub('.', '')
+          [
+            MetadataRule.new("release_note_#{suffix}", 4000, 'release_notes.txt'),
+            MetadataRule.new('app_store_name', 30, 'name.txt'),
+            MetadataRule.new('app_store_subtitle', 30, 'subtitle.txt'),
+            MetadataRule.new('app_store_description', 4000, 'description.txt'),
+            MetadataRule.new('app_store_keywords', 100, 'keywords.txt'),
+          ]
+        end
+      end
+
+      def self.write(locale_dir:, io:, rules:, &rule_for_unknown_key)
+        self.process_json(io: io, rules: rules, rule_for_unknown_key: rule_for_unknown_key) do |_key, rule, value|
+          dest = File.join(locale_dir, rule.filename)
+          if value.nil? && File.exist?(dest)
+            # Key found in JSON was rejected for being too long. Delete file
+            UI.verbose("Deleting file #{dest}")
+            FileUtils.rm(dest)
+          elsif value
+            UI.verbose("Writing file #{dest}")
+            FileUtils.mkdir_p(File.dirname(dest))
+            File.write(dest, value.chomp)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/fastlane_metadata_file_writer.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/fastlane_metadata_file_writer.rb
@@ -3,10 +3,17 @@ require 'fileutils'
 
 module Fastlane
   module Helper
-    module MetadataFilesWriter
+    module FastlaneMetadataFilesWriter
 
-      # @note If the translation for `key` exceeds the specified `max_len`, we will try to find an alternate key named `#{key}_short` by convention.
+      # A model/struct defining a rule on how to process and map metadata from GlotPress into txt files
+      #
+      # @param [String] key The key in the GlotPress export for the metadata
+      # @param [Int] max_len The maximum length allowed by the App Store / Play Store for that key.
+      #        Note: If the translation for `key` exceeds the specified `max_len`, we will try to find an alternate key named `#{key}_short` by convention.
+      # @param [String] filename The (relative) path to the `.txt` file to write that metadata to
+      #
       MetadataRule = Struct.new(:key, :max_len, :filename) do
+        # The common standardized set of Metadata rules for an Android project
         def self.android_rules(version_name:, version_code:)
           suffix = version_name.gsub('.', '')
           [
@@ -17,6 +24,7 @@ module Fastlane
           ]
         end
 
+        # The common standardized set of Metadata rules for an Android project
         def self.ios_rules(version_name:)
           suffix = version_name.gsub('.', '')
           [
@@ -29,8 +37,54 @@ module Fastlane
         end
       end
 
-      def self.write(locale_dir:, io:, rules:, &rule_for_unknown_key)
-        self.process_json(io: io, rules: rules, rule_for_unknown_key: rule_for_unknown_key) do |_key, rule, value|
+      # Visit each key/value pair of a translations Hash, and yield keys and matching translations from it based on the passed `MetadataRules`,
+      # trying any potential fallback key if the translation exceeds the max limit, and yielding each found and valid entry to the caller.
+      #
+      # @param [#read] io
+      # @param [Array<MetadataRule>] rules List of rules for each key
+      # @param [Block] rule_for_unknown_key An optional block called when a key that does not match any of the rules is encountered.
+      #        The block will receive a [String] (key) and must return a `MetadataRule` instance (or nil)
+      #
+      # @yield [String, MetadataRule, String] yield each (key, matching_rule, value) tuple found in the JSON, after resolving alternates for values exceeding max length
+      #        Note that if both translations for the key and its (optional) shorter alternate exceeds the max_len, it will still `yield` but with a `nil` value
+      #
+      def self.visit(translations:, rules:, rule_for_unknown_key:)
+        translations.each do |key, value|
+          next if key.nil? || key.end_with?('_short') # skip if alternate key
+
+          rule = rules.find { |r| r.key == key }
+          rule = rule_for_unknown_key.call(key) if rule.nil? && !rule_for_unknown_key.nil?
+          next if rule.nil?
+
+          if rule.max_len != nil && value.length > rule.max_len
+            UI.warning "Translation for #{key} is too long (#{value.length}), trying shorter alternate #{key}."
+            short_key = "#{key}_short"
+            value = json[short_key]
+            if value.nil?
+              UI.warning "No shorter alternate (#{short_key}) available, skipping entirely."
+              yield key, rule, nil
+              next
+            end
+            if value.length > rule.max_len
+              UI.warning "Translation alternate for #{short_key} was too long too (#{value.length}), skipping entirely."
+              yield short_key, rule, nil
+              next
+            end
+          end
+          yield key, rule, value
+        end
+      end
+
+      # Write the `.txt` files to disk for the given exported translation file (typically a JSON export) based on the `MetadataRules` provided
+      #
+      # @param [String] locale_dir the path to the locale directory (e.g. `fastlane/metadata/android/fr`) to write the `.txt` files to
+      # @param [Hash<String,String>] translations The hash of translations (key => translation) to visit based on `MetadataRules` then write to disk.
+      # @param [Array<MetadaataRule>] rules The list of fixed `MetadataRule` to use to extract the expected metadata from the `translations`
+      # @param [Block] rule_for_unknown_key An optional block called when a key that does not match any of the rules is encountered.
+      #        The block will receive a [String] (key) and must return a `MetadataRule` instance (or nil)
+      #
+      def self.write(locale_dir:, translations:, rules:, &rule_for_unknown_key)
+        self.visit(translations: translations, rules: rules, rule_for_unknown_key: rule_for_unknown_key) do |_key, rule, value|
           dest = File.join(locale_dir, rule.filename)
           if value.nil? && File.exist?(dest)
             # Key found in JSON was rejected for being too long. Delete file

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_downloader.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_downloader.rb
@@ -1,0 +1,116 @@
+require 'fastlane_core/ui/ui'
+require 'json'
+require 'open-uri'
+require 'zip'
+
+module Fastlane
+  module Helper
+    class GPDownloader
+      REQUEST_HEADERS = { 'User-Agent' => Wpmreleasetoolkit::USER_AGENT }
+
+      module FORMAT
+        ANDROID = 'android'
+        IOS = 'strings'
+        JSON = 'json'
+      end
+
+      # The host of the GlotPress instance. e.g. `'translate.wordpress.org'`
+      attr_accessor :host
+      # The path of the project in GlotPress. e.g. `'apps/ios/release-notes'`
+      attr_accessor :project
+
+      def initialize(host:, project:)
+        @host = host
+        @project = project
+      end
+
+      # @param [String] gp_locale
+      # @param [String] format Typically `'android'`, `'strings'` or `'json'`
+      # @param [Hash<String,String>] filters
+      #
+      # @yield [IO] the corresponding downloaded IO content
+      #
+      # @note For this case, `project_url` is on the form 'https://translate.wordpress.org/projects/apps/ios/release-notes'
+      def download_locale(gp_locale:, format:, filters: { status: 'current'})
+        query_params = filters.transform_keys { |k| "filters[#{k}]" }.merge(format: format)
+        uri = URI::HTTPS.build(host: host, path: File.join('/', 'projects', project, gp_locale, 'default', 'export-translations'), query: URI.encode_www_form(query_params))
+
+        UI.message "Downloading #{uri}"
+        io = begin
+          uri.open(REQUEST_HEADERS)
+        rescue StandardError => e
+          UI.error "Error downloading #{gp_locale} - #{e.message}"
+          return
+        end
+        UI.message "Download done."
+        yield io
+      end
+
+      # @param [String] format Typically `'android'`, `'strings'` or `'json'`
+      # @param [Hash<String,String>] filters
+      #
+      # @yield For each locale, a tuple of [String], [IO] corresponding to the glotpress locale code and IO content
+      #
+      # @note requires the GlotPress instance to have the Bulk Downloader plugin installed
+      # @note For this case, `project_url` is on the form 'https://translate.wordpress.org/exporter/apps/android/dev/'
+      def download_all_locales(format:, filters: { status: 'current'})
+        query_params = filters.transform_keys { |k| "filters[#{k}]" }.merge('export-format': format)
+        uri = URI::HTTPS.build(host: host, path: File.join('/', 'exporter', project, '-do'), query: URI.encode_www_form(query_params))
+        UI.message "Downloading #{uri}"
+        zip_stream = uri.open(REQUEST_HEADERS)
+        UI.message "Download done."
+
+        Zip::File.open_buffer(zip_stream) do |zip_file|
+          zip_file.each do |entry|
+            next if entry.name.end_with?('/') && entry.size.zero?
+
+            prefix = File.dirname(entry.name).gsub(/[0-9-]*$/, '') + '-'
+            locale = File.basename(entry.name, File.extname(entry.name)).delete_prefix(prefix)
+            UI.message "- Found locale in ZIP: #{locale}"
+
+            yield locale, entry.get_input_stream
+          end
+        end
+      end
+
+      # Process a JSON export downloaded from GlotPress, extract keys and translations from it based on the passed `MetadataRules`, and yield each found entry to the caller
+      #
+      # @param [#read] io
+      # @param [Array<MetadataRule>] rules List of rules for each key
+      # @param [Block] rule_for_unknown_key An optional block called when a key that does not match any of the rules is encountered.
+      #        The block will receive a [String] (key) and must return a `MetadataRule` instance (or nil)
+      #
+      # @yield [String, MetadataRule, String] yield each (key,matching_rule,value) tuple found in the JSON, after resolving alternates for values exceeding max length
+      #
+      def self.process_json_export(io:, rules:, rule_for_unknown_key:)
+        json = JSON.parse(io.read)
+        json.each do |composite_key, values|
+          key = composite_key.split(/\u0004/).first # composite_key is a concatenation of key + \u0004 + source
+          next if key.nil? || key.end_with?('_short') # skip if alternate key
+          value = values.first # Each value in the JSON Hash is an Array of all the translations; but if we provided the right filter, the first one should always be the right one
+
+          rule = rules.find { |r| r.key == key }
+          rule = rule_for_unknown_key.call(key) if rule.nil? && !rule_for_unknown_key.nil?
+          next if rule.nil?
+
+          if rule.max_len != nil && value.length > rule.max_len
+            UI.warning "Translation for #{key} is too long (#{value.length}), trying shorter alternate #{key}."
+            short_key = "#{key}_short"
+            value = json[short_key]&.first
+            if value.nil?
+              UI.warning "No shorter alternate (#{short_key}) available, skipping entirely."
+              yield key, rule, nil
+              next
+            end
+            if value.length > rule.max_len
+              UI.warning "Translation alternate for #{short_key} was too long too (#{value.length}), skipping entirely."
+              yield short_key, rule, nil
+              next
+            end
+          end
+          yield key, rule, value
+        end
+      end
+    end # class
+  end # module
+end # module

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_writer.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_writer.rb
@@ -1,0 +1,24 @@
+require 'fastlane_core/ui/ui'
+require 'fileutils'
+
+module Fastlane
+  module Helper
+    module Ios
+      module StringsFileWriter
+        # @param [String] dir path to destination directory
+        # @param [Locale] locale the locale to write the file for
+        # @param [File, IO] io The File IO containing the translations downloaded from GlotPress
+        def self.write_app_translations_file(dir:, locale:, io:)
+          # `dir` is typically `WordPress/Resources/` here
+          return unless Locale.valid?(locale, :ios)
+
+          dest = File.join(dir, locale.ios_path)
+          FileUtils.mkdir_p(File.dirname(dest))
+          UI.message("Writing: #{dest}")
+          IO.copy_stream(io, dest)
+        end
+      end
+    end
+  end
+end
+

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/locale.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/locale.rb
@@ -1,0 +1,29 @@
+require 'fastlane_core/ui/ui'
+
+module Fastlane
+  module Wpmreleasetoolkit
+    Locale = Struct.new(:glotpress, :android, :playstore, :ios, :appstore, keyword_init: true) do
+      def android_path
+        File.join("values-#{self.android}", 'strings.xml')
+      end
+
+      def ios_path
+        File.join("#{self.ios}.lproj", 'Localizable.strings')
+      end
+
+      def self.valid?(locale, *keys)
+        if locale.nil?
+          UI.warning("Locale is unknown")
+          return false
+        end
+        keys.each do |key|
+          if locale[key].nil?
+            UI.warning("Locale #{locale} is missing required key #{key}")
+            return false
+          end
+        end
+        return true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/locales.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/locales.rb
@@ -1,0 +1,152 @@
+module Fastlane
+  module Wpmreleasetoolkit
+    class Locales
+      ALL_KNOWN_LOCALES = [
+        Locale.new(glotpress: 'ar',    android: 'ar',     playstore: 'ar'),
+        Locale.new(glotpress: 'de',    android: 'de',     playstore: 'de-DE'),
+        Locale.new(glotpress: 'en-gb', android: 'en-rGB', playstore: 'en-US'),
+        Locale.new(glotpress: 'es',    android: 'es',     playstore: 'es-ES'),
+        Locale.new(glotpress: 'fr-ca', android: 'fr-rCA', playstore: 'fr-CA'),
+        Locale.new(glotpress: 'fr',    android: 'fr',     playstore: 'fr-FR', ios: 'fr-FR', appstore: 'fr-FR'),
+        Locale.new(glotpress: 'he',    android: 'he',     playstore: 'iw-IL'),
+        Locale.new(glotpress: 'id',    android: 'id',     playstore: 'id'),
+        Locale.new(glotpress: 'it',    android: 'it',     playstore: 'it-IT'),
+        Locale.new(glotpress: 'ja',    android: 'ja',     playstore: 'ja-JP'),
+        Locale.new(glotpress: 'ko',    android: 'ko',     playstore: 'ko-KR'),
+        Locale.new(glotpress: 'nl',    android: 'nl',     playstore: 'nl-NL'),
+        Locale.new(glotpress: 'pl',    android: 'pl',     playstore: 'pl-PL'),
+        Locale.new(glotpress: 'pt-br', android: 'pt-rBR', playstore: 'pt-BR', ios: 'pt-BR', appstore: 'pt-BR'),
+        Locale.new(glotpress: 'ru',    android: 'ru',     playstore: 'ru-RU'),
+        Locale.new(glotpress: 'sr',    android: 'sr',     playstore: 'sr'),
+        Locale.new(glotpress: 'sv',    android: 'sv',     playstore: 'sv-SE'),
+        Locale.new(glotpress: 'th',    android: 'th',     playstore: 'th'),
+        Locale.new(glotpress: 'tr',    android: 'tr',     playstore: 'tr-TR'),
+        Locale.new(glotpress: 'vi',    android: 'vi',     playstore: 'vi'),
+        Locale.new(glotpress: 'zh-cn', android: 'zh-rCN', playstore: 'zh-CN', ios: 'zh-Hans', appstore: 'zh-Hans'),
+        Locale.new(glotpress: 'zh-tw', android: 'zh-rTW', playstore: 'zh-TW', ios: 'zh-Hant', appstore: 'zh-Hant'),
+        Locale.new(glotpress: 'az',    android: 'az'),
+        Locale.new(glotpress: 'el',    android: 'el')
+        # FIXME: Complete the list with ios/app_store properties for all, and extending to more locales
+      ]
+
+      MAG16_GP_CODES = %w[ar de es fr he id it ja ko nl pt-br ru sv tr zh-cn zh-tw].freeze
+
+      ##############
+
+      # [Array<Locale>]
+      attr_accessor :locales
+
+      # @param [Array<Locale>,Array<Hash>] locales
+      def initialize(locales = ALL_KNOWN_LOCALES)
+        @locales = locales.map { |l| l.is_a?(Locale) ? l : Locale.new(l) }
+      end
+
+      ##############
+      # @!group Filter `Locales` based on locale codes
+
+      # Return the list of locales matching the gp_codes passed as input parameters
+      #
+      # @param [String...] codes The locale codes to get the Locales for
+      # @param [Symbol] key_name The name of the `Locale` property to use to filter those locales by.
+      #        Defaults to `:glotpress` (= the `codes` param is expected to be _GlotPress_ locale codes by default)
+      # @return [Locales]
+      def self.[](*codes, key_name: :glotpress)
+        locales = ALL_KNOWN_LOCALES.select { |l| codes.include?(l[key_name.to_sym]) }
+        Locales.new(locales)
+      end
+
+      # Find a single given locale amongst the set of all known locales
+      #
+      # @param [String] code
+      # @param [Symbol] key_name The name of the `Locale` property to use to filter those locales by.
+      #        Defaults to `:glotpress` (= the `codes` param is expected to be _GlotPress_ locale codes by default)
+      # @return [Locale?] The known locale matching the provided code, or `nil` if no known locale was found.
+      def self.find(code, key_name: :glotpress)
+        Locales.all.find(code, key_name: key_name)
+      end
+
+      # Find a single given locale amongst the set of locales registered in this `Locales` instance
+      #
+      # @param [String] code
+      # @param [Symbol] key_name The name of the `Locale` property to use to filter those locales by.
+      #        Defaults to `:glotpress` (= the `codes` param is expected to be _GlotPress_ locale codes by default)
+      # @return [Locale?] The known locale matching the provided code, or `nil` if no known locale was found.
+      def find(code, key_name: :glotpress)
+        @locales.find { |l| code == l[key_name.to_sym] }
+      end
+
+      # @!endgroup
+      ##############
+
+      ##############
+      # @!group Common locale sets
+
+      def self.all
+        Locales.new(ALL_KNOWN_LOCALES)
+      end
+
+      def self.mag16
+        Locales[*MAG16_GP_CODES]
+      end
+
+      # @!endgroup
+      ##############
+
+      ##############
+      # @!group Locales set arithmetics
+
+      # Substraction
+      def -(other)
+        Locales.new(self.locales - other.locales)
+      end
+
+      # Intersection
+      def &(other)
+        Locales.new(self.locales & other.locales)
+      end
+
+      # Addition (without deduplication guarantee)
+      def +(other)
+        Locales.new(self.locales + other.locales)
+      end
+
+      # Union (with deduplication)
+      def |(other)
+        Locales.new(self.locales | other.locales)
+      end
+
+      # @!endgroup
+      ##############
+
+      ##############
+      # @!group Conversion to other types and iteration
+
+      def each
+        @locales.each { |l| yield l }
+      end
+
+      # Constructs a `Hash` whose keys are the locale code for `key_sym` (e.g. `:glotpress`) and corresponding values are the locale code for `value_sym` (e.g. `:android`)
+      # Example: `Locales.mag16.to_hash(:glotpress, :android)`
+      def to_hash(key_sym, value_sym)
+        Hash.new(
+          @locales.map { |l| [l[key_sym], l[value_sym]] }
+        )
+      end
+
+      def to_a
+        if block_given?
+          @locales.map { |l| yield l }
+        else
+          @locales
+        end
+      end
+
+      def to_s
+        "\#<Locales: [\n  #{@locales.join("\n  ")}\n]>"
+      end
+
+      # @!endgroup
+      ##############
+    end
+  end
+end

--- a/spec/glotpress_downloader_spec.rb
+++ b/spec/glotpress_downloader_spec.rb
@@ -1,0 +1,98 @@
+# NOTE: This is not really a spec but a demo script instead that I used to test my implementation.
+# FIXME: Convert this to an actual spec with unit test cases and stubs/fixtures
+
+module GlotpressDownloaderDemo
+  DOTORG = 'translate.wordpress.org'
+  DOTCOM = 'translate.wordpress.com'
+  WP_ANDROID = { host: DOTORG, project: 'apps/android/dev' }
+  WP_IOS = { host: DOTORG, project: 'apps/ios/dev' }
+  WC_ANDROID = { host: DOTCOM, project: 'woocommerce/woocommerce-android' }
+  WC_IOS = { host: DOTCOM, project: 'woocommerce/woocommerce-ios' }
+
+  EXPORT_FMT = Fastlane::Helper::GPDownloader::FORMAT
+  FastlaneMetadataFilesWriter = Fastlane::Helper::FastlaneMetadataFilesWriter
+
+  EXAMPLE_OUTPUT_DIR = 'MyTestApp'
+
+  # Example Usages for App Translation
+
+  def demo_android_app_translations_bulk
+    output_dir = File.join(EXAMPLE_OUTPUT_DIR, 'src', 'main', 'res')
+    FileUtils.mkdir_p(output_dir)
+    downloader = Fastlane::Helper::GPDownloader.new(**WC_ANDROID)
+    downloader.download_all_locales(format: EXPORT_FMT::ANDROID) do |gp_locale, io|
+      locale = Locales.all.find(gp_locale)
+      Fastlane::Helper::Android::StringsFileWriter.write(dir: output_dir, locale: locale, io: io) unless locale.nil? # skip unknown locales that may be present in ZIP
+    end
+  end
+
+  def demo_ios_app_translations_bulk
+    output_dir = File.join(EXAMPLE_OUTPUT_DIR, 'Resources')
+    FileUtils.mkdir_p(output_dir)
+    downloader = Fastlane::Helper::GPDownloader.new(**WC_IOS)
+    downloader.download_all_locales(format: EXPORT_FMT::IOS) do |gp_locale, io|
+      locale = Locales.all.find(gp_locale)
+      Fastlane::Helper::Ios::StringsFileWriter.write(dir: output_dir, locale: locale, io: io) unless locale.nil? # skip unknown locales that may be present in ZIP
+    end
+  end
+
+  def demo_ios_app_translations_loop
+    output_dir = File.join(EXAMPLE_OUTPUT_DIR, 'Resources')
+    FileUtils.mkdir_p(output_dir)
+    downloader = Fastlane::Helper::GPDownloader.new(**WC_IOS)
+    Locales.mag16.each do |locale|
+      downloader.download_locale(gp_locale: locale.glotpress, format: EXPORT_FMT::IOS) do |io|
+        Fastlane::Helper::Ios::StringsFileWriter.write(dir: output_dir, locale: locale, io: io)
+      end
+    end
+  end
+
+  # Example Usages for Metadata
+
+  def demo_android_metadata_bulk
+    downloader = Fastlane::Helper::GPDownloader.new(host: DOTORG, project: 'apps/android/release-notes')
+    downloader.download_all_locales(format: EXPORT_FMT::JSON) do |gp_locale, io|
+      locale = Locales.mag16.find(gp_locale)
+      next unless Locale.valid?(locale, :playstore)
+
+      rules = FastlaneMetadataFilesWriter::MetadataRule.android_rules(version_name: '20.4', version_code: 1234)
+      translations = downloader.class.parse_json_export(io: io) # Convert odd GlotPress JSON export format to standard Hash
+
+      locale_dir = File.join(EXAMPLE_OUTPUT_DIR, 'fastlane', 'metadata', 'android', locale.playstore)
+      FastlaneMetadataFilesWriter.write(locale_dir: locale_dir, translations: translations, rules: rules) do |key|
+        # Example: if we find a non-standard key which ends up being a screenshot key, save under screenshots/ subdir.
+        # Otherwise, just ignore any other unknown key.
+        if key.start_with?('play_store_screenshot_')
+          FastlaneMetadataFilesWriter::MetadataRule.new(key, nil, File.join('screenshots', "#{key.delete_prefix('play_store_screenshot_')}.txt"))
+        end
+      end
+    end
+  end
+
+  def demo_android_metadata_loop
+    downloader = Fastlane::Helper::GPDownloader.new(host: DOTORG, project: 'apps/android/release-notes/')
+    Locales['fr', 'es'].each do |locale|
+      next unless Locale.valid?(locale, :playstore)
+      downloader.download_locale(gp_locale: locale.glotpress, format: EXPORT_FMT::JSON) do |io|
+        locale_dir = File.join(EXAMPLE_OUTPUT_DIR, 'fastlane', 'metadata', 'android', locale.playstore)
+        rules = FastlaneMetadataFilesWriter::MetadataRule.android_rules(version_name: '20.4', version_code: 1234)
+        translations = downloader.class.parse_json_export(io: io) # Convert odd GlotPress JSON export format to standard Hash
+        puts "Writing to #{locale_dir}..."
+        FastlaneMetadataFilesWriter.write(locale_dir: locale_dir, translations: translations, rules: rules)
+      end
+    end
+  end
+
+  def demo_ios_metadata_loop
+    downloader = Fastlane::Helper::GPDownloader.new(host: DOTORG, project: 'apps/ios/release-notes/')
+    Locales.mag16.each do |locale|
+      next unless Locale.valid?(locale, :appstore)
+      downloader.download_locale(gp_locale: locale.glotpress, format: EXPORT_FMT::JSON) do |io|
+        locale_dir = File.join(EXAMPLE_OUTPUT_DIR, 'fastlane', 'metadata', locale.appstore)
+        rules = FastlaneMetadataFilesWriter::MetadataRule.ios_rules(version_name: '20.4')
+        translations = downloader.class.parse_json_export(io: io) # Convert odd GlotPress JSON export format to standard Hash
+        FastlaneMetadataFilesWriter.write(locale_dir: locale_dir, translations: translations, rules: rules)
+      end
+    end
+  end
+end


### PR DESCRIPTION
> **Warning**: This is a Work in Progress branch. I've only commited this to the remote and opened this draft PR to upload and keep a backup of my experiment while I refine the implementation, but this is still early stage of the implementation

 🚧  Next Steps / TODO

 - [ ] Fix `rubocop` violations
 - [ ] Implement robust Unit Tests for all the new classes and stages
 - [ ] Implement the fastlane actions that will use those new implementations
 - [ ] Undraft this PR

---

## Why?

With us encountering the `429 Too Many Requests` quota limitation more and more often while downloading translations from GlotPress during our release duties, I've recently asked our Team Global and Orbit (ref: pxLjZ-72D-p2) to install [the `gp-import-export` plugin](https://github.com/Automattic/gp-import-export) on our GlotPress instances (ref: 307-gh-Automattic/Orbit), so that we can bulk-download the translations for all the locales at once (as a ZIP).

This will allow us to only make a single network request to export them instead of one request per locale (which ends up being a lot of requests especially for WordPress and the 40+ locales it supports)

## How?

I've reimplemented the logic for the download of GlotPress exports into a more modern infrastructure / code architecture in our code base. I intend to deprecate `glotpress_helper` and `gp_downloadmetadata_action` once this new implementation is validated as more stable, and refactoring `android_download_translations_action` / `ios_downlaod_strings_files_from_glotpress` to use the new helpers and models (or deprecating those actions and creating new ones to replace them).

The new implementation/architecture is structured like this:

### Models to manipulate locales easily

This will supersede my #296 draft PR (which I opened… one year ago!)

 - `models/locale`: is a `Struct` which represents a single locale, exposing the various locale code representations for that locale — since there are multiple ISO standards for locale codes needed/used in various places of the codebase (ios folder names, android folder names, glotpress locale codes…)
 - `models/locales`: represents a set of `Locale` objects. That model allows to build a set of locales based on their locale codes (to have an object representing all the locales supported by a project/app, typically), build convenience sets (e.g. Mag16), easily add/remove/filter locales from sets, and find a known locale from the set of all known locales

### A class dedicated to download exports from GlotPress

The `helper/glotpress_downloader` class knows how to exports from GlotPress in `android`, `ios` or `json` formats.

 - You start by initializing an instance with a GlotPress URL host and URL project path
 - You can then call methods to download exports from that project:
    - Either for a single, given locale, one by one
    - Or — provided the GlotPress host has the `gp-import-export` plugin installed and supports it — as a bulk download of all the locales at once (as a ZIP stream that will be decompressed by the downloader class on the fly)

 - That class also knows how to parse the odd format used by GlotPress for its JSON exports (where the JSON keys are actually the copy key + `\0004` + the original copy, and the JSON values are an array with mostly only one entry at most) and convert it to a usable `Hash`.

This class is supposed to only have the knowledge of the GlotPress side of things. Once it downloaded the export from GlotPress in memory (`File`/`IO` instance) and parsed it, it is not responsible for doing anything with the data except handing it over to the next piece in that new architecture (typically a `*_file_writer`).  
That way, if we want to support alternative Localization backends in the future (e.g. OneSky or Weblate, see 298-gh-Automattic/i18n-issues), this would be nicely decoupled.

### File writers — to write the downloaded translations for each locale to disk

 -  `helper/ios/ios_strings_file_writer` knows how to take a single `.strings` file export, for a single locale, and write it to disk(†).
 -  `helper/android/android_strings_file_writer` knows how to take a single `strings.xml` file export, for a single locale, and write it to disk(†).
 - `helper/fastlane_metadata_file_writer` knows how to take a `Hash` of exported translations (key => translation) for a single locale, and write it as `.txt` files to disk (typically in `fastlane/metadata/…/{locale}/` folders)
    - This class includes a subclass `MetadataRule` which describes the rules to apply to each key, especially its `max_len` and the name/path of the corresponding `.txt` file to associate with it.
    - The `FastlaneMetadataFileWrite` then knows how to use a list of `MetadataRule` objects to extract the proper keys from the translations, check their length, try the shorter alternatives (entries for `#{original_key}_short`, by convention), and write the one that fits the limit into the proper `.txt` file (or delete the file if no fitting translation was found).
    - The class provides predefined sets of `MetadataRule` lists for Android and iOS projects, with predefined keys for typical App Store / Play Store metadata.
    - The writer still offers a way to dynamically provide a `MetadataRule` for any unknown key, allowing us to describe how to handle unexpected/unusual keys (e.g. screenshots) as we encounter them.

(†) Those two `*_strings_file_writer` helpers are currently very simple, just taking the IO stream and writing it to disk verbatim, with the only logic being to know the relative path to use for the subfolder based on the locale passed.
But in the future I'm hoping we can improve those classes to optimize the way files are written to disk, especially reorder the XML nodes in `strings.xml` files to make sure they are always sorted in the same order, making PR diffs for them easier to review. This is not implemented in this PR yet though.

## To Test

🚧  There is currently no unit tests / specs. This is the next step on my TODO list.
In the meantime, I've written some "demo code" of how those helpers are supposed to interact with each other and assembled together.
This demo code is likely the scaffold of what the future new fastlane actions (the ones using this new implementaion) will look like, but for now they are quite drafty and only serve the purpose of brain-dumping my idea of how that new API of mine would work together at call site.