### PR TITLE
Release 6.1.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 6.1.0
+
+### New Features
+
 - Allow `android_firebase_test` to not crash on failure, letting the caller do custom failure handling (e.g. Buildkite Annotations, etc) on their side. [#430]
 - `promo_screenshots` now checks that the fonts—referenced via `font-family` in all the stylesheets referenced in the config file—are installed before starting, and prompt to install them if they are not. This check is enabled by default now but can be disabled/skipped if it causes any issue. [#429]
 - `promo_screenshots` now supports config files to be written in `YAML` in addition to still supporting `JSON`. [#429]  
@@ -17,10 +31,6 @@ _None_
 ### Bug Fixes
 
 - Fix deprecation warning in `RMagick` call used by `promo_screenshots` action. [#429]
-
-### Internal Changes
-
-_None_
 
 ## 6.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (6.0.0)
+    fastlane-plugin-wpmreleasetoolkit (6.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '6.0.0'
+    VERSION = '6.1.0'
   end
 end


### PR DESCRIPTION
New version 6.1.0 (especially so I can start using it for https://github.com/wordpress-mobile/WordPress-Android/pull/17584)

_PR Author: Be sure to create a GitHub Release and tag once this PR gets merged._