### PR TITLE
FTL: Support providing a `--test-targets` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Add a `test_targets` parameter to the `android_firebase_test` action to be able to filter the tests to be run. [#403]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_firebase_test.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_firebase_test.rb
@@ -33,6 +33,7 @@ module Fastlane
           apk_path: params[:apk_path],
           test_apk_path: params[:test_apk_path],
           device: device,
+          test_targets: params[:test_targets],
           type: params[:type]
         )
 
@@ -105,6 +106,13 @@ module Fastlane
               UI.user_error!('The `:test_apk_path` parameter is required') if value.empty?
               UI.user_error!("Invalid test APK: #{value}") unless File.exist?(value)
             end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :test_targets,
+            description: 'A list of one or more test target filters to apply',
+            type: String,
+            optional: true,
+            default_value: nil
           ),
           FastlaneCore::ConfigItem.new(
             key: :model,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_test_runner.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_test_runner.rb
@@ -20,20 +20,21 @@ module Fastlane
     # @param [FirebaseDevice] device The virtual device to run tests on.
     # @param [String] type The type of test to run.
     #
-    def self.run_tests(project_id:, apk_path:, test_apk_path:, device:, type: 'instrumentation')
+    def self.run_tests(project_id:, apk_path:, test_apk_path:, device:, test_targets: nil, type: 'instrumentation')
       raise "Unable to find apk: #{apk_path}" unless File.file?(apk_path)
       raise "Unable to find apk: #{test_apk_path}" unless File.file?(test_apk_path)
       raise "Invalid Type: #{type}" unless VALID_TEST_TYPES.include?(type)
 
-      command = Shellwords.join [
-        'gcloud', 'firebase', 'test', 'android', 'run',
-        '--project', project_id,
-        '--type', type,
-        '--app', apk_path,
-        '--test', test_apk_path,
-        '--device', device.to_s,
-        '--verbosity', 'info',
-      ]
+      params = {
+        project: project_id,
+        type: type,
+        app: apk_path,
+        test: test_apk_path,
+        'test-targets': test_targets,
+        device: device.to_s,
+        verbosity: 'info'
+      }.compact.flat_map { |k, v| ["--#{k}", v] }
+      command = Shellwords.join(['gcloud', 'firebase', 'test', 'android', 'run', *params])
 
       log_file_path = Fastlane::Actions.lane_context[:FIREBASE_TEST_LOG_FILE_PATH]
 

--- a/spec/firebase_test_runner_spec.rb
+++ b/spec/firebase_test_runner_spec.rb
@@ -31,7 +31,7 @@ describe Fastlane::FirebaseTestRunner do
       run_tests
     end
 
-    it 'includes and properly escape the test filters if any are provided' do
+    it 'includes and properly escapes the test targets if any are provided' do
       allow(Fastlane::Action).to receive('sh').with(
         "gcloud firebase test android run --project foo-bar-baz --type instrumentation --app #{default_file} --test #{default_file} --test-targets notPackage\\ org.wordpress.android.ui.screenshots --device device --verbosity info 2>&1 | tee #{runner_temp_file}"
       )

--- a/spec/firebase_test_runner_spec.rb
+++ b/spec/firebase_test_runner_spec.rb
@@ -31,6 +31,13 @@ describe Fastlane::FirebaseTestRunner do
       run_tests
     end
 
+    it 'includes and properly escape the test filters if any are provided' do
+      allow(Fastlane::Action).to receive('sh').with(
+        "gcloud firebase test android run --project foo-bar-baz --type instrumentation --app #{default_file} --test #{default_file} --test-targets notPackage\\ org.wordpress.android.ui.screenshots --device device --verbosity info 2>&1 | tee #{runner_temp_file}"
+      )
+      run_tests(test_targets: 'notPackage org.wordpress.android.ui.screenshots')
+    end
+
     it 'properly escapes the app path' do
       temp_file_path = File.join(Dir.tmpdir(), 'path with spaces.txt')
       expected_temp_file_path = File.join(Dir.tmpdir(), 'path\ with\ spaces.txt')
@@ -66,13 +73,14 @@ describe Fastlane::FirebaseTestRunner do
       expect { run_tests(type: 'foo') }.to raise_exception('Invalid Type: foo')
     end
 
-    def run_tests(project_id: 'foo-bar-baz', apk_path: default_file, test_apk_path: default_file, device: 'device', type: 'instrumentation')
+    def run_tests(project_id: 'foo-bar-baz', apk_path: default_file, test_apk_path: default_file, device: 'device', test_targets: nil, type: 'instrumentation')
       Fastlane::Actions.lane_context[:FIREBASE_TEST_LOG_FILE_PATH] = runner_temp_file
       described_class.run_tests(
         project_id: project_id,
         apk_path: apk_path,
         test_apk_path: test_apk_path,
         device: device,
+        test_targets: test_targets,
         type: type
       )
     end


### PR DESCRIPTION
## Why?

After migrating the code able to trigger Firebase Test Lab from CircleCI and [our related CircleCI orb](https://github.com/wordpress-mobile/circleci-orbs/blob/trunk/src/android/orb.yml#L81-L206) to [move it to a fastlane action in release-toolkit](https://github.com/wordpress-mobile/release-toolkit/pull/355) during the Buildkite migration, we forgot to add an option to filter the test targets, like we had and [used to use in e.g. WordPress Android to exclude screenshots from the instrumented/connected tests](https://github.com/wordpress-mobile/WordPress-Android/blob/2b4b4f1737ce387c2e95929ef8ebcdbdd854e68f/.circleci/config.yml#L156)

## How

Add an optional `test_targets` parameter (aka `ConfigItem`) to the `android_firebase_test` action which is then passed to the invocation of `gcloud`

## To test

The unit tests (`spec/firebase_test_runner_spec.rb`) have been updated to cover for cases with or without a `test_targets` parameter being provided, and for testing the proper escaping of the filter if one is provided.
So if CI is green, it should be all good to go.

## What's next

To workaround the fact that we couldn't filter the test targets during instrumented tests, @pachlava had to temporarily `@Ignore` the Screenshot tests in WordPress Android (https://github.com/wordpress-mobile/WordPress-Android/pull/16970).

Once this lands, we should then:
 - [x] Make a new release of the `release-toolkit`
 - [x] Point WordPress-Android to that new version of the toolkit
 - [x] Update [the call site of `android_firebase_test` in `build_and_run_instrumented_tests`](https://github.com/wordpress-mobile/WordPress-Android/blob/trunk/fastlane/lanes/test.rb#L24-L32) to add `test_targets: 'notPackage org.wordpress.android.ui.screenshots'` to the parameters
 - [x] Revert the changes made by https://github.com/wordpress-mobile/WordPress-Android/pull/16970 to un-ignore screenshot tests (and thus be able to progress on the work on Android screenshots)