### PR TITLE
Add Hash-splat operator to GithubHelper methods

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -15,7 +15,7 @@ module Fastlane
 
         UI.user_error!("Milestone #{milestone_title} not found.") if milestone.nil?
 
-        github_helper.update_milestone(repository: repository, number: milestone[:number], options: { state: 'closed' })
+        github_helper.update_milestone(repository: repository, number: milestone[:number], state: 'closed')
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/removebranchprotection_action.rb
@@ -8,14 +8,18 @@ module Fastlane
         repository = params[:repository]
         branch_name = params[:branch]
 
-        branch_prot = {}
         branch_url = "https://api.github.com/repos/#{repository}/branches/#{branch_name}"
-        branch_prot[:restrictions] = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
-        branch_prot[:enforce_admins] = nil
-        branch_prot[:required_pull_request_reviews] = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
+        restrictions = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
+        required_pull_request_reviews = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
 
         github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
-        github_helper.remove_branch_protection(repository: repository, branch: branch_name, options: branch_prot)
+        github_helper.remove_branch_protection(
+          repository: repository,
+          branch: branch_name,
+          restrictions: restrictions,
+          enforce_admins: nil,
+          required_pull_request_reviews: required_pull_request_reviews
+        )
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setbranchprotection_action.rb
@@ -8,14 +8,18 @@ module Fastlane
         repository = params[:repository]
         branch_name = params[:branch]
 
-        branch_prot = {}
         branch_url = "https://api.github.com/repos/#{repository}/branches/#{branch_name}"
-        branch_prot[:restrictions] = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
-        branch_prot[:enforce_admins] = nil
-        branch_prot[:required_pull_request_reviews] = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
+        restrictions = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
+        required_pull_request_reviews = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
 
         github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
-        github_helper.set_branch_protection(repository: repository, branch: branch_name, options: branch_prot)
+        github_helper.set_branch_protection(
+          repository: repository,
+          branch: branch_name,
+          restrictions: restrictions,
+          enforce_admins: nil,
+          required_pull_request_reviews: required_pull_request_reviews
+        )
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -29,7 +29,7 @@ module Fastlane
         end
 
         UI.message("New milestone: #{mile_title}")
-        github_helper.update_milestone(repository: repository, number: milestone[:number], options: { title: mile_title })
+        github_helper.update_milestone(repository: repository, number: milestone[:number], title: mile_title)
       end
 
       def self.is_frozen(milestone)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -189,7 +189,7 @@ module Fastlane
       # @return [Milestone] A single milestone object
       # @see http://developer.github.com/v3/issues/milestones/#update-a-milestone
       #
-      def update_milestone(repository:, number:, options:)
+      def update_milestone(repository:, number:, **options)
         client.update_milestone(repository, number, options)
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -211,7 +211,7 @@ module Fastlane
       # @param options [Hash] A customizable set of options.
       # @see https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
       #
-      def set_branch_protection(repository:, branch:, options:)
+      def set_branch_protection(repository:, branch:, **options)
         client.protect_branch(repository, branch, options)
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -200,7 +200,7 @@ module Fastlane
       # @param [Hash] options A customizable set of options.
       # @see https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
       #
-      def remove_branch_protection(repository:, branch:, options:)
+      def remove_branch_protection(repository:, branch:, **options)
         client.unprotect_branch(repository, branch, options)
       end
 


### PR DESCRIPTION
# What does this solve?

As [discussed here](https://github.com/wordpress-mobile/release-toolkit/pull/420#discussion_r1012086322) at PR #420. This PR aims to add the hash conversion operator (aka **) to the methods on GithubHelper that use the named param `options:` in their signature. With this, we hope to improve the legibility and make those methods calls cleaner.

# Good, but what is this Hash Operator?

This operator will allow the call site of those methods to just provide the `options:` variable/parameter directly as if they were keywords (kinda "flattening the Hash into keyword parameters") without having to wrap those options into `{ … } ` curly braces to make them a Hash. So the call site would look like this: 

### Instead of
```ruby
github_helper.update_milestone(repository: repository, number: milestone[:number], options: { title: mile_title })
```

### We'd have:
``` ruby
# Inside `update_milestone`'s implementation, the variable/parameter `options` would be a Hash equal to `{ title: mile_title }`
github_helper.update_milestone(repository: repository, number: milestone[:number], title: mile_title)
```