### PR TITLE
Add named params and yard docs to `create_milestone` method at `GithubHelper`

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -18,7 +18,14 @@ module Fastlane
         newmilestone_number = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(last_stone[:title])
         number_of_days_from_code_freeze_to_release = params[:number_of_days_from_code_freeze_to_release]
         UI.message("Next milestone: #{newmilestone_number} due on #{newmilestone_duedate}.")
-        github_helper.create_milestone(repository, newmilestone_number, newmilestone_duedate, milestone_duration, number_of_days_from_code_freeze_to_release, params[:need_appstore_submission])
+        github_helper.create_milestone(
+          repository: repository,
+          newmilestone_number: newmilestone_number,
+          newmilestone_duedate: newmilestone_duedate,
+          newmilestone_duration: milestone_duration,
+          number_of_days_from_code_freeze_to_release: number_of_days_from_code_freeze_to_release,
+          need_submission: params[:need_appstore_submission]
+        )
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -19,8 +19,8 @@ module Fastlane
         newmilestone_duedate = (milestone_duedate.to_datetime.next_day(milestone_duration).to_time).utc
         newmilestone_number = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(last_stone[:title])
         number_of_days_from_code_freeze_to_release = params[:number_of_days_from_code_freeze_to_release]
-        # If there is a review process, we want to submit the binary 3 days before its release
-        # Using 3 days is mostly for historical reasons where we release the apps on Monday and submit them on Friday.
+        # Because of the app stores review process, we submit the binary 3 days before the intended release date.
+        # Using 3 days is mostly for historical reasons, for a long time, we've been submitting apps on Friday and releasing them on Monday.
         days_until_submission = params[:need_appstore_submission] ? (number_of_days_from_code_freeze_to_release - 3) : milestone_duration
 
         UI.message("Next milestone: #{newmilestone_number} due on #{newmilestone_duedate}.")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -74,23 +74,16 @@ module Fastlane
       # Creates a new milestone
       #
       # @param [String] repository The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)
-      # @param [String] newmilestone_number The name of the milestone we want to create (e.g.: `16.9`)
-      # @param [Time] newmilestone_duedate milestone due date (e.g. `2022-10-22T12:00:00Z`)
-      # @param [Integer] newmilestone_duration Number of days that a milestone extents
-      # @param [Integer] number_of_days_from_code_freeze_to_release Number of days from code freeze to release
-      # @param [Boolean] need_submission The app needs to be submitted?
-      #  if `true`, will subtract 3 days from the `:number_of_days_from_code_freeze_to_release`.
-      #  if `false`, will use the days of `:newmilestone_duration`
+      # @param [String] title The name of the milestone we want to create (e.g.: `16.9`)
+      # @param [Time] due_date milestone due date (e.g. `2022-10-22T12:00:00Z`)
+      # @param [Integer] days_until_submission Number of days until submission
+      # @param [Integer] days_until_release Number of days from code freeze to release
       #
-      def create_milestone(repository:, newmilestone_number:, newmilestone_duedate:, newmilestone_duration:, number_of_days_from_code_freeze_to_release:, need_submission:)
-        # If there is a review process, we want to submit the binary 3 days before its release
-        #
-        # Using 3 days is mostly for historical reasons where we release the apps on Monday and submit them on Friday.
-        days_until_submission = need_submission ? (number_of_days_from_code_freeze_to_release - 3) : newmilestone_duration
-        submission_date = newmilestone_duedate.to_datetime.next_day(days_until_submission)
-        release_date = newmilestone_duedate.to_datetime.next_day(number_of_days_from_code_freeze_to_release)
+      def create_milestone(repository:, title:, due_date:, days_until_submission:, days_until_release:)
+        submission_date = due_date.to_datetime.next_day(days_until_submission)
+        release_date = due_date.to_datetime.next_day(days_until_release)
         comment = <<~MILESTONE_DESCRIPTION
-          Code freeze: #{newmilestone_duedate.to_datetime.strftime('%B %d, %Y')}
+          Code freeze: #{due_date.to_datetime.strftime('%B %d, %Y')}
           App Store submission: #{submission_date.strftime('%B %d, %Y')}
           Release: #{release_date.strftime('%B %d, %Y')}
         MILESTONE_DESCRIPTION
@@ -107,9 +100,9 @@ module Fastlane
         #
         # This is a bug in the GitHub API, not in our date computation logic.
         # To solve this, we trick it by forcing the time component of the ISO date we send to be `12:00:00Z`.
-        options[:due_on] = newmilestone_duedate.strftime('%Y-%m-%dT12:00:00Z')
+        options[:due_on] = due_date.strftime('%Y-%m-%dT12:00:00Z')
         options[:description] = comment
