### PR TITLE
Release 5.5.0 into `trunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 5.5.0
+
+### New Features
+
 - Propose to retry when `gp_downloadmetadata` receives a `429 - Too Many Requests` error. [#406]
 
 ### Bug Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (5.4.0)
+    fastlane-plugin-wpmreleasetoolkit (5.5.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '5.4.0'
+    VERSION = '5.5.0'
   end
 end


### PR DESCRIPTION
New version 5.5.0. 

- [x] @mokagio: Be sure to create a GitHub Release and tag once this PR gets merged.

## Why?

Because we are still getting 429 errors when downloading ASC metadata from GlotPress and #406 fixes it.

Example: I run into this earlier when deploying a the localization smoke testing build for Jetpack/WordPress iOS

```
Downloading language: zh-Hant
[15:52:59]: No translation available for zh-Hant 👈👈👈
[15:52:59]: ---------------------
[15:52:59]: --- Step: git_add ---
[15:52:59]: ---------------------
[15:52:59]: Successfully added "/Users/gio/Developer/a8c/wpios/fastlane/metadata/**/*.txt" 💾.
[15:52:59]: ------------------------
[15:52:59]: --- Step: git_commit ---
[15:52:59]: ------------------------
[15:52:59]: $ git status /Users/gio/Developer/a8c/wpios/fastlane/metadata/\*\*/\*.txt --porcelain
[15:52:59]: ▸ A  fastlane/metadata/ar-SA/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/de-DE/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/en-GB/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/es-ES/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/fr-FR/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/he/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/id/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/it/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/ko/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/nl-NL/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/ru/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/sv/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/tr/release_notes.txt
[15:52:59]: ▸ A  fastlane/metadata/zh-Hans/release_notes.txt
[15:52:59]: ▸ D fastlane/metadata/zh-Hant/description.txt 👈😭
[15:52:59]: ▸ D fastlane/metadata/zh-Hant/keywords.txt 👈😭
[15:52:59]: ▸ D fastlane/metadata/zh-Hant/name.txt 👈😭
[15:52:59]: ▸ D fastlane/metadata/zh-Hant/subtitle.txt 👈😭
````