### PR TITLE
Add Unit tests for milestone actions

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -11,6 +11,10 @@ module Fastlane
 
         github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
         last_stone = github_helper.get_last_milestone(repository)
+
+        UI.user_error!('No milestone found on the repository.') if last_stone.nil?
+        UI.user_error!("Milestone #{last_stone[:title]} has no due date.") if last_stone[:due_on].nil?
+
         UI.message("Last detected milestone: #{last_stone[:title]} due on #{last_stone[:due_on]}.")
         milestone_duedate = last_stone[:due_on]
         milestone_duration = params[:milestone_duration]
@@ -49,19 +53,19 @@ module Fastlane
                                        env_name: 'GHHELPER_NEED_APPSTORE_SUBMISSION',
                                        description: 'True if the app needs to be submitted',
                                        optional: true,
-                                       is_string: false,
+                                       type: Boolean,
                                        default_value: false),
           FastlaneCore::ConfigItem.new(key: :milestone_duration,
                                        env_name: 'GHHELPER_MILESTONE_DURATION',
                                        description: 'Milestone duration in number of days',
                                        optional: true,
-                                       is_string: false,
+                                       type: Integer,
                                        default_value: 14),
           FastlaneCore::ConfigItem.new(key: :number_of_days_from_code_freeze_to_release,
                                        env_name: 'GHHELPER_NUMBER_OF_DAYS_FROM_CODE_FREEZE_TO_RELEASE',
                                        description: 'Number of days from code freeze to release',
                                        optional: true,
-                                       is_string: false,
+                                       type: Integer,
                                        default_value: 14),
           Fastlane::Helper::GithubHelper.github_token_config_item,
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -71,7 +71,7 @@ module Fastlane
                                        description: 'The GitHub milestone',
                                        optional: false,
                                        default_value: true,
-                                       is_string: false),
+                                       type: Boolean),
           Fastlane::Helper::GithubHelper.github_token_config_item,
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/setfrozentag_action.rb
@@ -15,7 +15,6 @@ module Fastlane
         UI.user_error!("Milestone #{milestone_title} not found.") if milestone.nil?
 
         mile_title = milestone[:title]
-        puts freeze
         if freeze
           # Check if the state needs changes
           if is_frozen(milestone)

--- a/spec/close_milestone_action_spec.rb
+++ b/spec/close_milestone_action_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::CloseMilestoneAction do
+  describe 'initialize' do
+    let(:test_token) { 'Test-GithubToken-1234' }
+    let(:mock_params) do
+      {
+        repository: 'test-repository',
+        milestone: '10'
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [{ title: '10.1' }],
+        update_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    before do
+      ENV['GITHUB_TOKEN'] = nil
+      mock_params[:github_token] = nil
+      allow(Octokit::Client).to receive(:new).and_return(client)
+    end
+
+    it 'properly passes the environment variable `GITHUB_TOKEN` all the way to Octokit::Client' do
+      ENV['GITHUB_TOKEN'] = test_token
+      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+      run_described_fastlane_action(mock_params)
+    end
+
+    it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
+      mock_params[:github_token] = test_token
+      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+      run_described_fastlane_action(mock_params)
+    end
+
+    it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` enviroment variable if both are present' do
+      ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
+      mock_params[:github_token] = test_token
+      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+      run_described_fastlane_action(mock_params)
+    end
+
+    it 'prints an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
+      expect { run_described_fastlane_action(mock_params) }.to raise_error(FastlaneCore::Interface::FastlaneError)
+    end
+  end
+
+  describe 'get_milestone' do
+    let(:test_repository) { 'test-repository' }
+    let(:test_milestone) { '10' }
+    let(:mock_params) do
+      {
+        repository: test_repository,
+        milestone: test_milestone,
+        github_token: 'Test-GithubToken-1234'
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [{ title: '10.1' }],
+        update_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    it 'properly passes the repository all the way down to the Octokit::Client to list the milestones' do
+      allow(Octokit::Client).to receive(:new).and_return(client)
+      expect(client).to receive(:list_milestones).with(test_repository)
+      run_described_fastlane_action(mock_params)
+    end
+  end
+
+  describe 'update_milestone' do
+    let(:test_repository) { 'test-repository' }
+    let(:test_milestone_number) { '1234' }
+    let(:mock_params) do
+      {
+        repository: test_repository,
+        milestone: '10',
+        github_token: 'Test-GithubToken-1234'
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [{ title: '10.1', number: test_milestone_number }],
+        update_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    it 'properly passes the parameters all the way down to Octokit::Client' do
+      allow(Octokit::Client).to receive(:new).and_return(client)
+      expect(client).to receive(:update_milestone).with(test_repository, test_milestone_number, { state: 'closed' })
+      run_described_fastlane_action(mock_params)
+    end
+  end
+end

--- a/spec/close_milestone_action_spec.rb
+++ b/spec/close_milestone_action_spec.rb
@@ -1,105 +1,86 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::CloseMilestoneAction do
-  describe 'initialize' do
-    let(:test_token) { 'Test-GithubToken-1234' }
-    let(:mock_params) do
-      {
-        repository: 'test-repository',
-        milestone: '10'
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [{ title: '10.1' }],
-        update_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
+  let(:test_repository) { 'test-repository' }
+  let(:test_token) { 'Test-GithubToken-1234' }
+  let(:test_milestone) do
+    { title: '10.1', number: '1234' }
+  end
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      list_milestones: [test_milestone],
+      update_milestone: nil,
+      user: instance_double('User', name: 'test'),
+      'auto_paginate=': nil
+    )
+  end
 
-    before do
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+  end
+
+  it 'properly passes the environment variable `GITHUB_TOKEN` to Octokit::Client' do
+    ENV['GITHUB_TOKEN'] = test_token
+    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+    run_action_without_key(:github_token)
+  end
+
+  it 'properly passes the parameter `:github_token` to Octokit::Client' do
+    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+    run_described_fastlane_action(default_params)
+  end
+
+  it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` environment variable if both are present' do
+    ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
+    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+    run_described_fastlane_action(default_params)
+  end
+
+  it 'properly passes the repository and milestone to Octokit::Client to update the milestone as closed' do
+    expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], state: 'closed')
+    run_described_fastlane_action(default_params)
+  end
+
+  it 'raises an error when the milestone is not found or does not exist' do
+    allow(client).to receive(:list_milestones).and_return([])
+    expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Milestone 10.1 not found.')
+  end
+
+  describe 'Calling the Action validates input' do
+    it 'raises an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
       ENV['GITHUB_TOKEN'] = nil