-        client.create_milestone(repository, newmilestone_number, options)
+        client.create_milestone(repository, title, options)
       end
 
       # Creates a Release on GitHub as a Draft

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -80,9 +80,9 @@ module Fastlane
       # @param [Integer] days_until_release Number of days from code freeze to release
       #
       def create_milestone(repository:, title:, due_date:, days_until_submission:, days_until_release:)
-        UI.user_error!('days_until_release must be greater than zero.') if days_until_release <= 0
-        UI.user_error!('days_until_submission must be greater than zero.') if days_until_submission <= 0
-        UI.user_error!('days_until_release must be greather than days_until_submission') if days_until_submission >= days_until_release
+        UI.user_error!('days_until_release must be greater than zero.') unless days_until_release > 0
+        UI.user_error!('days_until_submission must be greater than zero.') unless days_until_submission > 0
+        UI.user_error!('days_until_release must be greater or equal to days_until_submission.') unless days_until_release >= days_until_submission
 
         submission_date = due_date.to_datetime.next_day(days_until_submission)
         release_date = due_date.to_datetime.next_day(days_until_release)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -75,11 +75,15 @@ module Fastlane
       #
       # @param [String] repository The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)
       # @param [String] title The name of the milestone we want to create (e.g.: `16.9`)
-      # @param [Time] due_date milestone due date (e.g. `2022-10-22T12:00:00Z`)
-      # @param [Integer] days_until_submission Number of days until submission
+      # @param [Time] due_date Milestone due date—which will also correspond to the code freeze date
+      # @param [Integer] days_until_submission Number of days from code freeze to submission to the App Store / Play Store
       # @param [Integer] days_until_release Number of days from code freeze to release
       #
       def create_milestone(repository:, title:, due_date:, days_until_submission:, days_until_release:)
+        UI.user_error!('days_until_release must be greater than zero.') if days_until_release <= 0
+        UI.user_error!('days_until_submission must be greater than zero.') if days_until_submission <= 0
+        UI.user_error!('days_until_release must be greather than days_until_submission') if days_until_submission >= days_until_release
+
         submission_date = due_date.to_datetime.next_day(days_until_submission)
         release_date = due_date.to_datetime.next_day(days_until_release)
         comment = <<~MILESTONE_DESCRIPTION

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -76,7 +76,7 @@ module Fastlane
       # @param [String] repository The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)
       # @param [String] newmilestone_number The name of the milestone we want to create (e.g.: `16.9`)
       # @param [Time] newmilestone_duedate milestone due date (e.g. `2022-10-22T12:00:00Z`)
-      # @param [Integer] newmilestone_duration Milestone duration in number of days
+      # @param [Integer] newmilestone_duration Number of days that a milestone extents
       # @param [Integer] number_of_days_from_code_freeze_to_release Number of days from code freeze to release
       # @param [Boolean] need_submission The app needs to be submitted?
       #  if `true`, will subtract 3 days from the `:number_of_days_from_code_freeze_to_release`.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -80,8 +80,8 @@ module Fastlane
       # @param [Integer] days_until_release Number of days from code freeze to release
       #
       def create_milestone(repository:, title:, due_date:, days_until_submission:, days_until_release:)
-        UI.user_error!('days_until_release must be greater than zero.') unless days_until_release > 0
-        UI.user_error!('days_until_submission must be greater than zero.') unless days_until_submission > 0
+        UI.user_error!('days_until_release must be greater than zero.') unless days_until_release.positive?
+        UI.user_error!('days_until_submission must be greater than zero.') unless days_until_submission.positive?
         UI.user_error!('days_until_release must be greater or equal to days_until_submission.') unless days_until_release >= days_until_submission
 
         submission_date = due_date.to_datetime.next_day(days_until_submission)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -71,7 +71,18 @@ module Fastlane
         last_stone
       end
 
-      def create_milestone(repository, newmilestone_number, newmilestone_duedate, newmilestone_duration, number_of_days_from_code_freeze_to_release, need_submission)
+      # Creates a new milestone
+      #
+      # @param [String] repository The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)
+      # @param [String] newmilestone_number The name of the milestone we want to create (e.g.: `16.9`)
+      # @param [Time] newmilestone_duedate milestone due date (e.g. `2022-10-22T12:00:00Z`)
+      # @param [Integer] newmilestone_duration Milestone duration in number of days
+      # @param [Integer] number_of_days_from_code_freeze_to_release Number of days from code freeze to release
+      # @param [Boolean] need_submission The app needs to be submitted?
+      #  if `true`, will subtract 3 days from the `:number_of_days_from_code_freeze_to_release`.
+      #  if `false`, will use the days of `:newmilestone_duration`
+      #
+      def create_milestone(repository:, newmilestone_number:, newmilestone_duedate:, newmilestone_duration:, number_of_days_from_code_freeze_to_release:, need_submission:)
         # If there is a review process, we want to submit the binary 3 days before its release
         #
         # Using 3 days is mostly for historical reasons where we release the apps on Monday and submit them on Friday.

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -234,14 +234,14 @@ describe Fastlane::Helper::GithubHelper do
     end
 
     def create_milestone(need_submission:, milestone_duration:, days_code_freeze:)
