### PR TITLE
Add Mac support to Release Toolkit actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Added Mac support to all `common` actions and any relevant `ios` actions [#439]
 
 ### Bug Fixes
 
@@ -36,7 +36,7 @@ _None_
 
 - Allow `android_firebase_test` to not crash on failure, letting the caller do custom failure handling (e.g. Buildkite Annotations, etc) on their side. [#430]
 - `promo_screenshots` now checks that the fonts—referenced via `font-family` in all the stylesheets referenced in the config file—are installed before starting, and prompt to install them if they are not. This check is enabled by default now but can be disabled/skipped if it causes any issue. [#429]
-- `promo_screenshots` now supports config files to be written in `YAML` in addition to still supporting `JSON`. [#429]  
+- `promo_screenshots` now supports config files to be written in `YAML` in addition to still supporting `JSON`. [#429]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -83,7 +83,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :android].include?(platform)
+        true
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -163,7 +163,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :android].include?(platform)
+        true
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -91,7 +91,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -91,7 +91,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -67,7 +67,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -67,7 +67,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -70,7 +70,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -70,7 +70,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -44,7 +44,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
 
       private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -44,7 +44,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
 
       private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -75,7 +75,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
 
       private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -75,7 +75,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
 
       private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -84,7 +84,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
 
       private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -84,7 +84,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
 
       private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -55,7 +55,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -55,7 +55,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -69,7 +69,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -69,7 +69,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -56,7 +56,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -56,7 +56,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
@@ -33,7 +33,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_current_branch_is_hotfix.rb
@@ -33,7 +33,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -45,7 +45,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -45,7 +45,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -57,7 +57,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -57,7 +57,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb
@@ -53,7 +53,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
@@ -71,7 +71,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
@@ -71,7 +71,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
@@ -37,7 +37,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_tag_build.rb
@@ -37,7 +37,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
@@ -33,7 +33,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata.rb
@@ -33,7 +33,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -74,7 +74,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -74,7 +74,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -54,7 +54,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -54,7 +54,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
@@ -39,7 +39,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        [:ios, :mac.include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_validate_ci_build.rb
@@ -39,7 +39,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac.include?(platform)
+        [:ios, :mac].include?(platform)
       end
     end
   end


### PR DESCRIPTION
## What does it do?
Many of the Release Toolkit actions only included iOS in the available platforms that could be used with that action. With Day One Mac, most of those actions can be used on Mac as well as iOS. This PR adds Mac as a supported platform for all the relevant actions so Day One Mac can use them as well. I went ahead and updated all the relevant actions even if Day One Mac isn't currently using them, just for the sake of not having to make a new Release Toolkit release in the future in case more of them end up being needed. 

For the two actions I changed in the `common` folder, I switched them from `[:ios, :android].include?(platform)` to `true` to match the other actions in `common`. 

For the actions in the `ios` folder, I changed them from `platform == :ios` to `[:ios, :mac.include?(platform)`. A few of them had already been updated, I assume for Simplenote Mac. 

I know it may not make sense to have Mac support in Release Toolkit actions that are specifically labeled "iOS". Because Day One Mac and Simplenote Mac are the only Automattic apps that might even potentially use them right now, I think it makes sense to just add Mac support for these actions rather than duplicating them into a separate `mac` folder. Especially because all of those actions would be just be exact copies of the code within the iOS actions. 

## How to Test
1. In an app like WordPress-iOS, open the Gemfile and change it from this: 

```
# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'trunk'
gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
```

to this: 

```
gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'add/mac-support-in-ios-actions'
# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 6.0'
```

2. Run `bundle install` to get the changes from this PR's branch
3. Add this to the Fastfile: 

```
platform :mac do
  lane :test_mac_support do
    ios_get_app_version
  end
end
```
4. Run `bundle exec fastlane mac test_mac_support`
5. That command should successfully run. Before this PR, it would give an error about Mac not being a supported platform for that action. 

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.