### PR TITLE
Add configuration item for .xcconfig file in `ios_get_app_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 - Remove the `skip_glotpress` parameter from the `ios_bump_version_release` action [#443]
+- Add the `public_version_xcconfig_file` parameter to the `ios_get_app_version` action to replace the need for an environment variable [#445]
 - Remove the `ios_localize_project` and `ios_update_metadata` actions [#447]
 
 ### New Features

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -24,7 +24,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :public_version_xcconfig_file,
-            env_name: 'FL_IOS_GET_APP_VERSION_PUBLIC_VERSION_XCCONFIG_FILE',
+            env_name: 'FL_IOS_PUBLIC_VERSION_XCCONFIG_FILE',
             description: 'Path to the .xcconfig file containing the public app version',
             type: String,
             optional: false

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_app_version.rb
@@ -4,9 +4,8 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/ios/ios_version_helper'
 
-        UI.user_error!('You need to set at least the PUBLIC_CONFIG_FILE env var to the path to the public xcconfig file') unless ENV['PUBLIC_CONFIG_FILE']
-
-        Fastlane::Helper::Ios::VersionHelper.get_public_version
+        public_version_xcconfig_file = params[:public_version_xcconfig_file]
+        Fastlane::Helper::Ios::VersionHelper.get_xcconfig_public_version(xcconfig_file: public_version_xcconfig_file)
       end
 
       #####################################################
@@ -22,7 +21,15 @@ module Fastlane
       end
 
       def self.available_options
-        # Define all options your action supports.
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :public_version_xcconfig_file,
+            env_name: 'FL_IOS_GET_APP_VERSION_PUBLIC_VERSION_XCCONFIG_FILE',
+            description: 'Path to the .xcconfig file containing the public app version',
+            type: String,
+            optional: false
+          ),
+        ]
       end
 
       def self.output

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -15,12 +15,30 @@ module Fastlane
 
         # Returns the public-facing version string.
         #
+        # @param [String] xcconfig_file The path for the .xcconfig file containing the public-facing version
+        #
         # @return [String] The public-facing version number, extracted from the VERSION_LONG entry of the xcconfig file.
         #         - If this version is a hotfix (more than 2 parts and 3rd part is non-zero), returns the "X.Y.Z" formatted string
         #         - Otherwise (not a hotfix / 3rd part of version is 0), returns "X.Y" formatted version number
         #
+        def self.get_xcconfig_public_version(xcconfig_file:)
+          version = read_long_version_from_config_file(xcconfig_file)
+          vp = get_version_parts(version)
+          return "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}" unless is_hotfix?(version)
+
+          "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}.#{vp[HOTFIX_NUMBER]}"
+        end
+
+        # Returns the public-facing version string.
+        #
+        # @return [String] The public-facing version number, extracted from the VERSION_LONG entry of the xcconfig file.
+        #         - If this version is a hotfix (more than 2 parts and 3rd part is non-zero), returns the "X.Y.Z" formatted string
+        #         - Otherwise (not a hotfix / 3rd part of version is 0), returns "X.Y" formatted version number
+        #
+        # @deprecated This method is going to be removed soon due to it's dependency on `ENV['PUBLIC_CONFIG_FILE']` via `get_build_version`.
+        #
         def self.get_public_version
-          version = get_build_version
+          version = get_build_version()
           vp = get_version_parts(version)
           return "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}" unless is_hotfix?(version)
 
@@ -169,7 +187,8 @@ module Fastlane
         # @return [String] The current version according to the public xcconfig file.
         #
         def self.get_build_version
-          versions = get_version_strings()[0]
+          xcconfig_file = ENV['PUBLIC_CONFIG_FILE']
+          read_long_version_from_config_file(xcconfig_file)
         end
 
         # Returns the current value of the `VERSION_LONG` key from the internal xcconfig file
@@ -177,7 +196,8 @@ module Fastlane
         # @return [String] The current version according to the internal xcconfig file.
         #
         def self.get_internal_version
-          get_version_strings()[1]
+          xcconfig_file = ENV['INTERNAL_CONFIG_FILE']
+          read_long_version_from_config_file(xcconfig_file)
         end
 
         # Prints the current and next release version numbers to stdout, then return the next release version
@@ -299,22 +319,6 @@ module Fastlane
           end
 
           return nil
-        end
-
-        # Read the version numbers from the xcconfig file
-        #
-        # @env PUBLIC_CONFIG_FILE The path to the xcconfig file containing the public version numbers.
-        # @env INTERNAL_CONFIG_FILE The path to the xcconfig file containing the internal version numbers. Can be nil.
-        #
-        # @return [String] Array of long version strings found.
-        #         The first element is always present and contains the version extracted from the public config file
-        #         The second element is the version extracted from the internal config file, only present if one was provided.
-        def self.get_version_strings
-          version_strings = []
-          version_strings << read_long_version_from_config_file(ENV['PUBLIC_CONFIG_FILE'])
-          version_strings << read_long_version_from_config_file(ENV['INTERNAL_CONFIG_FILE']) unless ENV['INTERNAL_CONFIG_FILE'].nil?
-
-          return version_strings
         end
 
         # Ensure that the version provided is only composed of number parts and return the validated string

--- a/spec/ios_bump_version_release_spec.rb
+++ b/spec/ios_bump_version_release_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Fastlane::Actions::IosBumpVersionReleaseAction do
   let(:default_branch) { 'my_new_branch' }
-  let(:versions) { ['6.30'] }
+  let(:version) { '6.30' }
   let(:next_version) { '6.31.0.0' }
   let(:next_version_short) { '6.31' }
 
@@ -15,7 +15,7 @@ describe Fastlane::Actions::IosBumpVersionReleaseAction do
       allow(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(default_branch)
       allow(Fastlane::Helper::GitHelper).to receive(:create_branch).with("release/#{next_version_short}", from: default_branch)
 
-      allow(Fastlane::Helper::Ios::VersionHelper).to receive(:get_version_strings).and_return(versions)
+      allow(Fastlane::Helper::Ios::VersionHelper).to receive(:read_from_config_file).and_return(version)
       allow(Fastlane::Helper::Ios::VersionHelper).to receive(:update_xc_configs).with(next_version, next_version_short, nil)
     end
 

--- a/spec/ios_get_app_version_spec.rb
+++ b/spec/ios_get_app_version_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IosGetAppVersionAction do
+  describe 'getting the public app version from the provided .xcconfig file' do
+    it 'parses the xcconfig file format correctly and gets the public version' do
+      xcconfig_mock_content = <<~CONTENT
+        // a comment
+        VERSION_SHORT=6
+        VERSION_LONG=6.30.0
+      CONTENT
+
+      allow(File).to receive(:exist?).and_return(true)
+
+      expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30')
+    end
+
+    it 'parses the xcconfig file format correctly and gets the public hotfix version' do
+      xcconfig_mock_content = <<~CONTENT
+        VERSION_SHORT=6
+        // a comment
+        VERSION_LONG=6.30.1
+      CONTENT
+
+      allow(File).to receive(:exist?).and_return(true)
+
+      expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30.1')
+    end
+
+    def expect_version(xcconfig_mock_content:, expected_version:)
+      xcconfig_mock_file_path = File.join('mock', 'file', 'path')
+
+      allow(File).to receive(:open).with(xcconfig_mock_file_path, 'r').and_yield(StringIO.new(xcconfig_mock_content))
+
+      version_result = run_described_fastlane_action(
+        public_version_xcconfig_file: xcconfig_mock_file_path
+      )
+
+      expect(version_result).to eq(expected_version)
+    end
+  end
+end


### PR DESCRIPTION
## What does it do?
This PR fixes #380 by adding a configuration item in the action `ios_get_app_version`, to be used instead of the environment variable `ENV['PUBLIC_CONFIG_FILE']`.

### 1️⃣ Adds the parameter `public_version_xcconfig_file` as a ConfigItem to the action `ios_get_app_version`.
The new parameter will be used to extract the app version, without relying on environment variables and deprecating the method that still does.
In order to to that, I've created a parameterised copy of the method `Ios::VersionHelper.get_public_version()`, which I called `Ios::VersionHelper.get_xcconfig_public_version`, also marking the original version as deprecated, and eventually we should stop using it.

Please note that there are still many uses in the codebase of the `ENV['PUBLIC_CONFIG_FILE']` (as well as `ENV['INTERNAL_CONFIG_FILE']`), not only directly in the actions but by their dependencies. These should be addressed in follow up Pull Requests.

### 2️⃣ Adds basic tests to `ios_get_app_version`
Basic tests to the action functionality. These tests are gonna be extended in the next PR, where I'll also improve some of the related code in `Ios::VersionHelper`.

## Related PRs
- [This PR](https://github.com/iangmaia/release-toolkit/pull/1) improves the code for the .xcconfig parsing and adds new tests to `ios_get_app_version`

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.