### PR TITLE
[WIP] Add Unit Tests for Actions that use GithubHelper

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -13,7 +13,7 @@ module Fastlane
         milestone = Fastlane::Helper::GithubHelper.get_milestone(repository, milestone_title)
         UI.user_error!("Milestone #{milestone_title} not found.") if milestone.nil?
 
-        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], state: 'closed')
+        github_helper.update_milestone(repository: repository, number: milestone[:number], options: { state: 'closed' })
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
@@ -7,14 +7,15 @@ module Fastlane
       def self.run(params)
         repository = params[:repository]
         branch_name = params[:branch]
-        branch_prot = {}
 
+        branch_prot = {}
         branch_url = "https://api.github.com/repos/#{repository}/branches/#{branch_name}"
         branch_prot[:restrictions] = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
         branch_prot[:enforce_admins] = nil
         branch_prot[:required_pull_request_reviews] = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
 
-        Fastlane::Helper::GithubHelper.github_client().unprotect_branch(repository, branch_name, branch_prot)
+        github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
+        github_helper.remove_branch_protection(repository: repository, branch: branch_name, options: branch_prot)
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
@@ -7,13 +7,15 @@ module Fastlane
       def self.run(params)
         repository = params[:repository]
         branch_name = params[:branch]
-        branch_prot = {}
 
+        branch_prot = {}
         branch_url = "https://api.github.com/repos/#{repository}/branches/#{branch_name}"
         branch_prot[:restrictions] = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
         branch_prot[:enforce_admins] = nil
         branch_prot[:required_pull_request_reviews] = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
-        Fastlane::Helper::GithubHelper.github_client().protect_branch(repository, branch_name, branch_prot)
+
+        github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
+        github_helper.set_branch_protection(repository: repository, branch: branch_name, options: branch_prot)
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -27,7 +27,7 @@ module Fastlane
         end
 
         UI.message("New milestone: #{mile_title}")
-        Fastlane::Helper::GithubHelper.github_client().update_milestone(repository, milestone[:number], title: mile_title)
+        github_helper.update_milestone(repository: repository, number: milestone[:number], options: { title: mile_title })
       end
 
       def self.is_frozen(milestone)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -172,6 +172,56 @@ module Fastlane
 
         reuse_identifier
       end
+<<<<<<< HEAD
+=======
+
+      # Update a milestone for a repository
+      #
+      # @param [String] repository The repository name (including the organization)
+      # @param [String] number The number of the milestone we want to fetch
+      # @param options [Hash] A customizable set of options.
+      # @option options [String] :title A unique title.
+      # @option options [String] :state
+      # @option options [String] :description A meaningful description
+      # @option options [Time] :due_on Set if the milestone has a due date
+      # @return [Milestone] A single milestone object
+      #
+      def self.update_milestone(repository:, number:, options: {})
+        client.update_milestone(repository, number, options)
+      end
+
+      # Unlock a single branch from a repository
+      #
+      # @param [String] repository The repository name (including the organization)
+      # @param [String] number The branch name
+      #
+      def self.remove_branch_protection(repository:, branch:, options:)
+        client.unprotect_branch(repository, branch_name, options)
+      end
+
+      # Lock a single branch from a repository
+      #
+      # @param [String] repository The repository name (including the organization)
+      # @param [String] number The branch name
+      #
+      def self.set_branch_protection(repository:, branch:, options:)
+        client.protect_branch(repository, branch_name, options)
+      end
+
+      # Creates a GithubToken Fastlane ConfigItem
+      #
+      # @return [FastlaneCore::ConfigItem] The Fastlane ConfigItem for GitHub OAuth access token
+      #
+      def self.github_token_config_item
+        return FastlaneCore::ConfigItem.new(
+          key: :github_token,
+          env_name: 'GITHUB_TOKEN',
+          description: 'The GitHub OAuth access token',
+          optional: false,
+          type: String
+        )
+      end
+>>>>>>> Actions: All Acess to OktoClient is done by GithubHelper
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -172,8 +172,6 @@ module Fastlane
 
         reuse_identifier
       end
-<<<<<<< HEAD
-=======
 
       # Update a milestone for a repository
       #
