### PR TITLE
Add Android AVD / emulator actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Add `android_create_avd`, `android_launch_emulator` and `android_shutdown_emulator` actions. [#409]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_avd_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_avd_action.rb
@@ -1,0 +1,90 @@
+module Fastlane
+  module Actions
+    class AndroidCreateAvdAction < Action
+      def self.run(params)
+        device_model = params[:device_model]
+        api_level = params[:api_level]
+        avd_name = params[:avd_name]
+        sdcard = params[:sdcard]
+
+        helper = Fastlane::Helper::Android::EmulatorHelper.new
+
+        # Ensure we have the system image needed for creating the AVD with this API level
+        system_image = params[:system_image] || helper.install_system_image(api: api_level)
+
+        # Create the AVD for device, API and system image we need
+        helper.create_avd(
+          api: api_level,
+          device: device_model,
+          system_image: system_image,
+          name: avd_name,
+          sdcard: sdcard
+        )
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Creates a new Android Virtual Device (AVD) for a specific device model and API level'
+      end
+
+      def self.details
+        <<~DESC
+          Creates a new Android Virtual Device (AVD) for a specific device model and API level.
+          By default, it also installs the necessary system image (using `sdkmanager`) if needed before creating the AVD
+        DESC
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :device_model,
+                                       env_name: 'FL_ANDROID_CREATE_AVD_DEVICE_MODEL',
+                                       description: 'The device model code to use to create the AVD. Valid values can be found using `avdmanager list devices`',
+                                       type: String,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :api_level,
+                                       env_name: 'FL_ANDROID_CREATE_AVD_API_LEVEL',
+                                       description: 'The API level to use to install the necessary system-image and create the AVD',
+                                       type: Integer,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :avd_name,
+                                       env_name: 'FL_ANDROID_CREATE_AVD_AVD_NAME',
+                                       description: 'The name to give to the created AVD. If not provided, will be derived from device model and API level',
+                                       type: String,
+                                       optional: true,
+                                       default_value: nil),
+          FastlaneCore::ConfigItem.new(key: :sdcard,
+                                       env_name: 'FL_ANDROID_CREATE_AVD_SDCARD',
+                                       description: 'The size of the SD card to use for the AVD',
+                                       type: String,
+                                       optional: true,
+                                       default_value: '512M'),
+          FastlaneCore::ConfigItem.new(key: :system_image,
+                                       env_name: 'FL_ANDROID_CREATE_AVD_SYSTEM_IMAGE',
+                                       description: 'The system image to use (as used/listed by `sdkmanager`). Defaults to the appropriate system image given the API level requested and the current machine\'s architecture',
+                                       type: String,
+                                       optional: true,
+                                       default_value_dynamic: true,
+                                       default_value: nil),
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        'Returns the name of the created AVD'
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_launch_emulator_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_launch_emulator_action.rb
@@ -1,0 +1,61 @@
+module Fastlane
+  module Actions
+    class AndroidLaunchEmulatorAction < Action
+      def self.run(params)
+        helper = Fastlane::Helper::Android::EmulatorHelper.new
+        helper.launch_avd(
+          name: params[:avd_name],
+          cold_boot: params[:cold_boot],
+          wipe_data: params[:wipe_data]
+        )
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Boots an Android emulator using the given AVD name'
+      end
+
+      def self.details
+        description
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :avd_name,
+                                       env_name: 'FL_ANDROID_LAUNCH_EMULATOR_AVD_NAME',
+                                       description: 'The name of the AVD to boot',
+                                       type: String,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :cold_boot,
+                                       env_name: 'FL_ANDROID_LAUNCH_EMULATOR_COLD_BOOT',
+                                       description: 'Indicate if we want a cold boot (true) of if we prefer booting from a snapshot (false)',
+                                       type: Fastlane::Boolean,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :wipe_data,
+                                       env_name: 'FL_ANDROID_LAUNCH_EMULATOR_WIPE_DATA',
+                                       description: 'Indicate if we want to wipe the device data before booting the AVD, so it is like it were a brand new device',
+                                       type: Fastlane::Boolean,
+                                       default_value: true),
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        'The serial of the emulator that was created after booting the AVD (e.g. `emulator-5554`)'
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_send_app_size_metrics.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_send_app_size_metrics.rb
@@ -71,31 +71,26 @@ module Fastlane
         end
 
         # The path where the `apkanalyzer` binary was found, after searching it:
-        #  - in priority in `$ANDROID_SDK_ROOT` (or `$ANDROID_HOME` for legacy setups), under `cmdline-tools/latest/bin/` or `cmdline-tools/tools/bin`
+        #  - in priority in `$ANDROID_HOME` (or `$ANDROID_SDK_ROOT` for legacy setups), under `cmdline-tools/latest/bin/` or `cmdline-tools/tools/bin`
         #  - and falling back by trying to find it in `$PATH`
         #
         # @return [String,Nil] The path to `apkanalyzer`, or `nil` if it wasn't found in any of the above tested paths.
         #
         def find_apkanalyzer_binary
-          sdk_root = ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_HOME']
-          if sdk_root
-            pattern = File.join(sdk_root, 'cmdline-tools', '{latest,tools}', 'bin', 'apkanalyzer')
-            apkanalyzer_bin = Dir.glob(pattern).find { |path| File.executable?(path) }
-          end
-          apkanalyzer_bin || Action.sh('command', '-v', 'apkanalyzer', print_command_output: false) { |_| nil }
+          @tools ||= Fastlane::Helper::Android::ToolsPathHelper.new
+          @tools.find_tool_path(binary: 'apkanalyzer', search_paths: @tools.cmdline_tools_search_paths)
         end
 
         # The path where the `apkanalyzer` binary was found, after searching it:
-        #  - in priority in `$ANDROID_SDK_ROOT` (or `$ANDROID_HOME` for legacy setups), under `cmdline-tools/latest/bin/` or `cmdline-tools/tools/bin`
+        #  - in priority in `$ANDROID_HOME` (or `$ANDROID_SDK_ROOT` for legacy setups), under `cmdline-tools/latest/bin/` or `cmdline-tools/tools/bin`
         #  - and falling back by trying to find it in `$PATH`
         #
         # @return [String] The path to `apkanalyzer`
         # @raise [FastlaneCore::Interface::FastlaneError] if it wasn't found in any of the above tested paths.
         #
         def find_apkanalyzer_binary!
-          apkanalyzer_bin = find_apkanalyzer_binary
-          UI.user_error!('Unable to find `apkanalyzer` executable in either `$PATH` or `$ANDROID_SDK_ROOT`. Make sure you installed the Android SDK Command-line Tools') if apkanalyzer_bin.nil?
-          apkanalyzer_bin
+          @tools ||= Fastlane::Helper::Android::ToolsPathHelper.new
+          @tools.find_tool_path!(binary: 'apkanalyzer', search_paths: @tools.cmdline_tools_search_paths)
         end
 
         # Add the `file-size` and `download-size` values of an APK to the helper, as reported by the corresponding `apkanalyzer apk …` commands

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_shutdown_emulator_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_shutdown_emulator_action.rb
@@ -1,0 +1,48 @@
+module Fastlane
+  module Actions
+    class AndroidShutdownEmulatorAction < Action
+      def self.run(params)
+        helper = Fastlane::Helper::Android::EmulatorHelper.new
+        helper.shut_down_emulators!(serials: params[:serial])
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Shuts down Android emulators'
+      end
+
+      def self.details
+        description
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :serial,
+                                       env_name: 'FL_ANDROID_SHUTDOWN_EMULATOR_SERIAL',
+                                       description: 'The serial(s) of the emulators to shut down. If not provided (nil), will shut them all down',
+                                       type: Array,
+                                       optional: true,
+                                       default_value: nil),
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_shutdown_emulator_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_shutdown_emulator_action.rb
@@ -3,7 +3,7 @@ module Fastlane
     class AndroidShutdownEmulatorAction < Action
       def self.run(params)
         helper = Fastlane::Helper::Android::EmulatorHelper.new
-        helper.shut_down_emulators!(serials: params[:serial])
+        helper.shut_down_emulators!(serials: params[:serials])
       end
 
       #####################################################
