### PR TITLE
Handle 429 and prevent 301 in `gp_downloadmetadata`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-_None_
+- Propose to retry when `gp_downloadmetadata` receives a `429 - Too Many Requests` error. [#406]
 
 ### New Features
 
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Update the URL used by `gp_downloadmetadata` to prevent consistent `301` responses. [#406]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -20,13 +20,13 @@ module Fastlane
         params[:locales].each do |loc|
           if loc.is_a?(Array)
             UI.message "Downloading language: #{loc[1]}"
-            complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations?filters[status]=current&format=json"
+            complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations/?filters[status]=current&format=json"
             downloader.download(loc[1], complete_url, loc[1] == params[:source_locale])
           end
 
           if loc.is_a?(String)
             UI.message "Downloading language: #{loc}"
-            complete_url = "#{params[:project_url]}#{loc}/default/export-translations?filters[status]=current&format=json"
+            complete_url = "#{params[:project_url]}#{loc}/default/export-translations/?filters[status]=current&format=json"
             downloader.download(loc, complete_url, loc == params[:source_locale])
           end
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -19,13 +19,13 @@ module Fastlane
 
         params[:locales].each do |loc|
           if loc.is_a?(Array)
-            puts "Downloading language: #{loc[1]}"
+            UI.message "Downloading language: #{loc[1]}"
             complete_url = "#{params[:project_url]}#{loc[0]}/default/export-translations?filters[status]=current&format=json"
             downloader.download(loc[1], complete_url, loc[1] == params[:source_locale])
           end
 
           if loc.is_a?(String)
-            puts "Downloading language: #{loc}"
+            UI.message "Downloading language: #{loc}"
             complete_url = "#{params[:project_url]}#{loc}/default/export-translations?filters[status]=current&format=json"
             downloader.download(loc, complete_url, loc == params[:source_locale])
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -102,22 +102,24 @@ module Fastlane
         case response.code
         when '200'
           # All good, parse the result
+          UI.success("Successfully downloaded `#{locale}`.")
           @alternates.clear
           loc_data = JSON.parse(response.body) rescue loc_data = nil
           parse_data(locale, loc_data, is_source)
           reparse_alternates(target_locale, loc_data, is_source) unless @alternates.length == 0
         when '301'
           # Follow the redirect
+          UI.message("Received 301 for `#{locale}`. Following redirect...")
           download(locale, response.header['location'], is_source)
         when '429'
           # We got rate-limited, offer to try again
           if UI.confirm("Retry downloading `#{locale}` after receiving 429 from the API?")
             download(locale, response.uri, is_source)
           else
-            UI.message("Giving up on attempting to download #{locale}.")
+            UI.error("Abandoning `#{locale}` download as requested.")
           end
         else
-          UI.error("Received unexpected #{response.code} from request to URI #{response.uri}")
+          UI.error("Received unexpected #{response.code} from request to URI #{response.uri}.")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -119,7 +119,8 @@ module Fastlane
             UI.error("Abandoning `#{locale}` download as requested.")
           end
         else
-          UI.error("Received unexpected #{response.code} from request to URI #{response.uri}.")
+          message = "Received unexpected #{response.code} from request to URI #{response.uri}."
+          UI.abort_with_message!(message) unless UI.confirm("#{message} Continue anyway?")
         end
       end
     end


### PR DESCRIPTION
During the WordPress 20.6 finalization, we noticed that `gp_downloadmetadata` didn't offer to retry the GlotPress request when receiving a 429 (see details in [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/19267#discussion_r960523291) and [this commit](https://github.com/wordpress-mobile/WordPress-iOS/pull/19275/commits/7c3289fcc7fe0b493aa9a49696bb3ba85a85646a))

This PR adds a crude retry mechanism to the action.

![image](https://user-images.githubusercontent.com/1218433/188541811-8014b48c-2b5c-450c-909c-76afe1b8f61a.png)


While working on this, I noticed that the URL used was lacking the `/`, consistently resulting in a 301 from the API. I addressed that, too.

`gp_downloadmetadata` is set to be removed in favor of a better alternative as soon as we'll have time for it. I tried to write new code that was good, but kept the refactoring and improvements to a minimum.

### Testing

I tested this by pointing my  WordPress iOS to my local copy of the repo.

```diff
--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -8,7 +8,8 @@ end

 # This comment avoids typing to switch to a development version for testing.
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'tru>
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.1'
+# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 5.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../release-toolkit'
```

I then run `bundle exec fastlane download_wordpress_localized_app_store_metadata` till I got a 429.