@@ -221,7 +219,6 @@ module Fastlane
           type: String
         )
       end
->>>>>>> Actions: All Acess to OktoClient is done by GithubHelper
     end
   end
 end

--- a/spec/android_download_file_by_version_spec.rb
+++ b/spec/android_download_file_by_version_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::AndroidDownloadFileByVersionAction do
+  describe 'run' do
+    let(:test_repo) { 'repo-test/project-test' }
+    let(:test_tag) { 'release/10.0' }
+    let(:test_version) { '10.0' }
+    let(:test_file) { 'test-file.xml' }
+    let(:test_folder) { 'test-folder' }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:download_file_from_tag) # .and_return(nil)
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+      allow(Fastlane::Helper::Android::VersionHelper).to receive(:get_library_version_from_gradle_config).and_return(test_version)
+    end
+
+    it 'includes the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the download_file_from_tag' do
+      expect(github_helper).to receive(:download_file_from_tag).with(
+        repository: test_repo,
+        tag: test_tag,
+        file_path: test_file,
+        download_folder: test_folder
+      )
+
+      described_class.run(mock_params)
+    end
+
+    def mock_params
+      {
+        repository: test_repo,
+        github_release_prefix: 'release/',
+        file_path: test_file,
+        download_folder: test_folder,
+        github_token: test_token
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(7)
+    end
+
+    it 'has the ConfigItem library_name' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :library_name))
+    end
+
+    it 'has the ConfigItem import_key' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :import_key))
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem file_path' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :file_path))
+    end
+
+    it 'has the ConfigItem download_folder' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :download_folder))
+    end
+
+    it 'has the ConfigItem github_release_prefix' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_release_prefix))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/close_milestone_action_spec.rb
+++ b/spec/close_milestone_action_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::CloseMilestoneAction do
+  describe 'run' do
+    let(:test_repository) { 'test/test' }
+    let(:test_milestone_title) { 'milestone_title' }
+    let(:test_milestone) { { number: 1234 } }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:update_milestone)
+      allow(github_helper).to receive(:get_milestone).and_return(test_milestone)
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the get_milestone' do
+      expect(github_helper).to receive(:get_milestone).with(test_repository, test_milestone_title)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the update_milestone' do
+      expect(github_helper).to receive(:update_milestone).with(
+        repository: test_repository,
+        number: 1234,
+        options: { state: 'closed' }
+      )
+
+      described_class.run(mock_params)
+    end
+
+    def mock_params
+      {
+        repository: test_repository,
+        milestone: test_milestone_title,
+        github_token: test_token
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(3)
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem milestone' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :milestone))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/comment_on_pr_spec.rb
+++ b/spec/comment_on_pr_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::CommentOnPrAction do
+  describe 'run' do
+    let(:test_project) { 'test/test' }
+    let(:test_pr_number) { 1234 }
+    let(:test_body) { 'Test' }
+    let(:test_reuse_identifier) { 'test-id' }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:comment_on_pr).and_return('')
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the comment_on_pr' do
+      expect(github_helper).to receive(:comment_on_pr).with(
+        project_slug: test_project,
+        pr_number: test_pr_number,
+        body: test_body,
+        reuse_identifier: test_reuse_identifier
+      )
+
+      described_class.run(mock_params)
+    end
+
+    def mock_params
+      {
+        project: test_project,
+        pr_number: test_pr_number,
+        body: test_body,
+        reuse_identifier: test_reuse_identifier,
+        github_token: test_token
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(5)
+    end
+
+    it 'has the ConfigItem reuse_identifier' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :reuse_identifier))
+    end
+
+    it 'has the ConfigItem project' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :project))
+    end
+
+    it 'has the ConfigItem pr_number' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :pr_number))
+    end
+
+    it 'has the ConfigItem body' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :body))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/create_new_milestone_action_spec.rb
+++ b/spec/create_new_milestone_action_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::CreateNewMilestoneAction do
+  describe 'run' do
+    let(:test_repository) { 'test/test' }
+    let(:test_milestone_duration) { 10 }
+    let(:test_freeze_days) { 5 }
+    let(:test_submit_appstore) { false }
+    let(:test_milestone_number) { 1234 }
+    let(:test_milestone_duedate) { '2022-11-01T23:39:01Z'.to_time.utc }
+    let(:test_milestone) { { title: 'milestone', due_on: '2022-10-22T23:39:01Z' } }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:create_milestone)
+      allow(github_helper).to receive(:get_last_milestone).and_return(test_milestone)
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+      allow(Fastlane::Helper::Ios::VersionHelper).to receive(:calc_next_release_version).and_return(test_milestone_number)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the get_last_milestone' do
+      expect(github_helper).to receive(:get_last_milestone).with(test_repository)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the create_milestone' do
+      expect(github_helper).to receive(:create_milestone).with(
+        test_repository,
+        test_milestone_number,
+        test_milestone_duedate,
+        test_milestone_duration,
+        test_freeze_days,
+        test_submit_appstore
+      )
+
+      described_class.run(mock_params)
+    end
+
+    def mock_params(freeze: false)
+      {
+        repository: test_repository,
+        milestone_duration: test_milestone_duration,
+        number_of_days_from_code_freeze_to_release: test_freeze_days,
+        need_appstore_submission: test_submit_appstore,
+        github_token: test_token
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(5)
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem need_appstore_submission' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :need_appstore_submission))
+    end
+
+    it 'has the ConfigItem milestone_duration' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :milestone_duration))
+    end
+
+    it 'has the ConfigItem number_of_days_from_code_freeze_to_release' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :number_of_days_from_code_freeze_to_release))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/create_release_action_spec.rb
+++ b/spec/create_release_action_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::CreateReleaseAction do
+  describe 'run' do
+    let(:test_repo) { 'repo-test/project-test' }
+    let(:test_version) { 'release/10.0' }
+    let(:test_target) { 'dummy_target' }
+    let(:test_prerelease) { false }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:create_release)
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the create_release' do
+      expect(github_helper).to receive(:create_release).with(
+        repository: test_repo,
+        version: test_version,
+        target: test_target,
+        description: '',
+        assets: [],
+        prerelease: test_prerelease
+      )
+
+      described_class.run(mock_params)
+    end
+
+    def mock_params
+      {
+        repository: test_repo,
+        version: test_version,
+        release_assets: [],
+        target: test_target,
+        prerelease: test_prerelease,
+        github_token: test_token
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(7)
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem version' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :version))
+    end
+
+    it 'has the ConfigItem target' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :target))
+    end
+
+    it 'has the ConfigItem release_notes_file_path' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :release_notes_file_path))
+    end
+
+    it 'has the ConfigItem release_assets' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :release_assets))
+    end
+
+    it 'has the ConfigItem prerelease' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :prerelease))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/get_prs_list_action_spec.rb
+++ b/spec/get_prs_list_action_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::GetPrsListAction do
+  describe 'run' do
+    let(:test_repo) { 'repo-test/project-test' }
+    let(:test_milestone) { 'release/10.0' }
+    let(:file_like_object) { double('file like object') }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(File).to receive(:open).and_return(file_like_object)
+      allow(github_helper).to receive(:get_prs_for_milestone).and_return([])
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the get_prs_for_milestone' do
+      expect(github_helper).to receive(:get_prs_for_milestone).with(test_repo, test_milestone)
+      described_class.run(mock_params)
+    end
+
+    def mock_params
+      {
+        repository: test_repo,
+        milestone: test_milestone,
+        report_path: '',
+        github_token: test_token
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(4)
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem report_path' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :report_path))
+    end
+
+    it 'has the ConfigItem milestone' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :milestone))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/removebranchprotection_action_spec.rb
+++ b/spec/removebranchprotection_action_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::RemovebranchprotectionAction do
+  describe 'run' do
+    let(:test_repository) { 'test/test' }
+    let(:test_branch) { 'test_branch' }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:remove_branch_protection)
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the remove_branch_protection' do
+      expect(github_helper).to receive(:remove_branch_protection).with(
+        repository: test_repository,
+        branch: test_branch,
+        options: branch_options
+      )
+
+      described_class.run(mock_params)
+    end
+
+    def mock_params
+      {
+        repository: test_repository,
+        branch: test_branch,
+        github_token: test_token
+      }
+    end
+
+    def branch_options
+      {
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false,
+          url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/required_pull_request_reviews'
+        },
+        restrictions: {
+          teams: [],
+          teams_url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/restrictions/teams',
+          url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/restrictions',
+          users: [],
+          users_url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/restrictions/users'
+        }
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(3)
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem branch' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :branch))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/setbranchprotection_action_spec.rb
+++ b/spec/setbranchprotection_action_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::SetbranchprotectionAction do
+  describe 'run' do
+    let(:test_repository) { 'test/test' }
+    let(:test_branch) { 'test_branch' }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:set_branch_protection)
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the set_branch_protection' do
+      expect(github_helper).to receive(:set_branch_protection).with(
+        repository: test_repository,
+        branch: test_branch,
+        options: branch_options
+      )
+
+      described_class.run(mock_params)
+    end
+
+    def mock_params
+      {
+        repository: test_repository,
+        branch: test_branch,
+        github_token: test_token
+      }
+    end
+
+    def branch_options
+      {
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false,
+          url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/required_pull_request_reviews'
+        },
+        restrictions: {
+          teams: [],
+          teams_url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/restrictions/teams',
+          url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/restrictions',
+          users: [],
+          users_url: 'https://api.github.com/repos/test/test/branches/test_branch/protection/restrictions/users'
+        }
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(3)
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem branch' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :branch))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end

