### PR TITLE
Remove call to `pod clean` from `ios_build_preflight`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 ### Breaking Changes
 
-- Propose to retry when `gp_downloadmetadata` receives a `429 - Too Many Requests` error. [#406]
+_None_
 
 ### New Features
 
-_None_
+- Propose to retry when `gp_downloadmetadata` receives a `429 - Too Many Requests` error. [#406]
 
 ### Bug Fixes
 
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Remove call to `rake dependencies:pod:clean` from `ios_build_preflight` [#407]
 
 ## 5.4.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -33,7 +33,6 @@ module Fastlane
           raise
         end
 
-        Action.sh('rake dependencies:pod:clean')
         other_action.cocoapods()
       end
 


### PR DESCRIPTION
Following up on what was discussed [here](https://github.com/woocommerce/woocommerce-ios/pull/7649#issuecomment-1236756962).

This call could lead to long wait times, in particular in WordPress iOS, as every pod was downloaded from scratch.

See:

- https://github.com/woocommerce/woocommerce-ios/pull/7649
- https://github.com/wordpress-mobile/WordPress-iOS/pull/19033#issuecomment-1183230212

---

I'm a bit unsure whether we should keep this whole action in the first place. Quoting from my comment in the WordPress PR:

> I considered removing the call to `ios_build_preflight` altogether, but maybe there's value in having them in those rare circumstances when we run builds locally? I might open an issue to discuss this option further [...]

I wonder whether it's not appropriate for this library to make assumptions on the kind of pre-requisites its clients should have. A pre-flight step might be useful, but maybe it should be up to each client to define it.