-      mock_params[:github_token] = nil
-      allow(Octokit::Client).to receive(:new).and_return(client)
+      expect { run_action_without_key(:github_token) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'github_token'")
     end
 
-    it 'properly passes the environment variable `GITHUB_TOKEN` all the way to Octokit::Client' do
-      ENV['GITHUB_TOKEN'] = test_token
-      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-      run_described_fastlane_action(mock_params)
+    it 'raises an error if no `GHHELPER_REPOSITORY` environment variable nor parameter `:repository` is present' do
+      expect { run_action_without_key(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
     end
 
-    it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
-      mock_params[:github_token] = test_token
-      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-      run_described_fastlane_action(mock_params)
+    it 'raises an error if no `GHHELPER_MILESTONE` environment variable nor parameter `:milestone` is present' do
+      expect { run_action_without_key(:milestone) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'milestone'")
     end
 
-    it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` enviroment variable if both are present' do
-      ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
-      mock_params[:github_token] = test_token
-      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-      run_described_fastlane_action(mock_params)
-    end
-
-    it 'prints an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
-      expect { run_described_fastlane_action(mock_params) }.to raise_error(FastlaneCore::Interface::FastlaneError)
+    it 'raises an error if `milestone:` parameter is passed as Integer' do
+      expect { run_action_with(:milestone, 10) }.to raise_error "'milestone' value must be a String! Found Integer instead."
     end
   end
 
-  describe 'get_milestone' do
-    let(:test_repository) { 'test-repository' }
-    let(:test_milestone) { '10' }
-    let(:mock_params) do
-      {
-        repository: test_repository,
-        milestone: test_milestone,
-        github_token: 'Test-GithubToken-1234'
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [{ title: '10.1' }],
-        update_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
-
-    it 'properly passes the repository all the way down to the Octokit::Client to list the milestones' do
-      allow(Octokit::Client).to receive(:new).and_return(client)
-      expect(client).to receive(:list_milestones).with(test_repository)
-      run_described_fastlane_action(mock_params)
-    end
+  def run_action_without_key(key)
+    run_described_fastlane_action(default_params.except(key))
   end
 
-  describe 'update_milestone' do
-    let(:test_repository) { 'test-repository' }
-    let(:test_milestone_number) { '1234' }
-    let(:mock_params) do
-      {
-        repository: test_repository,
-        milestone: '10',
-        github_token: 'Test-GithubToken-1234'
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [{ title: '10.1', number: test_milestone_number }],
-        update_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
+  def run_action_with(key, value)
+    values = default_params
+    values[key] = value
+    run_described_fastlane_action(values)
+  end
 
-    it 'properly passes the parameters all the way down to Octokit::Client' do
-      allow(Octokit::Client).to receive(:new).and_return(client)
-      expect(client).to receive(:update_milestone).with(test_repository, test_milestone_number, { state: 'closed' })
-      run_described_fastlane_action(mock_params)
-    end
+  def default_params
+    {
+      repository: test_repository,
+      milestone: test_milestone[:title],
+      github_token: test_token
+    }
   end
 end

--- a/spec/close_milestone_action_spec.rb
+++ b/spec/close_milestone_action_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
+require 'shared_examples_for_actions_with_github_token'
 
 describe Fastlane::Actions::CloseMilestoneAction do
   let(:test_repository) { 'test-repository' }
   let(:test_token) { 'Test-GithubToken-1234' }
   let(:test_milestone) do
     { title: '10.1', number: '1234' }
+  end
+  let(:default_params) do
+    { repository: test_repository,
+      milestone: test_milestone[:title],
+      github_token: 'Test-GithubToken-1234' }
   end
   let(:client) do
     instance_double(
@@ -20,24 +26,7 @@ describe Fastlane::Actions::CloseMilestoneAction do
     allow(Octokit::Client).to receive(:new).and_return(client)
   end
 
-  it 'properly passes the environment variable `GITHUB_TOKEN` to Octokit::Client' do
-    ENV['GITHUB_TOKEN'] = test_token
-    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-    run_action_without_key(:github_token)
-  end
-
-  it 'properly passes the parameter `:github_token` to Octokit::Client' do
-    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-    run_described_fastlane_action(default_params)
-  end
-
-  it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` environment variable if both are present' do
-    ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
-    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-    run_described_fastlane_action(default_params)
-  end
-
-  it 'properly passes the repository and milestone to Octokit::Client to update the milestone as closed' do
+  it 'closes the expected milestone on the expected repository' do
     expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], state: 'closed')
     run_described_fastlane_action(default_params)
   end
@@ -47,40 +36,30 @@ describe Fastlane::Actions::CloseMilestoneAction do
     expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Milestone 10.1 not found.')
   end
 
-  describe 'Calling the Action validates input' do
-    it 'raises an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
-      ENV['GITHUB_TOKEN'] = nil
-      expect { run_action_without_key(:github_token) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'github_token'")
-    end
+  describe 'initialize' do
+    include_examples 'github_token_initialization'
+  end
 
+  describe 'calling the action validates input' do
     it 'raises an error if no `GHHELPER_REPOSITORY` environment variable nor parameter `:repository` is present' do
-      expect { run_action_without_key(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
+      expect { run_action_without(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
     end
 
     it 'raises an error if no `GHHELPER_MILESTONE` environment variable nor parameter `:milestone` is present' do
-      expect { run_action_without_key(:milestone) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'milestone'")
+      expect { run_action_without(:milestone) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'milestone'")
     end
 
     it 'raises an error if `milestone:` parameter is passed as Integer' do
-      expect { run_action_with(:milestone, 10) }.to raise_error "'milestone' value must be a String! Found Integer instead."
+      expect { run_action_with(milestone: 10) }.to raise_error "'milestone' value must be a String! Found Integer instead."
     end
   end
 
-  def run_action_without_key(key)
+  def run_action_with(**keys_and_values)
+    params = default_params.merge(keys_and_values)
+    run_described_fastlane_action(params)
+  end
+
+  def run_action_without(key)
     run_described_fastlane_action(default_params.except(key))
-  end
-
-  def run_action_with(key, value)
-    values = default_params
-    values[key] = value
-    run_described_fastlane_action(values)
-  end
-
-  def default_params
-    {
-      repository: test_repository,
-      milestone: test_milestone[:title],
-      github_token: test_token
-    }
   end
 end

--- a/spec/create_new_milestone_action_spec.rb
+++ b/spec/create_new_milestone_action_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::CreateNewMilestoneAction do
+  describe 'initialize' do
+    let(:test_token) { 'Test-GithubToken-1234' }
+    let(:test_milestone) { { title: '10.1', due_on: '2022-10-31T07:00:00Z' } }
+    let(:mock_params) do
+      {
+        repository: 'test-repository',
+        need_appstore_submission: false
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [test_milestone],
+        create_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    before do
+      ENV['GITHUB_TOKEN'] = nil
+      mock_params[:github_token] = nil
+      allow(Octokit::Client).to receive(:new).and_return(client)
+    end
+
+    context 'with github_token' do
+      it 'properly passes the environment variable `GITHUB_TOKEN` all the way to Octokit::Client' do
+        ENV['GITHUB_TOKEN'] = test_token
+        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+        run_described_fastlane_action(mock_params)
+      end
+
+      it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
+        mock_params[:github_token] = test_token
+        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+        run_described_fastlane_action(mock_params)
+      end
+
+      it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` enviroment variable if both are present' do
+        ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
+        mock_params[:github_token] = test_token
+        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+        run_described_fastlane_action(mock_params)
+      end
+
+      it 'prints an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
+        expect { run_described_fastlane_action(mock_params) }.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+    end
+
+    context 'with default parameters' do
+      let(:glithub_helper) do
+        instance_double(
+          Fastlane::Helper::GithubHelper,
+          get_last_milestone: test_milestone,
+          create_milestone: nil
+        )
+      end
+
+      before do
+        mock_params[:github_token] = test_token
+        allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(glithub_helper)
+      end
+
+      it 'uses default value when neither `GHHELPER_NUMBER_OF_DAYS_FROM_CODE_FREEZE_TO_RELEASE` environment variable nor parameter `:number_of_days_from_code_freeze_to_release` is present' do
+        default_code_freeze_days = 14
+        mock_params[:number_of_days_from_code_freeze_to_release] = nil
+        ENV['GHHELPER_NUMBER_OF_DAYS_FROM_CODE_FREEZE_TO_RELEASE'] = nil
+        expect(glithub_helper).to receive(:create_milestone).with(
+          anything,
+          anything,
+          anything,
+          anything,
+          default_code_freeze_days,
+          anything
+        )
+        run_described_fastlane_action(mock_params)
+      end
+
+      it 'uses default value when neither `GHHELPER_MILESTONE_DURATION` environment variable nor parameter `:milestone_duration` is present' do
+        default_milestone_duration = 14
+        mock_params[:milestone_duration] = nil
+        ENV['GHHELPER_MILESTONE_DURATION'] = nil
+        expect(glithub_helper).to receive(:create_milestone).with(
+          anything,
+          anything,
+          anything,
+          default_milestone_duration,
+          anything,
+          anything
+        )
+        run_described_fastlane_action(mock_params)
+      end
+    end
+  end
+
+  describe 'get_last_milestone' do
+    let(:test_repository) { 'test-repository' }
+    let(:test_milestone) { { title: '10.1', due_on: '2022-10-31T07:00:00Z' } }
+    let(:mock_params) do
+      {
+        repository: test_repository,
+        need_appstore_submission: false,
+        github_token: 'Test-GithubToken-1234'
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [test_milestone],
+        create_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    it 'properly passes the repository all the way down to the Octokit::Client to list the existing milestones' do
+      allow(Octokit::Client).to receive(:new).and_return(client)
+      expect(client).to receive(:list_milestones).with(test_repository, { state: 'open' })
+      run_described_fastlane_action(mock_params)
+    end
+  end
+
+  describe 'create_milestone' do
+    let(:test_repository) { 'test-repository' }
+    let(:test_milestone_number) { '10.2' }
+    let(:test_milestone) { { title: '10.1', due_on: '2022-10-31T07:00:00Z' } }
+    let(:mock_params) do
+      {
+        repository: test_repository,
+        need_appstore_submission: false,
+        github_token: 'Test-GithubToken-1234'
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [test_milestone],
+        create_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    it 'properly passes the parameters all the way down to the Octokit::Client' do
+      comment = "Code freeze: November 14, 2022\nApp Store submission: November 28, 2022\nRelease: November 28, 2022\n"
+      options = { due_on: '2022-11-14T12:00:00Z', description: comment }
+      allow(Octokit::Client).to receive(:new).and_return(client)
+      expect(client).to receive(:create_milestone).with(test_repository, test_milestone_number, options)
+      run_described_fastlane_action(mock_params)
+    end
+  end
+end

--- a/spec/create_new_milestone_action_spec.rb
+++ b/spec/create_new_milestone_action_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
+require 'shared_examples_for_actions_with_github_token'
 
 describe Fastlane::Actions::CreateNewMilestoneAction do
   let(:test_repository) { 'test-repository' }
-  let(:test_token) { 'Test-GithubToken-1234' }
   let(:test_milestone) do
     { title: '10.1', number: '1234', due_on: '2022-10-31T07:00:00Z' }
   end
@@ -12,6 +12,11 @@ describe Fastlane::Actions::CreateNewMilestoneAction do
       { title: '10.3', number: '4567', due_on: '2022-11-02T15:00:00Z' },
       { title: '10.4', number: '7890', due_on: '2022-11-04T23:59:00Z' },
     ]
+  end
+  let(:default_params) do
+    { repository: test_repository,
+      need_appstore_submission: false,
+      github_token: 'Test-GithubToken-1234' }
   end
   let(:client) do
     instance_double(
@@ -27,54 +32,41 @@ describe Fastlane::Actions::CreateNewMilestoneAction do
     allow(Octokit::Client).to receive(:new).and_return(client)
   end
 
-  it 'computes the correct due date and milestone description' do
-    comment = "Code freeze: November 14, 2022\nApp Store submission: November 28, 2022\nRelease: November 28, 2022\n"
-    expect(client).to receive(:create_milestone).with(test_repository, '10.2', due_on: '2022-11-14T12:00:00Z', description: comment)
-    run_described_fastlane_action(default_params)
-  end
+  describe 'date computation is correct' do
+    it 'computes the correct due date and milestone description' do
+      comment = "Code freeze: November 14, 2022\nApp Store submission: November 28, 2022\nRelease: November 28, 2022\n"
+      expect(client).to receive(:create_milestone).with(test_repository, '10.2', due_on: '2022-11-14T12:00:00Z', description: comment)
+      run_described_fastlane_action(default_params)
+    end
 
-  it 'removes 3 days from the AppStore submission date when `:need_appstore_submission` is true' do
-    comment = "Code freeze: November 14, 2022\nApp Store submission: November 25, 2022\nRelease: November 28, 2022\n"
-    expect(client).to receive(:create_milestone).with(test_repository, '10.2', due_on: '2022-11-14T12:00:00Z', description: comment)
-    run_action_with(:need_appstore_submission, true)
-  end
+    it 'removes 3 days from the AppStore submission date when `:need_appstore_submission` is true' do
+      comment = "Code freeze: November 14, 2022\nApp Store submission: November 25, 2022\nRelease: November 28, 2022\n"
+      expect(client).to receive(:create_milestone).with(test_repository, '10.2', due_on: '2022-11-14T12:00:00Z', description: comment)
+      run_action_with(need_appstore_submission: true)
+    end
 
-  it 'uses the most recent milestone date to calculate the due date and version of new milestone' do
-    comment = "Code freeze: November 18, 2022\nApp Store submission: December 02, 2022\nRelease: December 02, 2022\n"
-    allow(client).to receive(:list_milestones).and_return(milestone_list)
-    expect(client).to receive(:create_milestone).with(test_repository, '10.5', due_on: '2022-11-18T12:00:00Z', description: comment)
-    run_described_fastlane_action(default_params)
-  end
+    it 'uses the most recent milestone date to calculate the due date and version of new milestone' do
+      comment = "Code freeze: November 18, 2022\nApp Store submission: December 02, 2022\nRelease: December 02, 2022\n"
+      allow(client).to receive(:list_milestones).and_return(milestone_list)
+      expect(client).to receive(:create_milestone).with(test_repository, '10.5', due_on: '2022-11-18T12:00:00Z', description: comment)
+      run_described_fastlane_action(default_params)
+    end
 
-  it 'raises an error when the due date of milestone does not exists' do
-    allow(client).to receive(:list_milestones).and_return([{ title: '10.1', number: '1234' }])
-    expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Milestone 10.1 has no due date.')
-  end
+    context 'when last milestone cannot be used' do
+      it 'raises an error when the due date of milestone does not exists' do
+        allow(client).to receive(:list_milestones).and_return([{ title: '10.1', number: '1234' }])
+        expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Milestone 10.1 has no due date.')
+      end
 
-  it 'raises an error when the milestone is not found or does not exist on the repository' do
-    allow(client).to receive(:list_milestones).and_return([])
-    expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'No milestone found on the repository.')
+      it 'raises an error when the milestone is not found or does not exist on the repository' do
+        allow(client).to receive(:list_milestones).and_return([])
+        expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'No milestone found on the repository.')
+      end
+    end
   end
 
   describe 'initialize' do
-    context 'with github_token' do
-      it 'properly passes the environment variable `GITHUB_TOKEN` to Octokit::Client' do
-        ENV['GITHUB_TOKEN'] = test_token
-        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_action_without_key(:github_token)
-      end
-
-      it 'properly passes the parameter `:github_token` to Octokit::Client' do
-        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(default_params)
-      end
-
-      it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` environment variable if both are present' do
-        ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
-        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(default_params)
-      end
-    end
+    include_examples 'github_token_initialization'
 
     context 'when using default parameters' do
       let(:github_helper) do
@@ -118,43 +110,29 @@ describe Fastlane::Actions::CreateNewMilestoneAction do
   end
 
   describe 'calling the action validates input' do
-    it 'raises an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
-      ENV['GITHUB_TOKEN'] = nil
-      expect { run_action_without_key(:github_token) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'github_token'")
-    end
-
     it 'raises an error if no `GHHELPER_REPOSITORY` environment variable nor parameter `:repository` is present' do
-      expect { run_action_without_key(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
+      expect { run_action_without(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
     end
 
     it 'raises an error if `need_appstore_submission:` parameter is passed as String' do
-      expect { run_action_with(:need_appstore_submission, 'foo') }.to raise_error "'need_appstore_submission' value must be either `true` or `false`! Found String instead."
+      expect { run_action_with(need_appstore_submission: 'foo') }.to raise_error "'need_appstore_submission' value must be either `true` or `false`! Found String instead."
     end
 
     it 'raises an error if `milestone_duration:` parameter is passed as String' do
-      expect { run_action_with(:milestone_duration, 'foo') }.to raise_error "'milestone_duration' value must be a Integer! Found String instead."
+      expect { run_action_with(milestone_duration: 'foo') }.to raise_error "'milestone_duration' value must be a Integer! Found String instead."
     end
 
     it 'raises an error if `number_of_days_from_code_freeze_to_release:` parameter is passed as String' do
-      expect { run_action_with(:number_of_days_from_code_freeze_to_release, 'foo') }.to raise_error "'number_of_days_from_code_freeze_to_release' value must be a Integer! Found String instead."
+      expect { run_action_with(number_of_days_from_code_freeze_to_release: 'foo') }.to raise_error "'number_of_days_from_code_freeze_to_release' value must be a Integer! Found String instead."
     end
   end
 
-  def run_action_without_key(key)
+  def run_action_with(**keys_and_values)
+    params = default_params.merge(keys_and_values)
+    run_described_fastlane_action(params)
+  end
+
+  def run_action_without(key)
     run_described_fastlane_action(default_params.except(key))
-  end
-
-  def run_action_with(key, value)
-    values = default_params
-    values[key] = value
-    run_described_fastlane_action(values)
-  end
-
-  def default_params
-    {
-      repository: test_repository,
-      need_appstore_submission: false,
-      github_token: test_token
-    }
   end
 end

--- a/spec/create_new_milestone_action_spec.rb
+++ b/spec/create_new_milestone_action_spec.rb
@@ -1,58 +1,83 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::CreateNewMilestoneAction do
+  let(:test_repository) { 'test-repository' }
+  let(:test_token) { 'Test-GithubToken-1234' }
+  let(:test_milestone) do
+    { title: '10.1', number: '1234', due_on: '2022-10-31T07:00:00Z' }
+  end
+  let(:milestone_list) do
+    [
+      { title: '10.2', number: '1234', due_on: '2022-10-31T12:00:00Z' },
+      { title: '10.3', number: '4567', due_on: '2022-11-02T15:00:00Z' },
+      { title: '10.4', number: '7890', due_on: '2022-11-04T23:59:00Z' },
+    ]
+  end
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      list_milestones: [test_milestone],
+      create_milestone: nil,
+      user: instance_double('User', name: 'test'),
+      'auto_paginate=': nil
+    )
+  end
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+  end
+
+  it 'computes the correct due date and milestone description' do
+    comment = "Code freeze: November 14, 2022\nApp Store submission: November 28, 2022\nRelease: November 28, 2022\n"
+    expect(client).to receive(:create_milestone).with(test_repository, '10.2', due_on: '2022-11-14T12:00:00Z', description: comment)
+    run_described_fastlane_action(default_params)
+  end
+
+  it 'removes 3 days from the AppStore submission date when `:need_appstore_submission` is true' do
+    comment = "Code freeze: November 14, 2022\nApp Store submission: November 25, 2022\nRelease: November 28, 2022\n"
+    expect(client).to receive(:create_milestone).with(test_repository, '10.2', due_on: '2022-11-14T12:00:00Z', description: comment)
+    run_action_with(:need_appstore_submission, true)
+  end
+
+  it 'uses the most recent milestone date to calculate the due date and version of new milestone' do
+    comment = "Code freeze: November 18, 2022\nApp Store submission: December 02, 2022\nRelease: December 02, 2022\n"
+    allow(client).to receive(:list_milestones).and_return(milestone_list)
+    expect(client).to receive(:create_milestone).with(test_repository, '10.5', due_on: '2022-11-18T12:00:00Z', description: comment)
+    run_described_fastlane_action(default_params)
+  end
+
+  it 'raises an error when the due date of milestone does not exists' do
+    allow(client).to receive(:list_milestones).and_return([{ title: '10.1', number: '1234' }])
+    expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Milestone 10.1 has no due date.')
+  end
+
+  it 'raises an error when the milestone is not found or does not exist on the repository' do
+    allow(client).to receive(:list_milestones).and_return([])
+    expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'No milestone found on the repository.')
+  end
+
   describe 'initialize' do
-    let(:test_token) { 'Test-GithubToken-1234' }
-    let(:test_milestone) { { title: '10.1', due_on: '2022-10-31T07:00:00Z' } }
-    let(:mock_params) do
-      {
-        repository: 'test-repository',
-        need_appstore_submission: false
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [test_milestone],
-        create_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
-
-    before do
-      ENV['GITHUB_TOKEN'] = nil
-      mock_params[:github_token] = nil
-      allow(Octokit::Client).to receive(:new).and_return(client)
-    end
-
     context 'with github_token' do
-      it 'properly passes the environment variable `GITHUB_TOKEN` all the way to Octokit::Client' do
+      it 'properly passes the environment variable `GITHUB_TOKEN` to Octokit::Client' do
         ENV['GITHUB_TOKEN'] = test_token
         expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(mock_params)
+        run_action_without_key(:github_token)
       end
 
-      it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
-        mock_params[:github_token] = test_token
+      it 'properly passes the parameter `:github_token` to Octokit::Client' do
         expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(mock_params)
+        run_described_fastlane_action(default_params)
       end
 
-      it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` enviroment variable if both are present' do
+      it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` environment variable if both are present' do
         ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
-        mock_params[:github_token] = test_token
         expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(mock_params)
-      end
-
-      it 'prints an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
-        expect { run_described_fastlane_action(mock_params) }.to raise_error(FastlaneCore::Interface::FastlaneError)
+        run_described_fastlane_action(default_params)
       end
     end
 
-    context 'with default parameters' do
-      let(:glithub_helper) do
+    context 'when using default parameters' do
+      let(:github_helper) do
         instance_double(
           Fastlane::Helper::GithubHelper,
           get_last_milestone: test_milestone,
@@ -61,15 +86,12 @@ describe Fastlane::Actions::CreateNewMilestoneAction do
       end
 
       before do
-        mock_params[:github_token] = test_token
-        allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(glithub_helper)
+        allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
       end
 
       it 'uses default value when neither `GHHELPER_NUMBER_OF_DAYS_FROM_CODE_FREEZE_TO_RELEASE` environment variable nor parameter `:number_of_days_from_code_freeze_to_release` is present' do
         default_code_freeze_days = 14
-        mock_params[:number_of_days_from_code_freeze_to_release] = nil
-        ENV['GHHELPER_NUMBER_OF_DAYS_FROM_CODE_FREEZE_TO_RELEASE'] = nil
-        expect(glithub_helper).to receive(:create_milestone).with(
+        expect(github_helper).to receive(:create_milestone).with(
           anything,
           anything,
           anything,
@@ -77,14 +99,12 @@ describe Fastlane::Actions::CreateNewMilestoneAction do
           default_code_freeze_days,
           anything
         )
-        run_described_fastlane_action(mock_params)
+        run_described_fastlane_action(default_params)
       end
 
       it 'uses default value when neither `GHHELPER_MILESTONE_DURATION` environment variable nor parameter `:milestone_duration` is present' do
         default_milestone_duration = 14
-        mock_params[:milestone_duration] = nil
-        ENV['GHHELPER_MILESTONE_DURATION'] = nil
-        expect(glithub_helper).to receive(:create_milestone).with(
+        expect(github_helper).to receive(:create_milestone).with(
           anything,
           anything,
           anything,
@@ -92,65 +112,49 @@ describe Fastlane::Actions::CreateNewMilestoneAction do
           anything,
           anything
         )
-        run_described_fastlane_action(mock_params)
+        run_described_fastlane_action(default_params)
       end
     end
   end
 
-  describe 'get_last_milestone' do
-    let(:test_repository) { 'test-repository' }
-    let(:test_milestone) { { title: '10.1', due_on: '2022-10-31T07:00:00Z' } }
-    let(:mock_params) do
-      {
-        repository: test_repository,
-        need_appstore_submission: false,
-        github_token: 'Test-GithubToken-1234'
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [test_milestone],
-        create_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
+  describe 'calling the action validates input' do
+    it 'raises an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
+      ENV['GITHUB_TOKEN'] = nil
+      expect { run_action_without_key(:github_token) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'github_token'")
     end
 
-    it 'properly passes the repository all the way down to the Octokit::Client to list the existing milestones' do
-      allow(Octokit::Client).to receive(:new).and_return(client)
-      expect(client).to receive(:list_milestones).with(test_repository, { state: 'open' })
-      run_described_fastlane_action(mock_params)
+    it 'raises an error if no `GHHELPER_REPOSITORY` environment variable nor parameter `:repository` is present' do
+      expect { run_action_without_key(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
+    end
+
+    it 'raises an error if `need_appstore_submission:` parameter is passed as String' do
+      expect { run_action_with(:need_appstore_submission, 'foo') }.to raise_error "'need_appstore_submission' value must be either `true` or `false`! Found String instead."
+    end
+
+    it 'raises an error if `milestone_duration:` parameter is passed as String' do
+      expect { run_action_with(:milestone_duration, 'foo') }.to raise_error "'milestone_duration' value must be a Integer! Found String instead."
+    end
+
+    it 'raises an error if `number_of_days_from_code_freeze_to_release:` parameter is passed as String' do
+      expect { run_action_with(:number_of_days_from_code_freeze_to_release, 'foo') }.to raise_error "'number_of_days_from_code_freeze_to_release' value must be a Integer! Found String instead."
     end
   end
 
-  describe 'create_milestone' do
-    let(:test_repository) { 'test-repository' }
-    let(:test_milestone_number) { '10.2' }
-    let(:test_milestone) { { title: '10.1', due_on: '2022-10-31T07:00:00Z' } }
-    let(:mock_params) do
-      {
-        repository: test_repository,
-        need_appstore_submission: false,
-        github_token: 'Test-GithubToken-1234'
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [test_milestone],
-        create_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
+  def run_action_without_key(key)
+    run_described_fastlane_action(default_params.except(key))
+  end
 
-    it 'properly passes the parameters all the way down to the Octokit::Client' do
-      comment = "Code freeze: November 14, 2022\nApp Store submission: November 28, 2022\nRelease: November 28, 2022\n"
-      options = { due_on: '2022-11-14T12:00:00Z', description: comment }
-      allow(Octokit::Client).to receive(:new).and_return(client)
-      expect(client).to receive(:create_milestone).with(test_repository, test_milestone_number, options)
-      run_described_fastlane_action(mock_params)
-    end
+  def run_action_with(key, value)
+    values = default_params
+    values[key] = value
+    run_described_fastlane_action(values)
+  end
+
+  def default_params
+    {
+      repository: test_repository,
+      need_appstore_submission: false,
+      github_token: test_token
+    }
   end
 end

--- a/spec/setfrozentag_action_spec.rb
+++ b/spec/setfrozentag_action_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::SetfrozentagAction do
+  describe 'initialize' do
+    let(:test_token) { 'Test-GithubToken-1234' }
+    let(:test_milestone) { { title: '10.1', number: 1234 } }
+    let(:mock_params) do
+      {
+        repository: 'test-repository',
+        milestone: test_milestone[:title]
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [test_milestone],
+        update_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    before do
+      ENV['GITHUB_TOKEN'] = nil
+      mock_params[:github_token] = nil
+      allow(Octokit::Client).to receive(:new).and_return(client)
+    end
+
+    context 'with github_token' do
+      it 'properly passes the environment variable `GITHUB_TOKEN` all the way to Octokit::Client' do
+        ENV['GITHUB_TOKEN'] = test_token
+        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+        run_described_fastlane_action(mock_params)
+      end
+
+      it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
+        mock_params[:github_token] = test_token
+        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+        run_described_fastlane_action(mock_params)
+      end
+
+      it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` enviroment variable if both are present' do
+        ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
+        mock_params[:github_token] = test_token
+        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+        run_described_fastlane_action(mock_params)
+      end
+
+      it 'prints an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
+        expect { run_described_fastlane_action(mock_params) }.to raise_error(FastlaneCore::Interface::FastlaneError)
+      end
+    end
+
+    context 'with default parameters' do
+      let(:glithub_helper) do
+        instance_double(
+          Fastlane::Helper::GithubHelper,
+          get_milestone: test_milestone,
+          create_milestone: nil
+        )
+      end
+
+      before do
+        mock_params[:github_token] = test_token
+        allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(glithub_helper)
+      end
+
+      it 'froze the milestone when the parameter `:freeze` is not present' do
+        default_freeze_milestone = { title: '10.1 ❄️' }
+        expect(glithub_helper).to receive(:update_milestone).with(
+          repository: anything,
+          number: anything,
+          options: default_freeze_milestone
+        )
+        run_described_fastlane_action(mock_params)
+      end
+    end
+  end
+
+  describe 'get_milestone' do
+    let(:test_repository) { 'test-repository' }
+    let(:test_milestone) { { title: '10.1', number: 1234 } }
+    let(:mock_params) do
+      {
+        repository: test_repository,
+        milestone: test_milestone[:title],
+        github_token: 'Test-GithubToken-1234'
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [test_milestone],
+        update_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    before do
+      allow(Octokit::Client).to receive(:new).and_return(client)
+    end
+
+    it 'properly passes parameters all the way down to the Octokit::Client' do
+      expect(client).to receive(:list_milestones).with(test_repository)
+      run_described_fastlane_action(mock_params)
+    end
+  end
+
+  describe 'update_milestone' do
+    let(:test_repository) { 'test-repository' }
+    let(:test_milestone) { { title: '10.1', number: 1234 } }
+    let(:mock_params) do
+      {
+        repository: test_repository,
+        milestone: test_milestone[:title],
+        github_token: 'Test-GithubToken-1234'
+      }
+    end
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        list_milestones: [test_milestone],
+        update_milestone: nil,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+
+    it 'properly passes parameters all the way down to the Octokit::Client' do
+      allow(Octokit::Client).to receive(:new).and_return(client)
+      expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], { title: '10.1 ❄️' })
+      run_described_fastlane_action(mock_params)
+    end
+  end
+end

--- a/spec/setfrozentag_action_spec.rb
+++ b/spec/setfrozentag_action_spec.rb
@@ -66,11 +66,11 @@ describe Fastlane::Actions::SetfrozentagAction do
       end
 
       it 'froze the milestone when the parameter `:freeze` is not present' do
-        default_freeze_milestone = { title: '10.1 ❄️' }
+        default_freeze_milestone = '10.1 ❄️'
         expect(glithub_helper).to receive(:update_milestone).with(
           repository: anything,
           number: anything,
-          options: default_freeze_milestone
+          title: default_freeze_milestone
         )
         run_described_fastlane_action(mock_params)
       end

--- a/spec/setfrozentag_action_spec.rb
+++ b/spec/setfrozentag_action_spec.rb
@@ -1,136 +1,102 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::SetfrozentagAction do
-  describe 'initialize' do
-    let(:test_token) { 'Test-GithubToken-1234' }
-    let(:test_milestone) { { title: '10.1', number: 1234 } }
-    let(:mock_params) do
-      {
-        repository: 'test-repository',
-        milestone: test_milestone[:title]
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [test_milestone],
-        update_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
+  let(:test_repository) { 'test-repository' }
+  let(:test_token) { 'Test-GithubToken-1234' }
+  let(:test_milestone) do
+    { title: '10.1', number: '1234' }
+  end
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      list_milestones: [test_milestone],
+      update_milestone: nil,
+      user: instance_double('User', name: 'test'),
+      'auto_paginate=': nil
+    )
+  end
 
-    before do
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+  end
+
+  it 'properly passes the environment variable `GITHUB_TOKEN` to Octokit::Client' do
+    ENV['GITHUB_TOKEN'] = test_token
+    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+    run_action_without_key(:github_token)
+  end
+
+  it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
+    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+    run_described_fastlane_action(default_params)
+  end
+
+  it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` environment variable if both are present' do
+    ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
+    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+    run_described_fastlane_action(default_params)
+  end
+
+  it 'raises an error when the milestone is not found or does not exist' do
+    allow(client).to receive(:list_milestones).and_return([])
+    expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Milestone 10.1 not found.')
+  end
+
+  it 'freezes the milestone adding ❄️ to the title' do
+    expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], title: '10.1 ❄️')
+    run_action_with(:freeze, true)
+  end
+
+  it 'does not freeze the milestone if is already frozen' do
+    allow(client).to receive(:list_milestones).and_return([{ title: '10.2 ❄️', number: '1234' }])
+    expect(client).not_to receive(:update_milestone)
+    run_action_with(:milestone, '10.2 ❄️')
+  end
+
+  it 'does not freeze the milestone if :freeze parameter is false' do
+    expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], title: '10.1')
+    run_action_with(:freeze, false)
+  end
+
+  describe 'Calling the Action validates input' do
+    it 'raises an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
       ENV['GITHUB_TOKEN'] = nil
-      mock_params[:github_token] = nil
-      allow(Octokit::Client).to receive(:new).and_return(client)
+      expect { run_action_without_key(:github_token) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'github_token'")
     end
 
-    context 'with github_token' do
-      it 'properly passes the environment variable `GITHUB_TOKEN` all the way to Octokit::Client' do
-        ENV['GITHUB_TOKEN'] = test_token
-        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(mock_params)
-      end
-
-      it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
-        mock_params[:github_token] = test_token
-        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(mock_params)
-      end
-
-      it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` enviroment variable if both are present' do
-        ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
-        mock_params[:github_token] = test_token
-        expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-        run_described_fastlane_action(mock_params)
-      end
-
-      it 'prints an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
-        expect { run_described_fastlane_action(mock_params) }.to raise_error(FastlaneCore::Interface::FastlaneError)
-      end
+    it 'raises an error if no `GHHELPER_REPOSITORY` environment variable nor parameter `:repository` is present' do
+      expect { run_action_without_key(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
     end
 
-    context 'with default parameters' do
-      let(:glithub_helper) do
-        instance_double(
-          Fastlane::Helper::GithubHelper,
-          get_milestone: test_milestone,
-          create_milestone: nil
-        )
-      end
+    it 'raises an error if no `GHHELPER_MILESTORE` environment variable nor parameter `:milestone` is present' do
+      expect { run_action_without_key(:milestone) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'milestone'")
+    end
 
-      before do
-        mock_params[:github_token] = test_token
-        allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(glithub_helper)
-      end
+    it 'raises an error if `:freeze` parameter is passed as String' do
+      expect { run_action_with(:freeze, 'foo') }.to raise_error "'freeze' value must be either `true` or `false`! Found String instead."
+    end
 
-      it 'froze the milestone when the parameter `:freeze` is not present' do
-        default_freeze_milestone = '10.1 ❄️'
-        expect(glithub_helper).to receive(:update_milestone).with(
-          repository: anything,
-          number: anything,
-          title: default_freeze_milestone
-        )
-        run_described_fastlane_action(mock_params)
-      end
+    it 'raises an error if `:milestone` parameter is passed as Integer' do
+      expect { run_action_with(:milestone, 10) }.to raise_error "'milestone' value must be a String! Found Integer instead."
     end
   end
 
-  describe 'get_milestone' do
-    let(:test_repository) { 'test-repository' }
-    let(:test_milestone) { { title: '10.1', number: 1234 } }
-    let(:mock_params) do
-      {
-        repository: test_repository,
-        milestone: test_milestone[:title],
-        github_token: 'Test-GithubToken-1234'
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [test_milestone],
-        update_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
-
-    before do
-      allow(Octokit::Client).to receive(:new).and_return(client)
-    end
-
-    it 'properly passes parameters all the way down to the Octokit::Client' do
-      expect(client).to receive(:list_milestones).with(test_repository)
-      run_described_fastlane_action(mock_params)
-    end
+  def run_action_without_key(key)
+    run_described_fastlane_action(default_params.except(key))
   end
 
-  describe 'update_milestone' do
-    let(:test_repository) { 'test-repository' }
-    let(:test_milestone) { { title: '10.1', number: 1234 } }
-    let(:mock_params) do
-      {
-        repository: test_repository,
-        milestone: test_milestone[:title],
-        github_token: 'Test-GithubToken-1234'
-      }
-    end
-    let(:client) do
-      instance_double(
-        Octokit::Client,
-        list_milestones: [test_milestone],
-        update_milestone: nil,
-        user: instance_double('User', name: 'test'),
-        'auto_paginate=': nil
-      )
-    end
+  def run_action_with(key, value)
+    values = default_params
+    values[key] = value
+    run_described_fastlane_action(values)
+  end
 
-    it 'properly passes parameters all the way down to the Octokit::Client' do
-      allow(Octokit::Client).to receive(:new).and_return(client)
-      expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], { title: '10.1 ❄️' })
-      run_described_fastlane_action(mock_params)
-    end
+  def default_params
+    {
+      repository: test_repository,
+      milestone: test_milestone[:title],
+      freeze: true,
+      github_token: test_token
+    }
   end
 end

--- a/spec/setfrozentag_action_spec.rb
+++ b/spec/setfrozentag_action_spec.rb
@@ -1,10 +1,19 @@
 require 'spec_helper'
+require 'shared_examples_for_actions_with_github_token'
 
 describe Fastlane::Actions::SetfrozentagAction do
   let(:test_repository) { 'test-repository' }
   let(:test_token) { 'Test-GithubToken-1234' }
   let(:test_milestone) do
     { title: '10.1', number: '1234' }
+  end
+  let(:default_params) do
+    {
+      repository: test_repository,
+      milestone: test_milestone[:title],
+      freeze: true,
+      github_token: 'Test-GithubToken-1234'
+    }
   end
   let(:client) do
     instance_double(
@@ -20,23 +29,6 @@ describe Fastlane::Actions::SetfrozentagAction do
     allow(Octokit::Client).to receive(:new).and_return(client)
   end
 
-  it 'properly passes the environment variable `GITHUB_TOKEN` to Octokit::Client' do
-    ENV['GITHUB_TOKEN'] = test_token
-    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-    run_action_without_key(:github_token)
-  end
-
-  it 'properly passes the parameter `:github_token` all the way to Octokit::Client' do
-    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-    run_described_fastlane_action(default_params)
-  end
-
-  it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` environment variable if both are present' do
-    ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
-    expect(Octokit::Client).to receive(:new).with(access_token: test_token)
-    run_described_fastlane_action(default_params)
-  end
-
   it 'raises an error when the milestone is not found or does not exist' do
     allow(client).to receive(:list_milestones).and_return([])
     expect { run_described_fastlane_action(default_params) }.to raise_error(FastlaneCore::Interface::FastlaneError, 'Milestone 10.1 not found.')
@@ -44,59 +36,54 @@ describe Fastlane::Actions::SetfrozentagAction do
 
   it 'freezes the milestone adding ❄️ to the title' do
     expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], title: '10.1 ❄️')
-    run_action_with(:freeze, true)
+    run_action_with(freeze: true)
   end
 
-  it 'does not freeze the milestone if is already frozen' do
+  it 'remove any existing ❄️ emoji from a frozen milestone' do
+    allow(client).to receive(:list_milestones).and_return([{ title: '10.2 ❄️', number: '1234' }])
+    expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], title: '10.2')
+    run_action_with(freeze: false, milestone: '10.2')
+  end
+
+  it 'does not change a milestone that is already frozen' do
     allow(client).to receive(:list_milestones).and_return([{ title: '10.2 ❄️', number: '1234' }])
     expect(client).not_to receive(:update_milestone)
-    run_action_with(:milestone, '10.2 ❄️')
+    run_action_with(milestone: '10.2 ❄️')
   end
 
-  it 'does not freeze the milestone if :freeze parameter is false' do
+  it 'does not change an unfrozen milestone if :freeze parameter is false' do
     expect(client).to receive(:update_milestone).with(test_repository, test_milestone[:number], title: '10.1')
-    run_action_with(:freeze, false)
+    run_action_with(freeze: false)
+  end
+
+  describe 'initialize' do
+    include_examples 'github_token_initialization'
   end
 
   describe 'Calling the Action validates input' do
-    it 'raises an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
-      ENV['GITHUB_TOKEN'] = nil
-      expect { run_action_without_key(:github_token) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'github_token'")
-    end
-
     it 'raises an error if no `GHHELPER_REPOSITORY` environment variable nor parameter `:repository` is present' do
-      expect { run_action_without_key(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
+      expect { run_action_without(:repository) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'repository'")
     end
 
     it 'raises an error if no `GHHELPER_MILESTORE` environment variable nor parameter `:milestone` is present' do
-      expect { run_action_without_key(:milestone) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'milestone'")
+      expect { run_action_without(:milestone) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'milestone'")
     end
 
     it 'raises an error if `:freeze` parameter is passed as String' do
-      expect { run_action_with(:freeze, 'foo') }.to raise_error "'freeze' value must be either `true` or `false`! Found String instead."
+      expect { run_action_with(freeze: 'foo') }.to raise_error "'freeze' value must be either `true` or `false`! Found String instead."
     end
 
     it 'raises an error if `:milestone` parameter is passed as Integer' do
-      expect { run_action_with(:milestone, 10) }.to raise_error "'milestone' value must be a String! Found Integer instead."
+      expect { run_action_with(milestone: 10) }.to raise_error "'milestone' value must be a String! Found Integer instead."
     end
   end
 
-  def run_action_without_key(key)
+  def run_action_with(**keys_and_values)
+    params = default_params.merge(keys_and_values)
+    run_described_fastlane_action(params)
+  end
+
+  def run_action_without(key)
     run_described_fastlane_action(default_params.except(key))
-  end
-
-  def run_action_with(key, value)
-    values = default_params
-    values[key] = value
-    run_described_fastlane_action(values)
-  end
-
-  def default_params
-    {
-      repository: test_repository,
-      milestone: test_milestone[:title],
-      freeze: true,
-      github_token: test_token
-    }
   end
 end

--- a/spec/shared_examples_for_actions_with_github_token.rb
+++ b/spec/shared_examples_for_actions_with_github_token.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.shared_examples 'github_token_initialization' do
+  let(:test_token) { 'Test-GithubToken-1234' }
+
+  describe 'GitHub Token is properly passed to the client' do
+    it 'properly passes the environment variable `GITHUB_TOKEN` to Octokit::Client' do
+      ENV['GITHUB_TOKEN'] = test_token
+      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+      run_action_without(:github_token)
+    end
+
+    it 'properly passes the parameter `:github_token` to Octokit::Client' do
+      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+      run_described_fastlane_action(default_params)
+    end
+
+    it 'prioritizes `:github_token` parameter over `GITHUB_TOKEN` environment variable if both are present' do
+      ENV['GITHUB_TOKEN'] = 'Test-EnvGithubToken-1234'
+      expect(Octokit::Client).to receive(:new).with(access_token: test_token)
+      run_described_fastlane_action(default_params)
+    end
+
+    it 'raises an error if no `GITHUB_TOKEN` environment variable nor parameter `:github_token` is present' do
+      ENV['GITHUB_TOKEN'] = nil
+      expect { run_action_without(:github_token) }.to raise_error(FastlaneCore::Interface::FastlaneError, "No value found for 'github_token'")
+    end
+  end
+end


### PR DESCRIPTION
# What does this solve?
With the changes/improvements made on PR #420, we discover that some actions were not properly covered by unit tests. On this PR we start adding them, starting with the milestone actions. 

# What does PR #420 was about?

As stated in issue #416,  The CI was failing at the moment of doing a GitHub release, The reason for the failure was a 401 from the GitHub API. This happened because neither `GHHELPER_ACCESS` (that is not valid anymore) nor `GITHUB_TOKEN` was available in the environment at runtime. 

We solved this by turning the `GITHUB_TOKEN` into a mandatory env variable/parameter to run those actions and changing the `GithubHelper` class to receive this token at their initialization, so we have a centralized entry-point at the GithubAPI.

# Any Dependencies?
As this work is impacted by #426, Please, _DO NOT_ merge this before it. Thanks! 😄 