--- a/spec/setfrozentag_action_spec.rb
+++ b/spec/setfrozentag_action_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::SetfrozentagAction do
+  describe 'run' do
+    let(:test_repository) { 'test/test' }
+    let(:test_milestone_title) { 'milestone_title' }
+    let(:test_milestone) { { title: 'milestone', number: 1234 } }
+    let(:test_token) { 'GITHUB_TOKEN' }
+    let(:github_helper) { class_double(Fastlane::Helper::GithubHelper) }
+
+    before do
+      allow(github_helper).to receive(:update_milestone)
+      allow(github_helper).to receive(:get_milestone).and_return(test_milestone)
+      allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+    end
+
+    it 'sets the github_token' do
+      expect(Fastlane::Helper::GithubHelper).to receive(:new).with(github_token: test_token)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the get_milestone' do
+      expect(github_helper).to receive(:get_milestone).with(test_repository, test_milestone_title)
+      described_class.run(mock_params)
+    end
+
+    it 'calls the update_milestone' do
+      expect(github_helper).to receive(:update_milestone).with(
+        repository: test_repository,
+        number: 1234,
+        options: { title: test_milestone_title }
+      )
+
+      described_class.run(mock_params)
+    end
+
+    it 'calls the update_milestone with freeze' do
+      expect(github_helper).to receive(:update_milestone).with(
+        repository: test_repository,
+        number: 1234,
+        options: { title: 'milestone ❄️' }
+      )
+
+      described_class.run(mock_params(freeze: true))
+    end
+
+    def mock_params(freeze: false)
+      {
+        repository: test_repository,
+        milestone: test_milestone_title,
+        freeze: freeze,
+        github_token: test_token
+      }
+    end
+  end
+
+  describe 'available_options' do
+    it 'has the correct length' do
+      expect(described_class.available_options.length).to be(4)
+    end
+
+    it 'has the ConfigItem repository' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :repository))
+    end
+
+    it 'has the ConfigItem milestone' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :milestone))
+    end
+
+    it 'has the ConfigItem freeze' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :freeze))
+    end
+
+    it 'has the ConfigItem github_token' do
+      expect(described_class.available_options).to include(an_object_having_attributes(key: :github_token))
+    end
+  end
+end


### PR DESCRIPTION
## Dependency

This PR Depends on [PR#420](https://github.com/wordpress-mobile/release-toolkit/pull/420) 

# What does this solve?

As some of the actions that were changed on the [PR#420](https://github.com/wordpress-mobile/release-toolkit/pull/420) didn't have unit tests to check the config items and the use now mandatory `GITHUB_TOKEN`, were created new UnitTests to cover those new cases and assure that the original behavior of them are not changing.