+      days_until_submission = need_submission ? (days_code_freeze - 3) : milestone_duration
       helper = described_class.new(github_token: 'Fake-GitHubToken-123')
       helper.create_milestone(
         repository: test_repo,
-        newmilestone_number: test_milestone_number,
-        newmilestone_duedate: test_milestone_duedate.to_time.utc,
-        newmilestone_duration: milestone_duration,
-        number_of_days_from_code_freeze_to_release: days_code_freeze,
-        need_submission: need_submission
+        title: test_milestone_number,
+        due_date: test_milestone_duedate.to_time.utc,
+        days_until_submission: days_until_submission,
+        days_until_release: days_code_freeze
       )
     end
   end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -236,12 +236,12 @@ describe Fastlane::Helper::GithubHelper do
     def create_milestone(need_submission:, milestone_duration:, days_code_freeze:)
       helper = described_class.new(github_token: 'Fake-GitHubToken-123')
       helper.create_milestone(
-        test_repo,
-        test_milestone_number,
-        test_milestone_duedate.to_time.utc,
-        milestone_duration,
-        days_code_freeze,
-        need_submission
+        repository: test_repo,
+        newmilestone_number: test_milestone_number,
+        newmilestone_duedate: test_milestone_duedate.to_time.utc,
+        newmilestone_duration: milestone_duration,
+        number_of_days_from_code_freeze_to_release: days_code_freeze,
+        need_submission: need_submission
       )
     end
   end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -242,6 +242,9 @@ describe Fastlane::Helper::GithubHelper do
     it 'computes the correct dates when the due date is on the verge of a DST day change' do
       # Europe DST starts on the last Sunday of March, and ends on the last Sunday of October
       Time.use_zone('Europe/London') do
