### PR TITLE
Fix milestone due date bug when crossing DST boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _None_
 ### Bug Fixes
 
  - Improve resilience of the `ios_lint_localizations` action to support UTF16 files, and to warn and skip files in XML format when trying to detect duplicate keys on `.strings` files. [#418]
+ - Work around GitHub API bug when creating a new milestone, where their interpretation of the milestone's due date sent during API call is incorrect when we cross DST change dates — leading to milestones created after Oct 30 having due dates set on Sunday instead of Monday. [#419]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -90,7 +90,18 @@ module Fastlane
         comment = "Code freeze: #{newmilestone_duedate.to_datetime.strftime('%B %d, %Y')} App Store submission: #{submission_date.strftime('%B %d, %Y')} Release: #{release_date.strftime('%B %d, %Y')}"
 
         options = {}
-        options[:due_on] = newmilestone_duedate
+        # == Workaround for GitHub API bug ==
+        #
+        # It seems that whatever date we send to the API, GitHub will 'floor' it to the date that seems to be at
+        # 00:00 PST/PDT and then discard the time component of the date we sent.
+        # This means that, when we cross the November DST change date, where the due date of the previous milestone
+        # was e.g. `2022-10-31T07:00:00Z` and `.next_day(14)` returns `2022-11-14T07:00:00Z` and we send that value
+        # for the `due_on` field via the API, GitHub ends up creating a milestone with a due of `2022-11-13T08:00:00Z`
+        # instead, introducing an off-by-one error on that due date.
+        #
+        # This is a bug in the GitHub API, not in our date computation logic.
+        # To solve this, we trick it by forcing the time component of the ISO date we send to be `12:00:00Z`.
+        options[:due_on] = newmilestone_duedate.strftime("%Y-%m-%dT12:00:00Z")
         options[:description] = comment
         github_client().create_milestone(repository, newmilestone_number, options)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -87,7 +87,11 @@ module Fastlane
         days_until_submission = need_submission ? (number_of_days_from_code_freeze_to_release - 3) : newmilestone_duration
         submission_date = newmilestone_duedate.to_datetime.next_day(days_until_submission)
         release_date = newmilestone_duedate.to_datetime.next_day(number_of_days_from_code_freeze_to_release)
-        comment = "Code freeze: #{newmilestone_duedate.to_datetime.strftime('%B %d, %Y')} App Store submission: #{submission_date.strftime('%B %d, %Y')} Release: #{release_date.strftime('%B %d, %Y')}"
+        comment = <<~MILESTONE_DESCRIPTION
+          Code freeze: #{newmilestone_duedate.to_datetime.strftime('%B %d, %Y')}
+          App Store submission: #{submission_date.strftime('%B %d, %Y')}
+          Release: #{release_date.strftime('%B %d, %Y')}
+        MILESTONE_DESCRIPTION
 
         options = {}
         # == Workaround for GitHub API bug ==

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -105,7 +105,7 @@ module Fastlane
         #
         # This is a bug in the GitHub API, not in our date computation logic.
         # To solve this, we trick it by forcing the time component of the ISO date we send to be `12:00:00Z`.
-        options[:due_on] = newmilestone_duedate.strftime("%Y-%m-%dT12:00:00Z")
+        options[:due_on] = newmilestone_duedate.strftime('%Y-%m-%dT12:00:00Z')
         options[:description] = comment
         github_client().create_milestone(repository, newmilestone_number, options)
       end


### PR DESCRIPTION
## What does this solve?

When creating new milestones using the release toolkit (usually during our `finalize_release` lanes in client repos, example [here](https://github.com/wordpress-mobile/WordPress-Android/blob/f8871d9b61f8170b1da0c7b9ed96ef58480ff1b4/fastlane/lanes/release.rb#L161)), each year we encounter an off-by-one error in the dates for the future milestones created for dates after the November DST switch.

For example, each milestone that was created in WPiOS and WPAndroid repos for due dates that were _after_ Oct 30 (DST ending date, at least in Europe) ended up having their due date be on the day before the expected day (and thus had the dates on a Sunday instead of a Monday)

## Why did it happen?

I first thought that this bug was due to some incorrect logic in our Ruby code doing the date computation, so I thought the resolution would be by improving this. But it turns out that it seems to be a bug in the GitHub REST API instead, and not an issue on our side.

Indeed, see those test calls I did using the `pry` REPL, and the resulting due date of the created milestone (that I since deleted after my testing):

<img width="1491" alt="GitHub-API-create_milestone-bug" src="https://user-images.githubusercontent.com/216089/196773734-8429d0bb-ec52-445c-837a-1c5df09693c4.png">
<img width="583" alt="GitHub-Milestone-incorrect-date" src="https://user-images.githubusercontent.com/216089/196773739-ad80bd9b-bed7-4cac-9dc8-da89bbdf588f.png">

Notice how the `due_on:` parameter I passed was `2022-11-14 07:00:00 UTC` (i.e. the correct date we want), but the `due_on` field in the API response describing the created milestone… is `2022-11-13 08:00:00 UTC`, proving the bug is on GitHub's side.

## How was it solved?

Given this, the resolution ended up working around that bug of the GitHub API rather than fixing any date computation code we have in our Ruby code. The workaround consists of using `newmilestone_duedate.strftime("%Y-%m-%dT12:00:00Z")` for the `due_on` field of the API call, to ensure the date passed has a forced time component of 12:00Z

## How to test?

Given that this is a GitHub API bug, there's not much unit testing we could do on our end for this one, hence why this PR didn't add any. The only way to test this is by doing manual e2e testing with the real API 😢, to check that the interpretation that GitHub does on their side of the value sent in the `due_on` field ends up being the date we want it to interpret…  

I've tested this in `pry`, by calling the API using the fixed-up date string, and validated that it solved the issue:
<img width="1614" alt="GitHub-API-create_milestone-workaround" src="https://user-images.githubusercontent.com/216089/196775586-5656d21b-41f5-44bc-85dc-fea8d4698a07.png">


## What's next?

<details><summary>Here are some ideas to improve the <tt>create_new_milestone</tt> action in the future</summary>

To be honest, our API for the [`create_new_milestone` action](https://github.com/wordpress-mobile/release-toolkit/blob/4447e1e49f4b458ad786a2ab8be1d64a420e0941/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb) — and [its associated `create_milestone` method in our GitHub helper](https://github.com/wordpress-mobile/release-toolkit/blob/8e1a31bedb3b4516749ed6f1e76d04dfdec125f0/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb#L83-L96)) starts to suffer the accumulation of legacy, and with option names not always super clear or flexible, and with some values still being hardcoded (like [the `-3` here](https://github.com/wordpress-mobile/release-toolkit/blob/8e1a31bedb3b4516749ed6f1e76d04dfdec125f0/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb#L87)).

Besides, we have no unit tests for this action nor the helper method 😱  Which is even more concerning given that action and helper method is doing a lot of date math, which is infamous for being tricky and full of traps, so something we'd definitively want unit tests for! Ah, legacy, legacy… 😢 

So while I was working on this I took note that imho, the next step for this action should be:

 - Improve the name of the `available_options` on the action, and directly expose the days offsets (e.g. `days_offset_to_submission` instead of just `needs_submission` — to stop hardcoding the `-3` in the helper — and `days_offset_to_release` instead of `number_of_days_from_code_freeze_to_release` — for consistency)
 - A `nil` value for `days_offset_to_submission` would mean no submission (do we still have client apps in our repertoire that don't need submissions those days, tho? 🤷 ), and we could make `milestone_duration` default to the value of `days_offset_to_release` (as usually the release of version N-1 means the start of next version N)
 - Then extract the date computation logic into a dedicated method, that we could easily unit-test. And of course, add a sh*tload of unit tests around all that date math, including across DST boundaries.

Note that this would be a breaking / non-backwards compatible change in the API, requiring us to do a major version bump and to update all the call sites in the client apps' Fastfiles accordingly. But I think it would be worth it, especially for flexibility and clarity of the parameters at call site.
</details>