### PR TITLE
Add an option to retry when GlotPress download fails on "429 Too Many Requests" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Propose to retry when the download of GlotPress translations failed for a locale (especially useful for occurrences of `429 - Too Many Requests` quota limits) [#402]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -291,6 +291,7 @@ module Fastlane
             uri.open(options) { |f| Nokogiri::XML(f.read.gsub("\t", '    '), nil, Encoding::UTF_8.to_s) }
           rescue StandardError => e
             UI.error "Error downloading #{locale} - #{e.message}"
+            retry if e.is_a?(OpenURI::HTTPError) && UI.confirm("Retry downloading `#{locale}`?")
             return nil
           end
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -152,6 +152,7 @@ module Fastlane
             IO.copy_stream(uri.open(options), destination)
           rescue StandardError => e
             UI.error "Error downloading locale `#{locale}` — #{e.message} (#{uri})"
+            retry if e.is_a?(OpenURI::HTTPError) && UI.confirm("Retry downloading `#{locale}`?")
             return nil
           end
         end

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -70,6 +70,7 @@ describe Fastlane::Actions::IosDownloadStringsFilesFromGlotpressAction do
         stub = gp_stub(locale: 'unknown-locale', query: { 'filters[status]': 'current', format: 'strings' }).to_return(status: [404, 'Not Found'])
         error_messages = []
         allow(FastlaneCore::UI).to receive(:error) { |message| error_messages.append(message) }
+        allow(FastlaneCore::UI).to receive(:confirm).and_return(false) # as we will be asked if we want to retry when getting a network error
 
         # Act
         run_described_fastlane_action(

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -260,6 +260,7 @@ describe Fastlane::Helper::Ios::L10nHelper do
         stub = stub_request(:get, "#{gp_fake_url}/invalid/default/export-translations/").with(query: { format: 'strings' }).to_return(status: [404, 'Not Found'])
         error_messages = []
         allow(FastlaneCore::UI).to receive(:error) { |message| error_messages.append(message) }
+        allow(FastlaneCore::UI).to receive(:confirm).and_return(false) # as we will be asked if we want to retry when getting a network error
         dest = StringIO.new
         # Act
         described_class.download_glotpress_export_file(project_url: gp_fake_url, locale: 'invalid', filters: nil, destination: dest)


### PR DESCRIPTION
## Why?

We still keep having `429 - Too Many Requests` errors from time to time when running the actions which download the app translations from GlotPress.

For example, on average I encounter those on at least 1-3 locales every time I'm doing a new beta or final release, forcing me to interrupt the lane, discard the unstaged changes in git, restart the lane from scratch again, and pray it will pass on those subsequent tries, otherwise I'll have to do all that again. And since the more you retry, the closer you are to the quota limit… things tend to actually get worse on subsequent retries.

This has become quite painful while doing betas and releases, especially for WordPress (which has more than 40 locales to download, so the chances of hitting the `429` error on at least one of them are higher)

## How?

This simply asks the user if they want to retry a the download of a locale if one fails.

 - This not only allows us to avoid having to restart the whole lane and thus the download of all locales from scratch (reducing the risk of hitting the quota once again)
 - But also allows the script to pause until the user replies to the `UI.confirm` prompt before retrying, which allows to leave some time before the first and next retry of the request, giving us even more chances for the quota limit to cool down before the next try.

## Related work

In parallel to that, other work is being done to help getting rid of this `429` error and quota limit. Especially, we've asked for the `gp-import-export` plugin to be installed on both of our GlotPress instances so we could do bulk-downloads of all the locales at once with a single request, and we plan to implement the code to in the `release-toolkit` to be able to use it hopefully soon (we already [have a Draft here](https://github.com/wordpress-mobile/release-toolkit/pull/401), but it's still very early stage so far).

Supporting bulk-download in the `release-toolkit` will require a bit more involved work though, for which I don't have the bandwidth for just yet. So this workaround of still using one-at-a-time locales download but allowing retry would hopefully help mitigate the issue in the meantime.