+        # March 27th, 2022 is the exact day that London switches to the DST (+1h)
+        # If the due date is too close to the next day, a day change will happen
+        # So, 2022-03-27 23:00:00Z will be exactly 2022-03-28 00:00:00 +0100 at the DST change
         due_date = Time.zone.parse('2022-03-27 23:00:00Z')
         options = {
           due_on: '2022-03-28T12:00:00Z',
@@ -256,6 +259,25 @@ describe Fastlane::Helper::GithubHelper do
     it 'computes the correct dates when the due date is on DST but has no day change' do
       # Europe DST starts on the last Sunday of March, and ends on the last Sunday of October
       Time.use_zone('Europe/London') do
+        # March 27th, 2022 is the exact day that London switches to the DST (+1h)
+        # If the due date is not close enough at the day change, nothing will occur.
+        # So, 2022-03-27 22:00:00Z will be exactly 2022-03-27 23:00:00 +0100 at the DST change.
+        due_date = Time.zone.parse('2022-03-27 22:00:00Z')
+        options = {
+          due_on: '2022-03-27T12:00:00Z',
+          description: "Code freeze: March 27, 2022\nApp Store submission: March 29, 2022\nRelease: March 30, 2022\n"
+        }
+
+        expect(client).to receive(:create_milestone).with(test_repo, test_milestone_number, options)
+        create_milestone(due_date: due_date, days_until_submission: 2, days_until_release: 3)
+      end
+    end
+
+    it 'computes the correct dates when the due date is one day before a DST change' do
+      # Europe DST starts on the last Sunday of March, and ends on the last Sunday of October
+      Time.use_zone('Europe/London') do
+        # As London changes to DST on March 27th, the date shouldn't be changed
+        # So, 2022-03-26 23:00:00Z will be exactly 2022-03-26 23:00:00 +0000 at this Timezone.
         due_date = Time.zone.parse('2022-03-26 23:00:00Z')
         options = {
           due_on: '2022-03-26T12:00:00Z',

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -240,7 +240,7 @@ describe Fastlane::Helper::GithubHelper do
     end
 
     it 'computes the correct dates when the due date is on the verge of a DST day change' do
-      # DST starts on the last Sunday of March and ends on the last Sunday of October
+      # Europe DST starts on the last Sunday of March, and ends on the last Sunday of October
       Time.use_zone('Europe/London') do
         due_date = Time.zone.parse('2022-03-27 23:00:00Z')
         options = {
@@ -254,7 +254,7 @@ describe Fastlane::Helper::GithubHelper do
     end
 
     it 'computes the correct dates when the due date is on DST but has no day change' do
-      # DST starts on the last Sunday of March and ends on the last Sunday of October
+      # Europe DST starts on the last Sunday of March, and ends on the last Sunday of October
       Time.use_zone('Europe/London') do
         due_date = Time.zone.parse('2022-03-26 23:00:00Z')
         options = {
@@ -264,6 +264,64 @@ describe Fastlane::Helper::GithubHelper do
 
         expect(client).to receive(:create_milestone).with(test_repo, test_milestone_number, options)
         create_milestone(due_date: due_date, days_until_submission: 2, days_until_release: 3)
+      end
+    end
+
+    it 'computes the correct dates when the offset is between DST endings' do
+      # Europe DST starts on the last Sunday of March, and ends on the last Sunday of October
+      Time.use_zone('Europe/London') do
+        due_date = Time.zone.parse('2022-10-30 23:00:00Z')
+        options = {
+          due_on: '2022-10-30T12:00:00Z',
+          description: "Code freeze: October 30, 2022\nApp Store submission: March 19, 2023\nRelease: March 25, 2023\n"
+        }
+
+        expect(client).to receive(:create_milestone).with(test_repo, test_milestone_number, options)
+        create_milestone(due_date: due_date, days_until_submission: 140, days_until_release: 146)
+      end
+    end
+
+    it 'computes the correct dates when the release and submission dates are at the last day of a DST change' do
+      # Europe DST starts on the last Sunday of March, and ends on the last Sunday of October
+      Time.use_zone('Europe/London') do
+        due_date = Time.zone.parse('2022-03-27 23:00:00Z')
+        options = {
+          due_on: '2022-03-28T12:00:00Z',
+          description: "Code freeze: March 28, 2022\nApp Store submission: October 30, 2022\nRelease: October 31, 2022\n"
+        }
+
+        expect(client).to receive(:create_milestone).with(test_repo, test_milestone_number, options)
+        create_milestone(due_date: due_date, days_until_submission: 216, days_until_release: 217)
+      end
+    end
+
+    it 'computes the correct dates when the due date is before Europe and USA DST changes and ends inside a DST period on Europe' do
+      # USA DST starts on the second Sunday in March. and ends on the first Sunday in November
+      # Europe DST starts on the last Sunday of March, and ends on the last Sunday in October
+      Time.use_zone('Europe/London') do
+        due_date = Time.zone.parse('2022-03-05 23:00:00Z')
+        options = {
+          due_on: '2022-03-05T12:00:00Z',
+          description: "Code freeze: March 05, 2022\nApp Store submission: May 04, 2022\nRelease: May 05, 2022\n"
+        }
+
+        expect(client).to receive(:create_milestone).with(test_repo, test_milestone_number, options)
+        create_milestone(due_date: due_date, days_until_submission: 60, days_until_release: 61)
+      end
+    end
+
+    it 'computes the correct dates when the due date is before Europe and USA DST changes and ends inside a DST period on USA' do
+      # USA DST starts on the second Sunday in March. and ends on the first Sunday in November
+      # Europe DST starts on the last Sunday of March, and ends on the last Sunday in October
+      Time.use_zone('America/Los_Angeles') do
+        due_date = Time.zone.parse('2022-03-05 23:00:00Z')
+        options = {
+          due_on: '2022-03-05T12:00:00Z',
+          description: "Code freeze: March 05, 2022\nApp Store submission: May 04, 2022\nRelease: May 05, 2022\n"
+        }
+
+        expect(client).to receive(:create_milestone).with(test_repo, test_milestone_number, options)
+        create_milestone(due_date: due_date, days_until_submission: 60, days_until_release: 61)
       end
     end
 


### PR DESCRIPTION
# What does this solve?

With the changes/improvements made on PR #420 and the creation of the unit tests being done on PR #425, we realized that the lack of yard documentation and named parameters were making the tests unclear and too verbose in the area of `CreateMilestoneAction`.  So, as [pointed on the PR #425 review](https://github.com/wordpress-mobile/release-toolkit/pull/425#discussion_r1014342778), we decided to open this new PR to address these issues that were found.

# How do the yard docs look now?

Glad you asked 😄 

![Screenshot 2022-11-07 at 14 59 52](https://user-images.githubusercontent.com/7543763/200350551-81ad74db-91a8-4456-bbe0-0d24bb9299e3.png)

# Dependency
This work is part of the one started on #425. 

So, here at #426 we are addressing the changes at the API of `GithubHelper#create_milestone`, and there on #425 are the unit tests. As pointed on the #425 PR description, **_this should be merged first_**, as it affects the work done there. 