### PR TITLE
Bump the VM image used to Xcode 14.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   env: &xcode_image
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14.1
   plugins:
   - &docker_plugin
     docker#v3.8.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Update the CI image used to build this project to use `xcode-14.1`. [#431]
 
 ## 6.0.0
 


### PR DESCRIPTION
What it says on the tin.

Not that we require a recent Xcode to build the toolkit per se; but using a more recent one will mostly avoid having our CI Mac hosts having to download an older xcode VM (which made [my last build for my recent other PR take 1h to build](https://buildkite.com/automattic/release-toolkit/builds/816#0184c8e4-1b51-4aad-b247-630d1ada21a4)), and instead use one that most other repos use — and thus which is more likely to be cached in our Mac hosts, at least for the upcoming months or so.

