### PR TITLE
Remove `skip_glotpress` and related cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-_None_
+- Remove the `skip_glotpress` parameter from the `ios_bump_version_release` action [#443]
 
 ### New Features
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -21,10 +21,6 @@ module Fastlane
         Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: default_branch)
         UI.message 'Done!'
 
-        UI.message 'Updating glotPressKeys...' unless params[:skip_glotpress]
-        update_glotpress_key unless params[:skip_glotpress]
-        UI.message 'Done' unless params[:skip_glotpress]
-
         UI.message 'Updating Fastlane deliver file...' unless params[:skip_deliver]
         Fastlane::Helper::Ios::VersionHelper.update_fastlane_deliver(@new_short_version) unless params[:skip_deliver]
         UI.message 'Done!' unless params[:skip_deliver]
@@ -35,7 +31,7 @@ module Fastlane
 
         Fastlane::Helper::Ios::GitHelper.commit_version_bump(
           include_deliverfile: !params[:skip_deliver],
-          include_metadata: !params[:skip_glotpress]
+          include_metadata: false
         )
 
         UI.message 'Done.'
@@ -55,16 +51,11 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :skip_glotpress,
-                                       env_name: 'FL_IOS_CODEFREEZE_BUMP_SKIPGLOTPRESS',
-                                       description: 'Skips GlotPress key update',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false), # the default value if the user didn't provide one
           FastlaneCore::ConfigItem.new(key: :skip_deliver,
                                        env_name: 'FL_IOS_CODEFREEZE_BUMP_SKIPDELIVER',
                                        description: 'Skips Deliver key update',
-                                       is_string: false, # true: verifies the input is a string, false: every kind of value
-                                       default_value: false), # the default value if the user didn't provide one
+                                       type: Boolean,
+                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',
@@ -104,15 +95,6 @@ module Fastlane
         UI.message("New internal version: #{@new_version_internal}") unless ENV['INTERNAL_CONFIG_FILE'].nil?
         UI.message("New short version: #{@new_short_version}")
         UI.message("Release branch: #{@new_release_branch}")
-      end
-
-      def self.update_glotpress_key
-        dm_file = ENV['DOWNLOAD_METADATA']
-        if File.exist?(dm_file)
-          sh("sed -i '' \"s/let glotPressWhatsNewKey.*/let glotPressWhatsNewKey = \\\"v#{@new_short_version}-whats-new\\\"/\" #{dm_file}")
-        else
-          UI.user_error!("Can't find #{dm_file}.")
-        end
       end
     end
   end

--- a/spec/ios_bump_version_release_spec.rb
+++ b/spec/ios_bump_version_release_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IosBumpVersionReleaseAction do
+  let(:default_branch) { 'my_new_branch' }
+  let(:ensure_git_action_instance) { double() }
+  let(:versions) { ['6.30'] }
+  let(:next_version) { '6.31.0.0' }
+  let(:next_version_short) { '6.31' }
+
+  describe 'creates the release branch, bumps the app version and commits the changes' do
+    before do
+      allow(Fastlane::Action).to receive(:other_action).and_return(ensure_git_action_instance)
+      allow(ensure_git_action_instance).to receive(:ensure_git_branch).with(branch: default_branch)
+
+      allow(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(default_branch)
+      allow(Fastlane::Helper::GitHelper).to receive(:create_branch).with("release/#{next_version_short}", from: default_branch)
+
+      allow(Fastlane::Helper::Ios::VersionHelper).to receive(:get_version_strings).and_return(versions)
+      allow(Fastlane::Helper::Ios::VersionHelper).to receive(:update_xc_configs).with(next_version, next_version_short, nil)
+    end
+
+    it 'does the fastlane deliver update' do
+      skip_deliver = false
+
+      expect(Fastlane::Helper::Ios::VersionHelper).to receive(:update_fastlane_deliver).with(next_version_short)
+      expect(Fastlane::Helper::Ios::GitHelper).to receive(:commit_version_bump).with(include_deliverfile: !skip_deliver, include_metadata: false)
+
+      run_described_fastlane_action(
+        skip_deliver: skip_deliver,
+        default_branch: default_branch
+      )
+    end
+
+    it 'skips the fastlane deliver update properly' do
+      skip_deliver = true
+
+      expect(Fastlane::Helper::Ios::VersionHelper).not_to receive(:update_fastlane_deliver)
+      expect(Fastlane::Helper::Ios::GitHelper).to receive(:commit_version_bump).with(include_deliverfile: !skip_deliver, include_metadata: false)
+
+      run_described_fastlane_action(
+        skip_deliver: skip_deliver,
+        default_branch: default_branch
+      )
+    end
+  end
+end

--- a/spec/ios_bump_version_release_spec.rb
+++ b/spec/ios_bump_version_release_spec.rb
@@ -2,15 +2,15 @@ require 'spec_helper'
 
 describe Fastlane::Actions::IosBumpVersionReleaseAction do
   let(:default_branch) { 'my_new_branch' }
-  let(:ensure_git_action_instance) { double() }
   let(:versions) { ['6.30'] }
   let(:next_version) { '6.31.0.0' }
   let(:next_version_short) { '6.31' }
 
   describe 'creates the release branch, bumps the app version and commits the changes' do
     before do
-      allow(Fastlane::Action).to receive(:other_action).and_return(ensure_git_action_instance)
-      allow(ensure_git_action_instance).to receive(:ensure_git_branch).with(branch: default_branch)
+      other_action_mock = double()
+      allow(Fastlane::Action).to receive(:other_action).and_return(other_action_mock)
+      allow(other_action_mock).to receive(:ensure_git_branch).with(branch: default_branch)
 
       allow(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(default_branch)
       allow(Fastlane::Helper::GitHelper).to receive(:create_branch).with("release/#{next_version_short}", from: default_branch)


### PR DESCRIPTION
**EDIT:**
The initial PR had a few other related changes, but independent, so we decided to break it down into smaller PRs built on top of this one. See **Related PRs**.

## What does it do?

### 1️⃣ Removes the `skip_glotpress` parameter from the `ios_bump_version_release` action
Fixing #372, this PR goes on the route of completely removing the `skip_glotpress` config item, given the latest localisation tooling doesn't rely on a local `download_metadata.swift` in the hosted project anymore.

### 2️⃣ Adds basic tests to `ios_bump_version_release`
In order to test the changes, a suite of basic unit tests were added to the `ios_bump_version_release` action.

## Related PRs
- https://github.com/iangmaia/release-toolkit/pull/2 -- includes the changes from @mokagio's [old PR](https://github.com/wordpress-mobile/release-toolkit/pull/370) and builds on top of this one.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.