### PR TITLE
Add ability for the caller to handle the firebase failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-* All `android_firebase_test` to not crash on failure, allowing the caller to do custom failure handling (e.g. Buildkite Annotations, etc) on their side. [#430]
+* Allow `android_firebase_test` to not crash on failure, letting the caller do custom failure handling (e.g. Buildkite Annotations, etc) on their side. [#430]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+* All `android_firebase_test` to not crash on failure, allowing the caller to do custom failure handling (e.g. Buildkite Annotations, etc) on their side. [#430]
 
 ### Bug Fixes
 


### PR DESCRIPTION
Especially so they can use `buildkite-annotate` and/or do other steps to report the failure before bailing

### To Test

See [this PR in WordPress-Android](https://github.com/wordpress-mobile/WordPress-Android/pull/17581) where this new feature has been tested and used, in particular:
 - [This Buildkite run](https://buildkite.com/automattic/wordpress-android/builds/7990) where an intentional failure was triggered and you can see the annotation
 - [This Buildkite run](https://buildkite.com/automattic/wordpress-android/builds/latest?branch=tooling/firebase-test-failure-annotation) where the intentional failure was reverted and you can see the Instrumented Tests step green and no annotation.