### PR TITLE
Release 5.6.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,21 @@ _None_
 
 ### New Features
 
-- Add `android_create_avd`, `android_launch_emulator` and `android_shutdown_emulator` actions. [#409]
+_None_
 
 ### Bug Fixes
 
 _None_
+
+### Internal Changes
+
+_None_
+
+## 5.6.0
+
+### New Features
+
+- Add `android_create_avd`, `android_launch_emulator` and `android_shutdown_emulator` actions. [#409]
 
 ### Internal Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (5.5.0)
+    fastlane-plugin-wpmreleasetoolkit (5.6.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '5.5.0'
+    VERSION = '5.6.0'
   end
 end


### PR DESCRIPTION
New version 5.6.0.

I especially need this new version in order to land https://github.com/wordpress-mobile/WordPress-Android/pull/17096

> PR Author: Be sure to create a GitHub Release and tag once this PR gets merged.