### PR TITLE
Allow `upload_to_s3` not to crash if file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### New Features
 
-_None_
+- Allow `upload_to_s3` action to just log instead of crash (using new `skip_if_exists` parameter) when the file already exists in the S3 bucket. [#427]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -24,10 +24,10 @@ module Fastlane
           message = "File already exists in S3 bucket #{bucket} at #{key}"
           if params[:skip_if_exists]
             UI.important("#{message}. Skipping upload.")
+            return key
           else
             UI.user_error!(message)
           end
-          return key
         end
 
         UI.message("Uploading #{file_path} to: #{key}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -27,7 +27,7 @@ module Fastlane
           else
             UI.user_error!(message)
           end
-          return
+          return key
         end
 
         UI.message("Uploading #{file_path} to: #{key}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -20,7 +20,15 @@ module Fastlane
           key = [file_name_hash, key].join('/')
         end
 
-        UI.user_error!("File already exists in S3 bucket #{bucket} at #{key}") if file_is_already_uploaded?(bucket, key)
+        if file_is_already_uploaded?(bucket, key)
+          message = "File already exists in S3 bucket #{bucket} at #{key}"
+          if params[:skip_if_exists]
+            UI.important("#{message}. Skipping upload.")
+          else
+            UI.user_error!(message)
+          end
+          return
+        end
 
         UI.message("Uploading #{file_path} to: #{key}")
 
@@ -99,6 +107,13 @@ module Fastlane
             description: 'Generate a derived prefix based on the filename that makes it harder to guess the URL of the uploaded object',
             optional: true,
             default_value: true,
+            type: Boolean
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :skip_if_exists,
+            description: 'If the file already exists in the S3 bucket, just log the error instead of failing with `user_error!`',
+            optional: true,
+            default_value: false,
             type: Boolean
           ),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -111,7 +111,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :skip_if_exists,
-            description: 'If the file already exists in the S3 bucket, just log the error instead of failing with `user_error!`',
+            description: 'If the file already exists in the S3 bucket, skip the upload (and report it in the logs), instead of failing with `user_error!`',
             optional: true,
             default_value: false,
             type: Boolean

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -144,7 +144,7 @@ describe Fastlane::Actions::UploadToS3Action do
       end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Path `this-file-does-not-exist.txt` does not exist.')
     end
 
-    it 'fails if the file already exists on S3' do
+    it 'fails if the file already exists on S3 and skip_if_exists:false' do
       expected_key = 'a62f2225bf70bfaccbc7f1ef2a397836717377de/key'
       stub_s3_response_for_file(expected_key)
 
@@ -156,6 +156,24 @@ describe Fastlane::Actions::UploadToS3Action do
             file: file_path
           )
         end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
+      end
+    end
+
+    it 'just logs if the file already exists on S3 and skip_if_exists:true' do
+      expected_key = 'a62f2225bf70bfaccbc7f1ef2a397836717377de/key'
+      stub_s3_response_for_file(expected_key)
+
+      warnings = []
+      allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
+
+      with_tmp_file(named: 'key') do |file_path|
+        run_described_fastlane_action(
+          bucket: test_bucket,
+          key: 'key',
+          file: file_path,
+          skip_if_exists: true
+        )
+        expect(warnings).to eq ["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."]
       end
     end
   end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -167,13 +167,14 @@ describe Fastlane::Actions::UploadToS3Action do
       allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
 
       with_tmp_file(named: 'key') do |file_path|
-        run_described_fastlane_action(
+        key = run_described_fastlane_action(
           bucket: test_bucket,
           key: 'key',
           file: file_path,
           skip_if_exists: true
         )
-        expect(warnings).to eq ["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."]
+        expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
+        expect(key).to eq(expected_key)
       end
     end
   end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -144,37 +144,39 @@ describe Fastlane::Actions::UploadToS3Action do
       end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Path `this-file-does-not-exist.txt` does not exist.')
     end
 
-    it 'fails if the file already exists on S3 and skip_if_exists:false' do
-      expected_key = 'a62f2225bf70bfaccbc7f1ef2a397836717377de/key'
-      stub_s3_response_for_file(expected_key)
+    context 'when the file already exists on S3' do
+      it 'fails if skip_if_exists:false' do
+        expected_key = 'a62f2225bf70bfaccbc7f1ef2a397836717377de/key'
+        stub_s3_response_for_file(expected_key)
 
-      with_tmp_file(named: 'key') do |file_path|
-        expect do
-          run_described_fastlane_action(
+        with_tmp_file(named: 'key') do |file_path|
+          expect do
+            run_described_fastlane_action(
+              bucket: test_bucket,
+              key: 'key',
+              file: file_path
+            )
+          end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
+        end
+      end
+
+      it 'logs a message without failing if skip_if_exists:true' do
+        expected_key = 'a62f2225bf70bfaccbc7f1ef2a397836717377de/key'
+        stub_s3_response_for_file(expected_key)
+
+        warnings = []
+        allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
+
+        with_tmp_file(named: 'key') do |file_path|
+          key = run_described_fastlane_action(
             bucket: test_bucket,
             key: 'key',
-            file: file_path
+            file: file_path,
+            skip_if_exists: true
           )
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
-      end
-    end
-
-    it 'just logs if the file already exists on S3 and skip_if_exists:true' do
-      expected_key = 'a62f2225bf70bfaccbc7f1ef2a397836717377de/key'
-      stub_s3_response_for_file(expected_key)
-
-      warnings = []
-      allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
-
-      with_tmp_file(named: 'key') do |file_path|
-        key = run_described_fastlane_action(
-          bucket: test_bucket,
-          key: 'key',
-          file: file_path,
-          skip_if_exists: true
-        )
-        expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
-        expect(key).to eq(expected_key)
+          expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
+          expect(key).to eq(expected_key)
+        end
       end
     end
   end


### PR DESCRIPTION
As discussed in Slack p1667975573803849/1667390691.763629-slack-CC7L49W13, we want to allow `upload_to_s3` to be able to just log the error if the file already exists in S3, to make it a soft error (instead of a hard one that makes the lane crash and fail).

This will especially be useful so that we can make the "Installable Build" (Android app repos) and "Upload to S3" (Android lib repos) steps in CI not fail when users rebuild a whole CI pipeline—that failed on other steps but already uploaded the Installable Build to S3 in the first run—from scratch.

## To Test

 - Validate that the new tests/spec added in this PR on CI do pass ✅ 
 - Check that [the PR in WPAndroid I opened to test this in action](https://github.com/wordpress-mobile/WordPress-Android/pull/17442#discussion_r1018050599) demonstrates the use case properly ✅ 