@@ -20,8 +20,8 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :serial,
-                                       env_name: 'FL_ANDROID_SHUTDOWN_EMULATOR_SERIAL',
+          FastlaneCore::ConfigItem.new(key: :serials,
+                                       env_name: 'FL_ANDROID_SHUTDOWN_EMULATOR_SERIALS',
                                        description: 'The serial(s) of the emulators to shut down. If not provided (nil), will shut them all down',
                                        type: Array,
                                        optional: true,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -24,7 +24,7 @@ module Fastlane
           package = system_image_package(api: api)
 
           UI.message("Installing System Image for Android #{api} (#{package})")
-          Actions.sh(@tools.sdkmanager, "--sdk_root=#{@tools.android_sdk_root}", '--install', package)
+          Actions.sh(@tools.sdkmanager, '--install', package)
           UI.success("System Image #{package} successfully installed.")
           package
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -125,7 +125,7 @@ module Fastlane
 
         def find_serial(avd_name:)
           running_emulators.find do |candidate|
-            Actions.sh(@tools.adb, '-s', candidate, 'emu', 'avd', 'name').first.chomp == avd_name
+            Actions.sh(@tools.adb, '-s', candidate.serial, 'emu', 'avd', 'name').first.chomp == avd_name
           end
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -178,7 +178,7 @@ module Fastlane
           @system_image_packages ||= {}
           @system_image_packages[api] ||= begin
             platform = `uname -m`.chomp
-            all_packages = `#{@tools.sdkmanager} --sdk_root=#{@tools.android_sdk_root} --list`
+            all_packages = `#{@tools.sdkmanager} --list`
             package = all_packages.match(/^ *(system-images;android-#{api};google_apis;#{platform}(-[^ ]*)?)/)&.captures&.first
             UI.user_error!("Could not find system-image for API `#{api}` and your platform `#{platform}` in `sdkmanager --list`. Maybe Google removed it for download and it's time to update to a newer API?") if package.nil?
             package

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -113,7 +113,7 @@ module Fastlane
           emulators_list.each do |e|
             Actions.sh(@tools.adb, '-s', e, 'emu', 'kill') { |_| } # ignore error if no emulator with specified serial is running
 
-            # Note: Alternative way of shutting down emulator would be to call the following command instead, which shuts down the emulator more gracefully:
+            # NOTE: Alternative way of shutting down emulator would be to call the following command instead, which shuts down the emulator more gracefully:
             # `adb -s #{e} shell reboot -p` # In case you're wondering, `-p` is for "power-off"
             # But this alternate command:
             #  - Requires that `-no-snapshot` was used on boot (to avoid being prompted to save current state on shutdown)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -24,7 +24,7 @@ module Fastlane
           package = system_image_package(api: api)
 
           UI.message("Installing System Image for Android #{api} (#{package})")
-          Actions.sh(@tools.sdkmanager, '--install', package)
+          Actions.sh(@tools.sdkmanager, "--sdk_root=#{@tools.android_sdk_root}", '--install', package)
           UI.success("System Image #{package} successfully installed.")
           package
         end
@@ -143,7 +143,8 @@ module Fastlane
           @system_image_packages ||= {}
           @system_image_packages[api] ||= begin
             platform = `uname -m`.chomp
-            package = `#{@tools.sdkmanager} --list`.match(/^ *(system-images;android-#{api};google_apis;#{platform}(-[^ ]*)?)/)&.captures&.first
+            all_packages = `#{@tools.sdkmanager} --sdk_root=#{@tools.android_sdk_root} --list`
+            package = all_packages.match(/^ *(system-images;android-#{api};google_apis;#{platform}(-[^ ]*)?)/)&.captures&.first
             UI.user_error!("Could not find system-image for API `#{api}` and your platform `#{platform}` in `sdkmanager --list`. Maybe Google removed it for download and it's time to update to a newer API?") if package.nil?
             package
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -135,7 +135,7 @@ module Fastlane
           end&.serial
         end
 
-        # Trigger a shutdown for all running emulators, and wait until there is no more emulator running.
+        # Trigger a shutdown for all running emulators, and wait until there is no more emulators running.
         #
         # @param [Array<String>] serials List of emulator serials to shut down. Will shut down all of them if `nil`.
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -14,7 +14,7 @@ module Fastlane
           @tools = Fastlane::Helper::Android::ToolsPathHelper.new
         end
 
-        # Installs the system-image suitable for a given Android `api`, with `google_apis`, and for the current machine's architecture
+        # Installs the system-image suitable for a given Android `api`, with Google APIs, and for the current machine's architecture
         #
         # @param [Integer] api The Android API level to use
         #
@@ -167,7 +167,7 @@ module Fastlane
           UI.success('All emulators are now shut down.')
         end
 
-        # Find the system-images package for the provided API, with Google APIs, and matching the current platform/architecture this lane is called from.
+        # Find the system-images package for the provided `api`, with Google APIs, and matching the current platform/architecture this lane is called from.
         #
         # @param [Integer] api The Android API level to use for this AVD
         # @return [String] The `system-images;android-<N>;google_apis;<platform>` package specifier for `sdkmanager` to use in its install command

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
@@ -1,0 +1,46 @@
+require 'fastlane_core/ui/ui'
+
+module Fastlane
+  module Helper
+    module Android
+      # Helper to find the paths of common Android build and SDK tools on the current machine
+      # Based on `$ANDROID_SDK_ROOT` and the common relative paths those tools are installed in.
+      #
+      class ToolsPathHelper
+        attr_reader :android_sdk_root
+
+        def initialize(sdk_root: nil)
+          @android_sdk_root = sdk_root || ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
+        end
+
+        def tool(paths:, binary:)
+          bin_path = `command -v #{binary}`.chomp
+          return bin_path unless bin_path.nil? || bin_path.empty? || !File.executable?(bin_path)
+
+          bin_path = paths
+                     .map { |path| File.join(android_sdk_root, path, binary) }
+                     .first { |path| File.executable?(path) }
+
+          UI.user_error!("Unable to find path for #{binary} in #{paths.inspect}. Verify you installed the proper Android tools.") if bin_path.nil?
+          bin_path
+        end
+
+        def sdkmanager
+          @sdkmanager ||= tool(paths: %w[cmdline-tools latest bin], binary: 'sdkmanager')
+        end
+
+        def avdmanager
+          @avdmanager ||= tool(paths: %w[cmdline-tools latest bin], binary: 'avdmanager')
+        end
+
+        def emulator
+          @emulator ||= tool(paths: ['emulator'], binary: 'emulator')
+        end
+
+        def adb
+          @adb ||= tool(paths: ['platform-tools'], binary: 'adb')
+        end
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
@@ -4,13 +4,13 @@ module Fastlane
   module Helper
     module Android
       # Helper to find the paths of common Android build and SDK tools on the current machine
-      # Based on `$ANDROID_SDK_ROOT` and the common relative paths those tools are installed in.
+      # Based on `$ANDROID_HOME` and the common relative paths those tools are installed in.
       #
       class ToolsPathHelper
-        attr_reader :android_sdk_root
+        attr_reader :android_home
 
         def initialize(sdk_root: nil)
-          @android_sdk_root = sdk_root || ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
+          @android_home = sdk_root || ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
         end
 
         def tool(binary:, search_paths:)
@@ -19,7 +19,7 @@ module Fastlane
           return bin_path unless bin_path.nil? || bin_path.empty? || !File.executable?(bin_path)
 
           bin_path = search_paths
-                     .map { |path| File.join(android_sdk_root, path, binary) }
+                     .map { |path| File.join(android_home, path, binary) }
                      .find { |path| File.executable?(path) }
 
           UI.user_error!("Unable to find path for #{binary} in #{search_paths.inspect}. Verify you installed the proper Android tools.") if bin_path.nil?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
@@ -13,32 +13,45 @@ module Fastlane
           @android_sdk_root = sdk_root || ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
         end
 
-        def tool(paths:, binary:)
+        def tool(binary:, search_paths:)
           bin_path = `command -v #{binary}`.chomp
+
           return bin_path unless bin_path.nil? || bin_path.empty? || !File.executable?(bin_path)
 
-          bin_path = paths
+          bin_path = search_paths
                      .map { |path| File.join(android_sdk_root, path, binary) }
-                     .first { |path| File.executable?(path) }
+                     .find { |path| File.executable?(path) }
 
-          UI.user_error!("Unable to find path for #{binary} in #{paths.inspect}. Verify you installed the proper Android tools.") if bin_path.nil?
+          UI.user_error!("Unable to find path for #{binary} in #{search_paths.inspect}. Verify you installed the proper Android tools.") if bin_path.nil?
           bin_path
         end
 
         def sdkmanager
-          @sdkmanager ||= tool(paths: %w[cmdline-tools latest bin], binary: 'sdkmanager')
+          @sdkmanager ||= tool(
+            binary: 'sdkmanager',
+            search_paths: [File.join('cmdline-tools', 'latest', 'bin')]
+          )
         end
 
         def avdmanager
-          @avdmanager ||= tool(paths: %w[cmdline-tools latest bin], binary: 'avdmanager')
+          @avdmanager ||= tool(
+            binary: 'avdmanager',
+            search_paths: [File.join('cmdline-tools', 'latest', 'bin')]
+          )
         end
 
         def emulator
-          @emulator ||= tool(paths: ['emulator'], binary: 'emulator')
+          @emulator ||= tool(
+            binary: 'emulator',
+            search_paths: [File.join('emulator')]
+          )
         end
 
         def adb
-          @adb ||= tool(paths: ['platform-tools'], binary: 'adb')
+          @adb ||= tool(
+            binary: 'adb',
+            search_paths: [File.join('platform-tools')]
+          )
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
@@ -25,10 +25,10 @@ module Fastlane
                      end
 
           # If not found in any of the `search_paths`, try to look for it in $PATH
-          bin_path ||= Action.sh('command', '-v', binary, print_command_output: false) { |_| nil }.chomp
+          bin_path ||= Actions.sh('command', '-v', binary) { |err, res, _| res if err&.success? }&.chomp
 
-          # Normalize return value to `nil` if it was not found or is not an executable
-          bin_path = nil if bin_path.empty? || !File.executable?(bin_path)
+          # Normalize return value to `nil` if it was not found, empty, or is not an executable
+          bin_path = nil if !bin_path.nil? && (bin_path.empty? || !File.executable?(bin_path))
 
           bin_path
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
@@ -13,42 +13,70 @@ module Fastlane
           @android_home = sdk_root || ENV['ANDROID_HOME'] || ENV['ANDROID_SDK_ROOT'] || ENV['ANDROID_SDK']
         end
 
-        def tool(binary:, search_paths:)
-          bin_path = `command -v #{binary}`.chomp
+        # @param [String] binary The name of the binary to search for
+        # @param [Array<String>] search_paths The search paths, relative to `@android_home`, in which to search for the tools.
+        #        If `android_home` is `nil` or the binary wasn't found in any of the `search_paths`, will fallback to searching in `$PATH`.
+        # @return [String] The absolute path of the tool if found, `nil` if not found.
+        def find_tool_path(binary:, search_paths:)
+          bin_path = unless android_home.nil?
+                       search_paths
+                         .map { |path| File.join(android_home, path, binary) }
+                         .find { |path| File.executable?(path) }
+                     end
 
-          return bin_path unless bin_path.nil? || bin_path.empty? || !File.executable?(bin_path)
+          # If not found in any of the `search_paths`, try to look for it in $PATH
+          bin_path ||= Action.sh('command', '-v', binary, print_command_output: false) { |_| nil }.chomp
 
-          bin_path = search_paths
-                     .map { |path| File.join(android_home, path, binary) }
-                     .find { |path| File.executable?(path) }
+          # Normalize return value to `nil` if it was not found or is not an executable
+          bin_path = nil if bin_path.empty? || !File.executable?(bin_path)
 
+          bin_path
+        end
+
+        # @param [String] binary The name of the binary to search for
+        # @param [Array<String>] search_paths The search paths, relative to `@android_home`, in which to search for the tools.
+        #        If `android_home` is `nil` or the binary wasn't found in any of the `search_paths`, will fallback to searching in `$PATH`.
+        # @return [String] The absolute path of the tool if found.
+        # @raise [FastlaneCore::Interface::FastlaneError] If the tool couldn't be found.
+        def find_tool_path!(binary:, search_paths:)
+          bin_path = find_tool_path(binary: binary, search_paths: search_paths)
           UI.user_error!("Unable to find path for #{binary} in #{search_paths.inspect}. Verify you installed the proper Android tools.") if bin_path.nil?
           bin_path
         end
 
+        def cmdline_tools_search_paths
+          # It appears that depending on the machines and versions of Android SDK, some versions
+          # installed the command line tools in `tools` and not `latest` subdirectory, hence why
+          # we search both (`latest` first, `tools` as fallback) to cover all our bases.
+          [
+            File.join('cmdline-tools', 'latest', 'bin'),
+            File.join('cmdline-tools', 'tools', 'bin'),
+          ]
+        end
+
         def sdkmanager
-          @sdkmanager ||= tool(
+          @sdkmanager ||= find_tool_path!(
             binary: 'sdkmanager',
-            search_paths: [File.join('cmdline-tools', 'latest', 'bin')]
+            search_paths: cmdline_tools_search_paths
           )
         end
 
         def avdmanager
-          @avdmanager ||= tool(
+          @avdmanager ||= find_tool_path!(
             binary: 'avdmanager',
-            search_paths: [File.join('cmdline-tools', 'latest', 'bin')]
+            search_paths: cmdline_tools_search_paths
           )
         end
 
         def emulator
-          @emulator ||= tool(
+          @emulator ||= find_tool_path!(
             binary: 'emulator',
             search_paths: [File.join('emulator')]
           )
         end
 
         def adb
-          @adb ||= tool(
+          @adb ||= find_tool_path!(
             binary: 'adb',
             search_paths: [File.join('platform-tools')]
           )


### PR DESCRIPTION
Adds a helper and multiple actions to help us install Android system-images, create AVDs dynamically, and boot and shutdown Android emulators.

These are used by our `screenshots` lane in https://github.com/wordpress-mobile/WordPress-Android/pull/17096 to automate capture of raw screenshots.

> EDIT: Reworked to improve many error cases (e.g. `sdkmanager` installed via `brew` but `emulator` installed by Android Studio, leading to multiple SDK roots; or giving hints for the `PANIC: Broken AVD` message; etc.) and to support dynamic emulator TCP ports (i.e. non-hardcoded `emulator-5554` serial) to support running multiple emulators in parallel 💪 

## To Test

### Base Scenario

 - Switch to the `tooling/screenshots` branch in WPAndroid (from https://github.com/wordpress-mobile/WordPress-Android/pull/17096)
 - Run `bundle install` to make sure you point the `fastlane/Pluginfile` and `release-toolkit` in that WPAndroid branch to this toolkit's `screenshots/emulator-helper` branch
 - Run `bundle exec fastlane screenshots app:wordpress locale:zh-CN` from the WPAndroid repo
 - Ensure that the screenshot automation finishes and worked (it can take a couple of minutes†…), in particular:
   - Check that the logs mention calling the `android_create_avd` action, installing the system image and creating the AVD successfully, for each case (phone, tablet)
   - Check that the logs mention calling the `android_launch_emulator` action, booting the emulator then waiting for it to finish booting, for each case (phone, tablet)
   - Check that the lane ended up creating the raw screenshots in Chinese for both phone and tablet device sizes successfully.
   - Once the full lane completes and the screenshot UI tests have finished running, check that the raw screenshots images have been generated and pulled from the emulator's sdcard, and are present in the HTML summary file.

> **Note**: _† For some reason it appears that sometimes there's a long pause between when the unit test has started and the app has launched… and when the first click of the UI test scenario finally starts. I'm still not sure what could explain those delays (they are not consistent and are hard to debug), so for the time just don't be surprised that it could sometime be between 2 to 8 minutes between when the app's first screen shows in the emulator and when the UI test finally starts its clickity-clackity work._ 🙃 

### Variants / configurations

Please consider testing all these different setups, to ensure all my error handling of possible scenarios encountered on different user's machines or CI hosts will be covered

 - 💻  Test on both an Intel and an M1 machine
    - especially to validate that the installation of the appropriate Android System Image by `sdkmanager` installs the appropriate system image depending on the architecture of the machine you run those lanes from.
 - 🔧  Test with different ways of installing the Android Command Line Tools
    - Uninstall the command line tools like `sdkmanager` and `avdmanager`, then re-run the `screnshots` lane and confirm that the action errors, with a suggestion to install them
    - Install the Android command line tools [using `brew`](https://formulae.brew.sh/cask/android-commandlinetools) — while you keep `emulator` installed by Android Studio and reachable from terminal (either via your `$PATH` or by having `$ANDROID_SDK_ROOT` defined). Then re-run the `screenshots` lane and confirm that the action errors, suggesting that you might have two different Android SDK locations (brew and AS) and that `sdkmanager` and `emulator` might not be installed in the same one. Then `brew uninstall` the Android command line tools once done.
    - Finally, re-install the Command Line Tools via the Android Studio's "SDK Manager" window, and test the lane again. That time it should succeed.
 - 🏎️  Test to run multiple emulators in parallel
    - Start any AVD from Android Studio that is neither `Pixel_3_API_28` nor `Nexus_9_API_28`. The goal here is to have the TCP port `5554` — which is usually the default one / first picked by `adb` to connect to an emulator — already in use.
    - In one terminal window, run `bundle exec fastlane screenshots app:wordpress locale:ar device:phone`
    - While the first command is still running, run `bundle exec fastlane screenshots app:wordpress locale:ar device:tenInch` in another terminal window
    - Verify that each command found the correct serial (e.g. `emulator-5556` for the phone one and `emulator-5558` for the tablet one — since `emulator-5554` was likely the one already used by the dummy AVD you launched from AS in step one)