### PR TITLE
Add `prototype_build_details_comment` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add new `buildkite_annotate` action to add/remove annotations from the current build. [#442]
 - Add new `buildkite_metadata` action to set/get metadata from the current build. [#442]
+- Add new `prototype_build_details_comment` action to make it easier to generate the HTML comment about Prototype Builds in PRs. [#449]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -47,7 +47,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Generates the nicely-formatted string providing all the details of a prototype build, ready to be used as a PR comment (e.g. via `comment_on_pr`).'
+        'Generates a string providing all the details of a prototype build, nicely-formatted and ready to be used as a PR comment (e.g. via `comment_on_pr`).'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -11,7 +11,7 @@ module Fastlane
         metadata = params[:metadata] # e.g. {'Build Config':… , 'Version': …, 'Short Version': …}
         direct_link = params[:download_url]
         unless direct_link.nil?
-          metadata['Direct Link'] = "<a href='#{direct_link}'><tt>#{File.basename(direct_link)}</tt></a>"
+          metadata['Direct Link'] = "<a href='#{direct_link}'><code>#{File.basename(direct_link)}</code></a>"
         end
 
         # Build the comment parts
@@ -26,11 +26,11 @@ module Fastlane
           <table>
           <tr>
             <td rowspan='#{metadata.count + 3}'><img src='#{qr_code_url}' width='250' height='250' /></td>
-            <td width='150px'><b>App Name</b></td><td><tt>#{appcenter_app_name}</tt></td>
+            <td width='150px'><b>App Name</b></td><td><code>#{appcenter_app_name}</code></td>
           </tr>
           #{metadata_rows.join("\n")}
           <tr><td><b>App Center Build</b></td><td><a href='#{install_url}'>Build \##{appcenter_release_id}</a></td></tr>
-          <tr><td><b>Commit</b></td><td><tt>#{commit}</tt></td></tr>
+          <tr><td><b>Commit</b></td><td><code>#{commit}</code></td></tr>
           </table>
           #{params[:footnote]}
         COMMENT_BODY

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -18,7 +18,7 @@ module Fastlane
         metadata = params[:metadata]&.transform_keys(&:to_s) || {}
         metadata['Build Number'] ||= app_center_info['version']
         metadata['Version'] ||= app_center_info['short_version']
-        metadata[app_center_info['app_os'] == 'Android' ? 'Application ID' : 'Bundle ID'] = app_center_info['bundle_identifier']
+        metadata[app_center_info['app_os'] == 'Android' ? 'Application ID' : 'Bundle ID'] ||= app_center_info['bundle_identifier']
         # (Feel free to add more CI-specific env vars in the line below to support other CI providers if you need)
         metadata['Commit'] ||= ENV.fetch('BUILDKITE_COMMIT', nil) || other_action.last_git_commit[:abbreviated_commit_hash]
 
@@ -39,7 +39,7 @@ module Fastlane
         icon_img_tag = img_tag(params[:app_icon] || app_center_info['app_icon_url'], alt: app_display_name)
         metadata_rows = metadata.compact.map { |key, value| "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>" }
         intro = "#{icon_img_tag}📲 You can test the changes from this Pull Request in <b>#{app_display_name}</b> by scanning the QR code below to install the corresponding build."
-        footnote = params[:footnote] || (app_center_org_name.nil? ? '' : '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>')
+        footnote = params[:footnote] || (app_center_org_name.nil? ? '' : DEFAULT_APP_CENTER_FOOTNOTE)
         body = <<~COMMENT_BODY
           <table>
           <tr>
@@ -67,6 +67,8 @@ module Fastlane
          - Either use this action right after using `appcenter_upload` and provide an `app_center_org_name` (so that this action can use the link to the App Center build)
          - Or provide an explicit value for the `download_url` parameter
       NO_URL_ERROR
+
+      DEFAULT_APP_CENTER_FOOTNOTE = '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'.freeze
 
       def self.img_tag(url_or_emoji, alt: '')
         return nil if url_or_emoji.nil?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -2,17 +2,24 @@ module Fastlane
   module Actions
     class PrototypeBuildDetailsCommentAction < Action
       def self.run(params)
+        # Get Input Parameters
         appcenter_org_name = params[:appcenter_org_name]
         appcenter_app_name = params[:appcenter_app_name]
         appcenter_release_id = params[:appcenter_release_id]
         commit = params[:commit] || other_action.last_git_commit[:abbreviated_commit_hash]
-        metadata = params[:metadata] # e.g. {'Build Config':… , 'Version': …, 'Short Version': …}
 
+        metadata = params[:metadata] # e.g. {'Build Config':… , 'Version': …, 'Short Version': …}
+        direct_link = params[:download_url]
+        unless direct_link.nil?
+          metadata['Direct Link'] = "<a href='#{direct_link}'><tt>#{File.basename(direct_link)}</tt></a>"
+        end
+
+        # Build the comment parts
         install_url = "https://install.appcenter.ms/orgs/#{appcenter_org_name}/apps/#{appcenter_app_name}/releases/#{appcenter_release_id}"
         qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
-        metadata_rows = metadata.map do |key, value|
+        metadata_rows = metadata.compact.map do |key, value|
           "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>"
-        end.join("\n")
+        end
 
         intro = "📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>#{appcenter_app_name}</strong> build from App Center."
         body = <<~COMMENT_BODY
@@ -21,7 +28,7 @@ module Fastlane
             <td rowspan='#{metadata.count + 3}'><img src='#{qr_code_url}' width='250' height='250' /></td>
             <td width='150px'><b>App</b></td><td><tt>#{appcenter_app_name}</tt></td>
           </tr>
-          #{metadata_rows}
+          #{metadata_rows.join("\n")}
           <tr><td><b>App Center Build</b></td><td><a href='#{install_url}'>Build \##{appcenter_release_id}</a></td></tr>
           <tr><td><b>Commit</b></td><td><tt>#{commit}</tt></td></tr>
           </table>
@@ -62,6 +69,14 @@ module Fastlane
             env_name: 'FL_PROTOTYPE_BUILD_APPCENTER_RELEASE_ID',
             description: 'The release ID/Number in App Center',
             type: Integer
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :download_url,
+            env_name: 'FL_PROTOTYPE_BUILD_DOWNLOAD_URL',
+            description: 'The URL to download the build directly; e.g. a public link to the `.apk` file; you might use `lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]` for this for example',
+            type: String,
+            optional: true,
+            default_value: nil
           ),
           FastlaneCore::ConfigItem.new(
             key: :fold,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -26,7 +26,7 @@ module Fastlane
           <table>
           <tr>
             <td rowspan='#{metadata.count + 3}'><img src='#{qr_code_url}' width='250' height='250' /></td>
-            <td width='150px'><b>App</b></td><td><tt>#{appcenter_app_name}</tt></td>
+            <td width='150px'><b>App Name</b></td><td><tt>#{appcenter_app_name}</tt></td>
           </tr>
           #{metadata_rows.join("\n")}
           <tr><td><b>App Center Build</b></td><td><a href='#{install_url}'>Build \##{appcenter_release_id}</a></td></tr>

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -21,7 +21,7 @@ module Fastlane
           "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>"
         end
 
-        intro = "📲 You can test the changes from this Pull Request in <strong>#{appcenter_app_name}</strong> by scanning the QR code below to install the corresponding build via App Center."
+        intro = "📲 You can test the changes from this Pull Request in <b>#{appcenter_app_name}</b> by scanning the QR code below to install the corresponding build via App Center."
         body = <<~COMMENT_BODY
           <table>
           <tr>

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -26,11 +26,11 @@ module Fastlane
           <table>
           <tr>
             <td rowspan='#{metadata.count + 3}'><img src='#{qr_code_url}' width='250' height='250' /></td>
-            <td width='150px'><b>App Name</b></td><td><code>#{appcenter_app_name}</code></td>
+            <td width='150px'><b>App Name</b></td><td>#{appcenter_app_name}</td>
           </tr>
           #{metadata_rows.join("\n")}
           <tr><td><b>App Center Build</b></td><td><a href='#{install_url}'>Build \##{appcenter_release_id}</a></td></tr>
-          <tr><td><b>Commit</b></td><td><code>#{commit}</code></td></tr>
+          <tr><td><b>Commit</b></td><td>#{commit}</td></tr>
           </table>
           #{params[:footnote]}
         COMMENT_BODY

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -36,7 +36,7 @@ module Fastlane
         COMMENT_BODY
 
         if params[:fold]
-          "<details>#{intro}</details>\n<summary>\n#{body}</summary>\n"
+          "<details><summary>#{intro}</summary>\n#{body}</details>\n"
         else
           "<p>#{intro}</p>\n#{body}"
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -1,0 +1,104 @@
+module Fastlane
+  module Actions
+    class PrototypeBuildDetailsCommentAction < Action
+      def self.run(params)
+        appcenter_org_name = params[:appcenter_org_name]
+        appcenter_app_name = params[:appcenter_app_name]
+        appcenter_release_id = params[:appcenter_release_id]
+        commit = params[:commit] || other_action.last_git_commit[:abbreviated_commit_hash]
+
+        metadata = params[:metadata] # e.g. {'Build Config':… , 'Version': …, 'Short Version': …}
+
+        install_url = "https://install.appcenter.ms/orgs/#{appcenter_org_name}/apps/#{appcenter_app_name}/releases/#{appcenter_release_id}"
+        qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
+
+        metadata_rows = metadata.map do |key, value|
+          "<tr><td><b>#{key}</b></td><td><tt>#{value}</tt></td></tr>"
+        end.join("\n")
+
+        <<~COMMENT_BODY
+          <p>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>#{appcenter_app_name}</strong> build from App Center.</p>
+          <table>
+          <tr>
+            <td rowspan='#{metadata.count + 3}'><img src='#{qr_code_url}' width='250' height='250' /></td>
+            <td width='150px'><b>App</b></td><td><tt>#{appcenter_app_name}</tt></td>
+          </tr>
+          #{metadata_rows}
+          <tr><td><b>App Center Build</b></td><td><a href='#{install_url}'>Build \##{appcenter_release_id}</a></td></tr>
+          <tr><td><b>Commit</b></td><td><tt>#{commit}</tt></td></tr>
+          </table>
+          #{params[:footnote]}
+        COMMENT_BODY
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Generates the nicely-formatted string providing all the details of a prototype build, ready to be used as a PR comment (e.g. via `comment_on_pr`).'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :appcenter_org_name,
+            env_name: 'APPCENTER_OWNER_NAME', # Same as the one used by the `appcenter_upload` action
+            description: 'The name of the organization in App Center',
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :appcenter_app_name,
+            env_name: 'APPCENTER_APP_NAME', # Same as the one used by the `appcenter_upload` action
+            description: 'The name of the app in App Center',
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :appcenter_release_id,
+            env_name: 'FL_PROTOTYPE_BUILD_APPCENTER_RELEASE_ID',
+            description: 'The release ID/Number in App Center',
+            type: Integer
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :metadata,
+            env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_METADATA',
+            description: 'All additional metadata (as key/value pairs) you want to include in the HTML table of the comment',
+            type: Hash,
+            optional: true,
+            default_value: {}
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :footnote,
+            env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_FOOTNOTE',
+            description: 'Optional footnote to add below the HTML table of the comment',
+            type: String,
+            default_value: '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :commit,
+            env_name: 'BUILDKITE_COMMIT',
+            description: 'The commit this prototype build was build from; usually not passed explicitly, but derived from the environment variable instead',
+            type: String,
+            optional: true
+          ),
+        ]
+      end
+
+      def self.return_type
+        :string
+      end
+
+      def self.return_value
+        'The HTML comment containing all the relevant info about a Prototype build published to App Center'
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -67,7 +67,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :appcenter_release_id,
             env_name: 'FL_PROTOTYPE_BUILD_APPCENTER_RELEASE_ID',
-            description: 'The release ID/Number in App Center',
+            description: "The release ID/Number in App Center; can be obtained using `lane_context[SharedValues::APPCENTER_BUILD_INFORMATION]['id']`",
             type: Integer
           ),
           FastlaneCore::ConfigItem.new(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -13,7 +13,7 @@ module Fastlane
         qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
 
         metadata_rows = metadata.map do |key, value|
-          "<tr><td><b>#{key}</b></td><td><tt>#{value}</tt></td></tr>"
+          "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>"
         end.join("\n")
 
         <<~COMMENT_BODY

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -2,37 +2,49 @@ module Fastlane
   module Actions
     class PrototypeBuildDetailsCommentAction < Action
       def self.run(params)
-        # Get Input Parameters
-        appcenter_org_name = params[:appcenter_org_name]
-        appcenter_app_name = params[:appcenter_app_name]
-        appcenter_release_id = params[:appcenter_release_id]
-        commit = params[:commit] || other_action.last_git_commit[:abbreviated_commit_hash]
+        app_display_name = params[:app_display_name]
 
-        metadata = params[:metadata] # e.g. {'Build Config':… , 'Version': …, 'Short Version': …}
-        direct_link = params[:download_url]
-        unless direct_link.nil?
-          metadata['Direct Link'] = "<a href='#{direct_link}'><code>#{File.basename(direct_link)}</code></a>"
+        app_center_org_name = params[:app_center_org_name]
+        app_center_info = app_center_org_name.nil? ? {} : lane_context[SharedValues::APPCENTER_BUILD_INFORMATION] || {}
+        app_center_app_name = params[:app_center_app_name] || app_center_info['app_name']
+        app_center_app_display_name = app_center_info['app_display_name'] || app_center_app_name
+        app_center_release_id = params[:app_center_release_id] || app_center_info['id']
+
+        # Consolidate the list of Metadata to display with some implicit metadata if available
+        metadata = params[:metadata] || {}
+        metadata['Build Number'] ||= app_center_info['version']
+        metadata['Version'] ||= app_center_info['short_version']
+        metadata[app_center_info['app_os'] == 'Android' ? 'Application ID' : 'Bundle ID'] = app_center_info['bundle_identifier']
+        # (Feel free to add more CI-specific env vars in the line below to support other CI providers if you need)
+        metadata['Commit'] ||= ENV.fetch('BUILDKITE_COMMIT', nil) || other_action.last_git_commit[:abbreviated_commit_hash]
+
+        # Installation Link(s) -- either download_url param, or App Center Build link, or both
+        install_url = nil
+        if params[:download_url]
+          install_url = params[:download_url]
+          metadata['Direct Download'] = "<a href='#{install_url}'><code>#{File.basename(install_url)}</code></a>"
         end
+        if app_center_org_name && app_center_app_name
+          install_url = "https://install.appcenter.ms/orgs/#{app_center_org_name}/apps/#{app_center_app_name}/releases/#{app_center_release_id}"
+          metadata['App Center Build'] = "<a href='#{install_url}'>#{app_center_app_display_name} \##{app_center_release_id}</a>"
+        end
+        UI.user_error!(NO_INSTALL_URL_ERROR_MESSAGE) if install_url.nil?
+        qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
 
         # Build the comment parts
-        install_url = "https://install.appcenter.ms/orgs/#{appcenter_org_name}/apps/#{appcenter_app_name}/releases/#{appcenter_release_id}"
-        qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
-        metadata_rows = metadata.compact.map do |key, value|
-          "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>"
-        end
-
-        intro = "📲 You can test the changes from this Pull Request in <b>#{appcenter_app_name}</b> by scanning the QR code below to install the corresponding build via App Center."
+        icon_img_tag = img_tag(params[:app_icon] || app_center_info['app_icon_url'], alt: app_display_name)
+        metadata_rows = metadata.compact.map { |key, value| "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>" }
+        intro = "#{icon_img_tag}📲 You can test the changes from this Pull Request in <b>#{app_display_name}</b> by scanning the QR code below to install the corresponding build."
+        footnote = params[:footnote] || (app_center_info.nil? ? '' : '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>')
         body = <<~COMMENT_BODY
           <table>
           <tr>
-            <td rowspan='#{metadata.count + 3}'><img src='#{qr_code_url}' width='250' height='250' /></td>
-            <td width='150px'><b>App Name</b></td><td>#{appcenter_app_name}</td>
+            <td rowspan='#{metadata.count + 1}' width='260px'><img src='#{qr_code_url}' width='250' height='250' /></td>
+            <td width='150px'><b>App Name</b></td><td>#{icon_img_tag} #{app_display_name}</td>
           </tr>
           #{metadata_rows.join("\n")}
-          <tr><td><b>App Center Build</b></td><td><a href='#{install_url}'>Build \##{appcenter_release_id}</a></td></tr>
-          <tr><td><b>Commit</b></td><td>#{commit}</td></tr>
           </table>
-          #{params[:footnote]}
+          #{footnote}
         COMMENT_BODY
 
         if params[:fold]
@@ -43,6 +55,28 @@ module Fastlane
       end
 
       #####################################################
+      # @!group Helpers
+      #####################################################
+
+      NO_INSTALL_URL_ERROR_MESSAGE = <<~NO_URL_ERROR.freeze
+        No URL provided to download or install the app.
+         - Either use this action right after using `appcenter_upload` and provide an `app_center_org_name` (so that this action can use the link to the App Center build)
+         - Or provide an explicit value for the `download_url` parameter
+      NO_URL_ERROR
+
+      def self.img_tag(url_or_emoji, alt: '')
+        return nil if url_or_emoji.nil?
+
+        emoji = url_or_emoji.match(/:(.*):/)&.captures&.first
+        app_icon_url = if emoji
+                         "https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/#{emoji}.png"
+                       elsif URI(url_or_emoji)
+                         url_or_emoji
+                       end
+        app_icon_url ? "<img alt='#{alt}' align='top' src='#{app_icon_url}' width='20px' />" : ''
+      end
+
+      #####################################################
       # @!group Documentation
       #####################################################
 
@@ -50,30 +84,75 @@ module Fastlane
         'Generates a string providing all the details of a prototype build, nicely-formatted and ready to be used as a PR comment (e.g. via `comment_on_pr`).'
       end
 
+      def self.details
+        <<~DESC
+          Generates a string providing all the details of a prototype build, nicely-formatted as HTML.
+          The returned string will typically be subsequently used by the `comment_on_pr` action to post that HTML as comment on a PR.
+
+          If you used the `appcenter_upload` lane (to upload the Prototype build to App Center) before calling this action, and pass
+          a value to the `app_center_org_name` parameter, then many of the parameters and metadata will be automatically extracted
+          from the `lane_context` provided by `appcenter_upload`, including:
+
+           - The `app_center_app_name`, `app_center_release_id` and installation URL to use for the QR code to point to that release in App Center
+           - The `app_icon`
+           - The app's Build Number / versionCode
+           - The app's Version / versionName
+           - The app's Bundle ID / Application ID
+           - A `footnote` mentioning the MC tool for Automatticians to add themselves to App Center
+
+          This means that if you are using App Center to distribute your Prototype Build, the only parameters you *have* to provide
+          to this action are `app_display_name` and `app_center_org_name`; plus, for `metadata` most of the interesting values will already be pre-filled.
+
+          Any of those implicit default values/metadata can of course be overridden by passing an explicit value to the appropriate parameter(s).
+        DESC
+      end
+
       def self.available_options
+        app_center_auto = '(will be automatically extracted from `lane_context if you used `appcenter_upload` to distribute your Prototype build)'
         [
           FastlaneCore::ConfigItem.new(
-            key: :appcenter_org_name,
-            env_name: 'APPCENTER_OWNER_NAME', # Same as the one used by the `appcenter_upload` action
-            description: 'The name of the organization in App Center',
+            key: :app_display_name,
+            env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_APP_DISPLAY_NAME',
+            description: 'The display name to use for the app in the comment message',
+            optional: false,
             type: String
           ),
           FastlaneCore::ConfigItem.new(
-            key: :appcenter_app_name,
-            env_name: 'APPCENTER_APP_NAME', # Same as the one used by the `appcenter_upload` action
-            description: 'The name of the app in App Center',
-            type: String
+            key: :app_center_org_name,
+            env_name: 'APPCENTER_OWNER_NAME', # Intentionally the same as the one used by the `appcenter_upload` action
+            description: 'The name of the organization in App Center (if you used `appcenter_upload` to distribute your Prototype build)',
+            type: String,
+            optional: true
           ),
           FastlaneCore::ConfigItem.new(
-            key: :appcenter_release_id,
-            env_name: 'FL_PROTOTYPE_BUILD_APPCENTER_RELEASE_ID',
-            description: "The release ID/Number in App Center; can be obtained using `lane_context[SharedValues::APPCENTER_BUILD_INFORMATION]['id']`",
-            type: Integer
+            key: :app_center_app_name,
+            env_name: 'APPCENTER_APP_NAME', # Intentionally the same as the one used by the `appcenter_upload` action
+            description: "The name of the app in App Center #{app_center_auto}",
+            type: String,
+            optional: true,
+            default_value_dynamic: true # As it will be extracted from the `lane_context`` if you used `appcenter_upload``
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :app_center_release_id,
+            env_name: 'APPCENTER_RELEASE_ID',
+            description: "The release ID/Number in App Center #{app_center_auto}",
+            type: String,
+            optional: true,
+            default_value_dynamic: true # As it will be extracted from the `lane_context`` if you used `appcenter_upload``
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :app_icon,
+            env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_APP_ICON',
+            description: "An `:emojicode:` or URL to use for the icon of the app in the message. #{app_center_auto}",
+            type: String,
+            optional: true,
+            default_value_dynamic: true # As it will be extracted from the `lane_context`` if you used `appcenter_upload``
           ),
           FastlaneCore::ConfigItem.new(
             key: :download_url,
-            env_name: 'FL_PROTOTYPE_BUILD_DOWNLOAD_URL',
-            description: 'The URL to download the build directly; e.g. a public link to the `.apk` file; you might use `lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]` for this for example',
+            env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_DOWNLOAD_URL',
+            description: 'The URL to download the build as a direct download. ' \
+             + 'If you uploaded the build to App Center, we recommend leaving this nil (the comment will use the URL to the App Center build for the QR code)',
             type: String,
             optional: true,
             default_value: nil
@@ -88,25 +167,20 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :metadata,
             env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_METADATA',
-            description: 'All additional metadata (as key/value pairs) you want to include in the HTML table of the comment',
+            description: 'All additional metadata (as key/value pairs) you want to include in the HTML table of the comment. ' \
+             + 'If you are running this action after `appcenter_upload`, some metadata will automatically be added to this list too',
             type: Hash,
             optional: true,
-            default_value: {}
+            default_value_dynamic: true # As some metadata will be auto-filled if you used `appcenter_upload`
           ),
           FastlaneCore::ConfigItem.new(
             key: :footnote,
             env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_FOOTNOTE',
-            description: 'Optional footnote to add below the HTML table of the comment',
+            description: 'Optional footnote to add below the HTML table of the comment. ' \
+             + 'If you are running this action after `appcenter_upload`, a default footnote for Automatticians will be used unless you provide an explicit value',
             type: String,
-            default_value: '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
-          ),
-          FastlaneCore::ConfigItem.new(
-            key: :commit,
-            # Buildkite ENV var: https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_COMMIT
-            env_names: ['BUILDKITE_COMMIT'], # Feel free to add more CI-specific env vars for other CI providers
-            description: 'The commit this prototype build was build from; usually not passed explicitly, but derived from the environment variable instead',
-            type: String,
-            optional: true
+            optional: true,
+            default_value_dynamic: true # We have a default footnote for the case when you used App Center
           ),
         ]
       end
@@ -116,7 +190,7 @@ module Fastlane
       end
 
       def self.return_value
-        'The HTML comment containing all the relevant info about a Prototype build published to App Center'
+        'The HTML comment containing all the relevant info about a Prototype build and links to install it'
       end
 
       def self.authors

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -15,7 +15,7 @@ module Fastlane
         app_center_release_id = params[:app_center_release_id] || app_center_info['id']
 
         # Consolidate the list of Metadata to display with some implicit metadata if available
-        metadata = params[:metadata] || {}
+        metadata = params[:metadata]&.transform_keys(&:to_s) || {}
         metadata['Build Number'] ||= app_center_info['version']
         metadata['Version'] ||= app_center_info['short_version']
         metadata[app_center_info['app_os'] == 'Android' ? 'Application ID' : 'Bundle ID'] = app_center_info['bundle_identifier']
@@ -39,12 +39,12 @@ module Fastlane
         icon_img_tag = img_tag(params[:app_icon] || app_center_info['app_icon_url'], alt: app_display_name)
         metadata_rows = metadata.compact.map { |key, value| "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>" }
         intro = "#{icon_img_tag}📲 You can test the changes from this Pull Request in <b>#{app_display_name}</b> by scanning the QR code below to install the corresponding build."
-        footnote = params[:footnote] || (app_center_info.nil? ? '' : '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>')
+        footnote = params[:footnote] || (app_center_org_name.nil? ? '' : '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>')
         body = <<~COMMENT_BODY
           <table>
           <tr>
             <td rowspan='#{metadata_rows.count + 1}' width='260px'><img src='#{qr_code_url}' width='250' height='250' /></td>
-            <td width='150px'><b>App Name</b></td><td>#{icon_img_tag} #{app_display_name}</td>
+            <td><b>App Name</b></td><td>#{icon_img_tag} #{app_display_name}</td>
           </tr>
           #{metadata_rows.join("\n")}
           </table>

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -6,18 +6,16 @@ module Fastlane
         appcenter_app_name = params[:appcenter_app_name]
         appcenter_release_id = params[:appcenter_release_id]
         commit = params[:commit] || other_action.last_git_commit[:abbreviated_commit_hash]
-
         metadata = params[:metadata] # e.g. {'Build Config':… , 'Version': …, 'Short Version': …}
 
         install_url = "https://install.appcenter.ms/orgs/#{appcenter_org_name}/apps/#{appcenter_app_name}/releases/#{appcenter_release_id}"
         qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
-
         metadata_rows = metadata.map do |key, value|
           "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>"
         end.join("\n")
 
-        <<~COMMENT_BODY
-          <p>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>#{appcenter_app_name}</strong> build from App Center.</p>
+        intro = "📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>#{appcenter_app_name}</strong> build from App Center."
+        body = <<~COMMENT_BODY
           <table>
           <tr>
             <td rowspan='#{metadata.count + 3}'><img src='#{qr_code_url}' width='250' height='250' /></td>
@@ -29,6 +27,12 @@ module Fastlane
           </table>
           #{params[:footnote]}
         COMMENT_BODY
+
+        if params[:fold]
+          "<details>#{intro}</details>\n<summary>\n#{body}</summary>\n"
+        else
+          "<p>#{intro}</p>\n#{body}"
+        end
       end
 
       #####################################################
@@ -58,6 +62,13 @@ module Fastlane
             env_name: 'FL_PROTOTYPE_BUILD_APPCENTER_RELEASE_ID',
             description: 'The release ID/Number in App Center',
             type: Integer
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :fold,
+            env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_FOLD',
+            description: 'If true, will wrap the HTML table inside a <details> block (hidden by default)',
+            type: Boolean,
+            default_value: false
           ),
           FastlaneCore::ConfigItem.new(
             key: :metadata,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -5,7 +5,11 @@ module Fastlane
         app_display_name = params[:app_display_name]
 
         app_center_org_name = params[:app_center_org_name]
-        app_center_info = app_center_org_name.nil? ? {} : lane_context[SharedValues::APPCENTER_BUILD_INFORMATION] || {}
+        app_center_info = if app_center_org_name && defined?(SharedValues::APPCENTER_BUILD_INFORMATION)
+                            lane_context[SharedValues::APPCENTER_BUILD_INFORMATION] || {}
+                          else
+                            {}
+                          end
         app_center_app_name = params[:app_center_app_name] || app_center_info['app_name']
         app_center_app_display_name = app_center_info['app_display_name'] || app_center_app_name
         app_center_release_id = params[:app_center_release_id] || app_center_info['id']
@@ -39,7 +43,7 @@ module Fastlane
         body = <<~COMMENT_BODY
           <table>
           <tr>
-            <td rowspan='#{metadata.count + 1}' width='260px'><img src='#{qr_code_url}' width='250' height='250' /></td>
+            <td rowspan='#{metadata_rows.count + 1}' width='260px'><img src='#{qr_code_url}' width='250' height='250' /></td>
             <td width='150px'><b>App Name</b></td><td>#{icon_img_tag} #{app_display_name}</td>
           </tr>
           #{metadata_rows.join("\n")}

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -197,7 +197,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :app_icon,
             env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_APP_ICON',
-            description: "An `:emojicode:` or URL to use for the icon of the app in the message. #{app_center_auto}",
+            description: "The name of an emoji from the https://github.com/buildkite/emojis list or the full image URL to use for the icon of the app in the message. #{app_center_auto}",
             type: String,
             optional: true,
             default_value_dynamic: true # As it will be extracted from the `lane_context`` if you used `appcenter_upload``

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -102,7 +102,8 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :commit,
-            env_name: 'BUILDKITE_COMMIT',
+            # Buildkite ENV var: https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_COMMIT
+            env_names: ['BUILDKITE_COMMIT'], # Feel free to add more CI-specific env vars for other CI providers
             description: 'The commit this prototype build was build from; usually not passed explicitly, but derived from the environment variable instead',
             type: String,
             optional: true

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -21,7 +21,7 @@ module Fastlane
           "<tr><td><b>#{key}</b></td><td>#{value}</td></tr>"
         end
 
-        intro = "📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>#{appcenter_app_name}</strong> build from App Center."
+        intro = "📲 You can test the changes from this Pull Request in <strong>#{appcenter_app_name}</strong> by scanning the QR code below to install the corresponding build via App Center."
         body = <<~COMMENT_BODY
           <table>
           <tr>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -35,9 +35,9 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       metadata: metadata
     )
     expect(comment).to include "<td rowspan='6'>"
-    expect(comment).to include '<td><b>Version:Short</b></td><td><tt>28.1</tt></td>'
-    expect(comment).to include '<td><b>Version:Long</b></td><td><tt>281003</tt></td>'
-    expect(comment).to include '<td><b>Build Config</b></td><td><tt>Prototype</tt></td>'
+    expect(comment).to include '<td><b>Version:Short</b></td><td>28.1</td>'
+    expect(comment).to include '<td><b>Version:Long</b></td><td>281003</td>'
+    expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>'
   end
 
   it 'includes the default footnote by default' do
@@ -81,10 +81,10 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
         <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
       </tr>
-      <tr><td><b>Version:Short</b></td><td><tt>28.2</tt></td></tr>
-      <tr><td><b>Version:Long</b></td><td><tt>28.2.0.108</tt></td></tr>
-      <tr><td><b>Flavor</b></td><td><tt>Celray</tt></td></tr>
-      <tr><td><b>Panel</b></td><td><tt>false</tt></td></tr>
+      <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
+      <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
+      <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+      <tr><td><b>Panel</b></td><td>false</td></tr>
       <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
       <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
       </table>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -87,7 +87,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
-        <p>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</p>
+        <p>📲 You can test the changes from this Pull Request in <strong>BestApp</strong> by scanning the QR code below to install the corresponding build via App Center.</p>
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
@@ -118,7 +118,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
-        <p>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</p>
+        <p>📲 You can test the changes from this Pull Request in <strong>BestApp</strong> by scanning the QR code below to install the corresponding build via App Center.</p>
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
@@ -152,7 +152,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
-        <details><summary>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</summary>
+        <details><summary>📲 You can test the changes from this Pull Request in <strong>BestApp</strong> by scanning the QR code below to install the corresponding build via App Center.</summary>
         <table>
         <tr>
           <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -276,7 +276,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
 
     before do
       stub_const('Fastlane::Actions::SharedValues::APPCENTER_BUILD_INFORMATION', :fake_app_center_build_info)
-      allow(described_class).to receive(:lane_context).and_return({ fake_app_center_build_info: fake_lane_context })
+      allow(Fastlane::Actions).to receive(:lane_context).and_return({ fake_app_center_build_info: fake_lane_context })
     end
 
     describe 'checking specific content is present' do

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -41,6 +41,16 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>'
     end
 
+    it 'includes the direct link if one is provided' do
+      comment = run_described_fastlane_action(
+        appcenter_app_name: 'MyApp',
+        appcenter_release_id: 1337,
+        download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
+      )
+      expect(comment).to include "<td rowspan='4'>"
+      expect(comment).to include "<td><b>Direct Link</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><tt>myapp-prototype-build-pr1337-a1b2c3f.apk</tt></a></td>"
+    end
+
     it 'includes the default footnote by default' do
       comment = run_described_fastlane_action(
         appcenter_org_name: 'BestOrg',
@@ -86,6 +96,38 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
         <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
+        <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
+        </table>
+        <em>Note: Google Sign-In in not available in those builds</em>
+      EXPECTED_COMMENT
+    end
+
+    it 'generates a HTML table comment including the direct link if provided' do
+      metadata = {
+        'Version:Short': '28.2',
+        'Version:Long': '28.2.0.108'
+      }
+
+      comment = run_described_fastlane_action(
+        appcenter_org_name: 'BestOrg',
+        appcenter_app_name: 'BestApp',
+        appcenter_release_id: 8888,
+        download_url: 'https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk',
+        metadata: metadata,
+        footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+      )
+
+      expect(comment).to eq <<~EXPECTED_COMMENT
+        <p>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</p>
+        <table>
+        <tr>
+          <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+          <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
+        </tr>
+        <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
+        <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
+        <tr><td><b>Direct Link</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><tt>bestapp-pr1357-a1b2c3f.apk</tt></a></td></tr>
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
         <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
         </table>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -114,8 +114,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         appcenter_app_name: 'BestApp',
         appcenter_release_id: 8888,
         download_url: 'https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk',
-        metadata: metadata,
-        footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+        metadata: metadata
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
@@ -131,7 +130,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
         <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
         </table>
-        <em>Note: Google Sign-In in not available in those builds</em>
+        <em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>
       EXPECTED_COMMENT
     end
 
@@ -146,7 +145,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       comment = run_described_fastlane_action(
         appcenter_org_name: 'BestOrg',
         appcenter_app_name: 'BestApp',
-        appcenter_release_id: 8888,
+        appcenter_release_id: 1234,
         fold: true,
         metadata: metadata,
         footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
@@ -156,14 +155,14 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <details><summary>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</summary>
         <table>
         <tr>
-          <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+          <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
           <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
         <tr><td><b>Flavor</b></td><td>Celray</td></tr>
         <tr><td><b>Configuration</b></td><td>Debug</td></tr>
-        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
+        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/1234'>Build \#1234</a></td></tr>
         <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
         </table>
         <em>Note: Google Sign-In in not available in those builds</em>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -6,168 +6,179 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
     ENV['BUILDKITE_COMMIT'] = 'a1b2c3f'
   end
 
-  describe 'expected info is included' do
-    it 'generates the proper App Center link and QR code given an org, app name and release ID' do
-      comment = run_described_fastlane_action(
-        appcenter_app_name: 'MyApp',
-        appcenter_release_id: 1337
-      )
-      expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/MyApp/releases/1337'>Build #1337</a>"
-      expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMyApp%2Freleases%2F1337&choe=UTF-8'
+  context 'when using App Center' do
+    describe 'expected info is included' do
+      it 'generates the proper App Center link and QR code given an org, app name and release ID' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_app_name: 'MyApp',
+          app_center_release_id: '1337'
+        )
+        expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/MyApp/releases/1337'>MyApp #1337</a>"
+        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMyApp%2Freleases%2F1337&choe=UTF-8'
+      end
+
+      it 'includes the commit as part of the default rows' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_app_name: 'MyApp',
+          app_center_release_id: '1337'
+        )
+        expect(comment).to include '<td><b>Commit</b></td><td>a1b2c3f</td>'
+      end
+
+      it 'correctly includes additional metadata when some are provided' do
+        metadata = {
+          'Version:Short': '28.1',
+          'Version:Long': '281003',
+          'Build Config': 'Prototype'
+        }
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_app_name: 'MyApp',
+          app_center_release_id: '1337',
+          metadata: metadata
+        )
+        expect(comment).to include "<td rowspan='6'" # additional inferred metadata rows: App Name, Commit, App Center Build
+        expect(comment).to include '<td><b>Version:Short</b></td><td>28.1</td>'
+        expect(comment).to include '<td><b>Version:Long</b></td><td>281003</td>'
+        expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>'
+      end
+
+      it 'includes the direct link if one is provided' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_app_name: 'MyApp',
+          app_center_release_id: '1337',
+          download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
+        )
+        expect(comment).to include "<td rowspan='4'" # inferred metadata rows: App Name, Commit, Direct Download, App Center Build
+        expect(comment).to include "<td><b>Direct Download</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
+      end
+
+      it 'includes the default footnote by default' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'BestOrg',
+          app_center_app_name: 'MyApp',
+          app_center_release_id: '1337'
+        )
+        expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+      end
+
+      it 'includes the provided footnote if any' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_app_name: 'MyApp',
+          app_center_release_id: '1337',
+          footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
+        )
+        expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
+      end
     end
 
-    it 'includes the commit as part of the default rows' do
-      comment = run_described_fastlane_action(
-        appcenter_app_name: 'MyApp',
-        appcenter_release_id: 1337
-      )
-      expect(comment).to include '<td><b>Commit</b></td><td>a1b2c3f</td>'
-    end
+    describe 'full comment' do
+      it 'generates a standard HTML table comment by default, with all the information provided' do
+        metadata = {
+          'Version:Short': '28.2',
+          'Version:Long': '28.2.0.108',
+          Flavor: 'Celray'
+        }
 
-    it 'correctly includes additional metadata when some are provided' do
-      metadata = {
-        'Version:Short': '28.1',
-        'Version:Long': '281003',
-        'Build Config': 'Prototype'
-      }
-      comment = run_described_fastlane_action(
-        appcenter_app_name: 'MyApp',
-        appcenter_release_id: 1337,
-        metadata: metadata
-      )
-      expect(comment).to include "<td rowspan='6'>"
-      expect(comment).to include '<td><b>Version:Short</b></td><td>28.1</td>'
-      expect(comment).to include '<td><b>Version:Long</b></td><td>281003</td>'
-      expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>'
-    end
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          app_center_org_name: 'BestOrg',
+          app_center_app_name: 'BestApp',
+          app_center_release_id: '8888',
+          metadata: metadata,
+          footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+        )
 
-    it 'includes the direct link if one is provided' do
-      comment = run_described_fastlane_action(
-        appcenter_app_name: 'MyApp',
-        appcenter_release_id: 1337,
-        download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
-      )
-      expect(comment).to include "<td rowspan='4'>"
-      expect(comment).to include "<td><b>Direct Link</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
-    end
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <p>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
+          <table>
+          <tr>
+            <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+            <td width='150px'><b>App Name</b></td><td> The Best App</td>
+          </tr>
+          <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
+          <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
+          <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>BestApp \#8888</a></td></tr>
+          </table>
+          <em>Note: Google Sign-In in not available in those builds</em>
+        EXPECTED_COMMENT
+      end
 
-    it 'includes the default footnote by default' do
-      comment = run_described_fastlane_action(
-        appcenter_org_name: 'BestOrg',
-        appcenter_app_name: 'MyApp',
-        appcenter_release_id: 1337
-      )
-      expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
-    end
+      it 'generates a HTML table comment including the direct link if provided' do
+        metadata = {
+          'Version:Short': '28.2',
+          'Version:Long': '28.2.0.108'
+        }
 
-    it 'includes the provided footnote if any' do
-      comment = run_described_fastlane_action(
-        appcenter_app_name: 'MyApp',
-        appcenter_release_id: 1337,
-        footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
-      )
-      expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
-    end
-  end
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          app_center_org_name: 'BestOrg',
+          app_center_app_name: 'BestApp',
+          app_center_release_id: '8888',
+          download_url: 'https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk',
+          metadata: metadata
+        )
 
-  describe 'full comment' do
-    it 'generates a standard HTML table comment by default, with all the information provided' do
-      metadata = {
-        'Version:Short': '28.2',
-        'Version:Long': '28.2.0.108',
-        Flavor: 'Celray'
-      }
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <p>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
+          <table>
+          <tr>
+            <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+            <td width='150px'><b>App Name</b></td><td> The Best App</td>
+          </tr>
+          <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
+          <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>Direct Download</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><code>bestapp-pr1357-a1b2c3f.apk</code></a></td></tr>
+          <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>BestApp \#8888</a></td></tr>
+          </table>
+          <em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>
+        EXPECTED_COMMENT
+      end
 
-      comment = run_described_fastlane_action(
-        appcenter_org_name: 'BestOrg',
-        appcenter_app_name: 'BestApp',
-        appcenter_release_id: 8888,
-        metadata: metadata,
-        footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
-      )
+      it 'generates a HTML table in a spoiler block if fold is true' do
+        metadata = {
+          'Version:Short': '28.2',
+          'Version:Long': '28.2.0.108',
+          Flavor: 'Celray',
+          Configuration: 'Debug'
+        }
 
-      expect(comment).to eq <<~EXPECTED_COMMENT
-        <p>📲 You can test the changes from this Pull Request in <b>BestApp</b> by scanning the QR code below to install the corresponding build via App Center.</p>
-        <table>
-        <tr>
-          <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td>BestApp</td>
-        </tr>
-        <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
-        <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
-        <tr><td><b>Flavor</b></td><td>Celray</td></tr>
-        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
-        <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
-        </table>
-        <em>Note: Google Sign-In in not available in those builds</em>
-      EXPECTED_COMMENT
-    end
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          app_center_org_name: 'BestOrg',
+          app_center_app_name: 'BestApp',
+          app_center_release_id: '1234',
+          fold: true,
+          metadata: metadata,
+          footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+        )
 
-    it 'generates a HTML table comment including the direct link if provided' do
-      metadata = {
-        'Version:Short': '28.2',
-        'Version:Long': '28.2.0.108'
-      }
-
-      comment = run_described_fastlane_action(
-        appcenter_org_name: 'BestOrg',
-        appcenter_app_name: 'BestApp',
-        appcenter_release_id: 8888,
-        download_url: 'https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk',
-        metadata: metadata
-      )
-
-      expect(comment).to eq <<~EXPECTED_COMMENT
-        <p>📲 You can test the changes from this Pull Request in <b>BestApp</b> by scanning the QR code below to install the corresponding build via App Center.</p>
-        <table>
-        <tr>
-          <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td>BestApp</td>
-        </tr>
-        <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
-        <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
-        <tr><td><b>Direct Link</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><code>bestapp-pr1357-a1b2c3f.apk</code></a></td></tr>
-        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
-        <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
-        </table>
-        <em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>
-      EXPECTED_COMMENT
-    end
-
-    it 'generates a HTML table in a spoiler block if fold is true' do
-      metadata = {
-        'Version:Short': '28.2',
-        'Version:Long': '28.2.0.108',
-        Flavor: 'Celray',
-        Configuration: 'Debug'
-      }
-
-      comment = run_described_fastlane_action(
-        appcenter_org_name: 'BestOrg',
-        appcenter_app_name: 'BestApp',
-        appcenter_release_id: 1234,
-        fold: true,
-        metadata: metadata,
-        footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
-      )
-
-      expect(comment).to eq <<~EXPECTED_COMMENT
-        <details><summary>📲 You can test the changes from this Pull Request in <b>BestApp</b> by scanning the QR code below to install the corresponding build via App Center.</summary>
-        <table>
-        <tr>
-          <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td>BestApp</td>
-        </tr>
-        <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
-        <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
-        <tr><td><b>Flavor</b></td><td>Celray</td></tr>
-        <tr><td><b>Configuration</b></td><td>Debug</td></tr>
-        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/1234'>Build \#1234</a></td></tr>
-        <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
-        </table>
-        <em>Note: Google Sign-In in not available in those builds</em>
-        </details>
-      EXPECTED_COMMENT
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <details><summary>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</summary>
+          <table>
+          <tr>
+            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
+            <td width='150px'><b>App Name</b></td><td> The Best App</td>
+          </tr>
+          <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
+          <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
+          <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+          <tr><td><b>Configuration</b></td><td>Debug</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/1234'>BestApp \#1234</a></td></tr>
+          </table>
+          <em>Note: Google Sign-In in not available in those builds</em>
+          </details>
+        EXPECTED_COMMENT
+      end
     end
   end
 end

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -2,32 +2,65 @@ require_relative './spec_helper'
 
 describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
   before do
-    ENV['APPCENTER_OWNER_NAME'] = 'My-Org'
     ENV['BUILDKITE_COMMIT'] = 'a1b2c3f'
   end
 
-  context 'when using App Center' do
-    describe 'expected info is included' do
+  describe 'cases common to all operating modes' do
+    it 'includes the app display name as part of the intro text' do
+      comment = run_described_fastlane_action(
+        app_display_name: 'My Cool App',
+        download_url: 'https://localhost/foo.apk'
+      )
+      expect(comment).to include 'You can test the changes from this Pull Request in <b>My Cool App</b>'
+    end
+
+    it 'includes the commit as part of the default rows' do
+      comment = run_described_fastlane_action(
+        app_display_name: 'My App',
+        download_url: 'https://localhost/foo.apk'
+      )
+      expect(comment).to include '<td><b>Commit</b></td><td>a1b2c3f</td>'
+    end
+
+    it 'includes the provided footnote if one was provided explicitly' do
+      comment = run_described_fastlane_action(
+        app_display_name: 'My App',
+        download_url: 'https://localhost/foo.apk',
+        footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
+      )
+      expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
+    end
+  end
+
+  context 'when using App Center with explicit parameters' do
+    it 'raises an error if neither `app_center_app_name` nor `download_url` is provided' do
+      expected_message = <<~ERROR
+        No URL provided to download or install the app.
+         - Either use this action right after using `appcenter_upload` and provide an `app_center_org_name` (so that this action can use the link to the App Center build)
+         - Or provide an explicit value for the `download_url` parameter
+      ERROR
+
+      expect do
+        run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'BestOrg'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, expected_message)
+    end
+
+    describe 'checking specific content is present' do
       it 'generates the proper App Center link and QR code given an org, app name and release ID' do
         comment = run_described_fastlane_action(
           app_display_name: 'My App',
-          app_center_app_name: 'MyApp',
+          app_center_org_name: 'My-Org',
+          app_center_app_name: 'My-App',
           app_center_release_id: '1337'
         )
-        expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/MyApp/releases/1337'>MyApp #1337</a>"
-        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMyApp%2Freleases%2F1337&choe=UTF-8'
+        expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/My-App/releases/1337'>My-App #1337</a>"
+        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337&choe=UTF-8'
       end
 
-      it 'includes the commit as part of the default rows' do
-        comment = run_described_fastlane_action(
-          app_display_name: 'My App',
-          app_center_app_name: 'MyApp',
-          app_center_release_id: '1337'
-        )
-        expect(comment).to include '<td><b>Commit</b></td><td>a1b2c3f</td>'
-      end
-
-      it 'correctly includes additional metadata when some are provided' do
+      it 'includes both explicit and implicit metadata when some are provided by the user' do
         metadata = {
           'Version:Short': '28.1',
           'Version:Long': '281003',
@@ -35,28 +68,36 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         }
         comment = run_described_fastlane_action(
           app_display_name: 'My App',
-          app_center_app_name: 'MyApp',
+          app_center_org_name: 'My-Org',
+          app_center_app_name: 'My-App',
           app_center_release_id: '1337',
           metadata: metadata
         )
-        expect(comment).to include "<td rowspan='6'" # additional inferred metadata rows: App Name, Commit, App Center Build
+        expect(comment).to include '<td><b>App Name</b></td><td> My App</td>'
         expect(comment).to include '<td><b>Version:Short</b></td><td>28.1</td>'
         expect(comment).to include '<td><b>Version:Long</b></td><td>281003</td>'
         expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>'
+        expect(comment).to include '<td><b>Commit</b></td><td>a1b2c3f</td>'
+        expect(comment).to include "<tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/My-Org/apps/My-App/releases/1337'>My-App \#1337</a></td></tr>"
+        # Additional inferred metadata rows: App Name, Commit, App Center Build
+        expect(comment).to include "<td rowspan='6'"
       end
 
-      it 'includes the direct link if one is provided' do
+      it 'includes use the App Center link for the QR code even if a download_url is provided' do
         comment = run_described_fastlane_action(
           app_display_name: 'My App',
-          app_center_app_name: 'MyApp',
+          app_center_org_name: 'My-Org',
+          app_center_app_name: 'My-App',
           app_center_release_id: '1337',
           download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
         )
-        expect(comment).to include "<td rowspan='4'" # inferred metadata rows: App Name, Commit, Direct Download, App Center Build
         expect(comment).to include "<td><b>Direct Download</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
+        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337&choe=UTF-8'
+        # Inferred metadata rows: App Name, Commit, Direct Download, App Center Build
+        expect(comment).to include "<td rowspan='4'"
       end
 
-      it 'includes the default footnote by default' do
+      it 'includes the default footnote about App Center if not overridden' do
         comment = run_described_fastlane_action(
           app_display_name: 'My App',
           app_center_org_name: 'BestOrg',
@@ -65,19 +106,9 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         )
         expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
       end
-
-      it 'includes the provided footnote if any' do
-        comment = run_described_fastlane_action(
-          app_display_name: 'My App',
-          app_center_app_name: 'MyApp',
-          app_center_release_id: '1337',
-          footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
-        )
-        expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
-      end
     end
 
-    describe 'full comment' do
+    describe 'validating full comment' do
       it 'generates a standard HTML table comment by default, with all the information provided' do
         metadata = {
           'Version:Short': '28.2',
@@ -99,7 +130,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <table>
           <tr>
             <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-            <td width='150px'><b>App Name</b></td><td> The Best App</td>
+            <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
           <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
@@ -131,7 +162,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <table>
           <tr>
             <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-            <td width='150px'><b>App Name</b></td><td> The Best App</td>
+            <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
           <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
@@ -166,7 +197,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <table>
           <tr>
             <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
-            <td width='150px'><b>App Name</b></td><td> The Best App</td>
+            <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
           <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
@@ -180,5 +211,138 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         EXPECTED_COMMENT
       end
     end
+  end
+
+  context 'when using App Center and relying on implicit info from `lane_context`' do
+    before do
+      stub_const('Fastlane::Actions::SharedValues::APPCENTER_BUILD_INFORMATION', :fake_app_center_build_info)
+
+      lane_ctx = {
+        app_name: 'My-App-Alpha',
+        app_display_name: 'My App (Alpha)',
+        id: '1337',
+        version: '1287003',
+        short_version: '28.7',
+        app_os: 'Android',
+        bundle_identifier: 'com.stubfactory.myapp',
+        app_icon_url: 'https://assets.appcenter.ms/My-App-Alpha/1337/icon.png'
+      }.transform_keys(&:to_s)
+
+      allow(described_class).to receive(:lane_context).and_return({ fake_app_center_build_info: lane_ctx })
+    end
+
+    describe 'checking specific content is present' do
+      it 'generates the proper App Center link and QR code given just an org' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org'
+        )
+        expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/My-App-Alpha/releases/1337'>My App (Alpha) #1337</a>"
+        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8'
+      end
+
+      it 'includes and prioritize user-provided metadata over implicit ones' do
+        metadata = {
+          'Version': '42.3',
+          'Build Number': '4203008',
+          'Build Config': 'Prototype'
+        }
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org',
+          metadata: metadata
+        )
+        expect(comment).to include '<td><b>Version</b></td><td>42.3</td>' # explicitly provided, overriding the implicit value
+        expect(comment).not_to include '<td><b>Version</b></td><td>28.7</td>' # otherwise implicitly added if it were not overridden
+        expect(comment).to include '<td><b>Build Number</b></td><td>4203008</td>' # explicitly provided, overriding the implicit value
+        expect(comment).not_to include '<td><b>Build Number</b></td><td>1287003</td>' # otherwise implicitly added if it were not overridden
+        expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>' # an explicit metadata not overriding any implicit one
+        # Additional inferred metadata rows: App Name, Application ID, Commit, App Center Build
+        expect(comment).to include "<td rowspan='7'"
+      end
+
+      it 'includes the direct link if one is provided' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org',
+          download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
+        )
+        expect(comment).to include "<td><b>Direct Download</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
+        # Inferred metadata rows: App Name, Build Number, Version, Application ID, Commit, Direct Download, App Center Build
+        expect(comment).to include "<td rowspan='7'"
+      end
+
+      it 'includes the App Center default footnote if no explicit footnote is provided' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'BestOrg'
+        )
+        expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+      end
+
+      it 'includes the provided footnote if one was provided explicitly' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org',
+          footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
+        )
+        expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
+      end
+    end
+
+    describe 'validating full comment' # TODO
+  end
+
+  context 'when not using App Center' do
+    it 'raises an error if no `download_url` is provided' do
+      expected_message = <<~ERROR
+        No URL provided to download or install the app.
+         - Either use this action right after using `appcenter_upload` and provide an `app_center_org_name` (so that this action can use the link to the App Center build)
+         - Or provide an explicit value for the `download_url` parameter
+      ERROR
+
+      expect do
+        run_described_fastlane_action(
+          app_display_name: 'My App'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, expected_message)
+    end
+
+    describe 'checking specific content is present' do
+      it 'generates the proper QR code from the download url' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
+        )
+        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Ffoo.cloudfront.net%2Fsomeuuid%2Fmyapp-prototype-build-pr1337-a1b2c3f.apk&choe=UTF-8'
+      end
+
+      it 'includes the direct link as metadata' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
+        )
+        expect(comment).to include "<td><b>Direct Download</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
+      end
+
+      it 'does not include the App Center default footnote if no explicit footnote is provided' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          download_url: 'https://localhost/foo.apk'
+        )
+        expect(comment).not_to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+      end
+
+      it 'includes the provided footnote if one was provided explicitly' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          download_url: 'https://localhost/foo.apk',
+          footnote: 'The link to this APK might stop working after a retention delay of 30 days.'
+        )
+        expect(comment).to include 'The link to this APK might stop working after a retention delay of 30 days.'
+      end
+    end
+
+    describe 'validating full comment' # TODO
   end
 end

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         appcenter_app_name: 'MyApp',
         appcenter_release_id: 1337
       )
-      expect(comment).to include '<td><b>Commit</b></td><td><tt>a1b2c3f</tt></td>'
+      expect(comment).to include '<td><b>Commit</b></td><td><code>a1b2c3f</code></td>'
     end
 
     it 'correctly includes additional metadata when some are provided' do
@@ -48,7 +48,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
       )
       expect(comment).to include "<td rowspan='4'>"
-      expect(comment).to include "<td><b>Direct Link</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><tt>myapp-prototype-build-pr1337-a1b2c3f.apk</tt></a></td>"
+      expect(comment).to include "<td><b>Direct Link</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
     end
 
     it 'includes the default footnote by default' do
@@ -91,13 +91,13 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td><tt>BestApp</tt></td>
+          <td width='150px'><b>App Name</b></td><td><code>BestApp</code></td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
         <tr><td><b>Flavor</b></td><td>Celray</td></tr>
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
-        <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
+        <tr><td><b>Commit</b></td><td><code>a1b2c3f</code></td></tr>
         </table>
         <em>Note: Google Sign-In in not available in those builds</em>
       EXPECTED_COMMENT
@@ -122,13 +122,13 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td><tt>BestApp</tt></td>
+          <td width='150px'><b>App Name</b></td><td><code>BestApp</code></td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
-        <tr><td><b>Direct Link</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><tt>bestapp-pr1357-a1b2c3f.apk</tt></a></td></tr>
+        <tr><td><b>Direct Link</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><code>bestapp-pr1357-a1b2c3f.apk</code></a></td></tr>
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
-        <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
+        <tr><td><b>Commit</b></td><td><code>a1b2c3f</code></td></tr>
         </table>
         <em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>
       EXPECTED_COMMENT
@@ -156,14 +156,14 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td><tt>BestApp</tt></td>
+          <td width='150px'><b>App Name</b></td><td><code>BestApp</code></td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
         <tr><td><b>Flavor</b></td><td>Celray</td></tr>
         <tr><td><b>Configuration</b></td><td>Debug</td></tr>
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/1234'>Build \#1234</a></td></tr>
-        <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
+        <tr><td><b>Commit</b></td><td><code>a1b2c3f</code></td></tr>
         </table>
         <em>Note: Google Sign-In in not available in those builds</em>
         </details>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -6,12 +6,64 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
   end
 
   describe 'cases common to all operating modes' do
-    it 'includes the app display name as part of the intro text' do
-      comment = run_described_fastlane_action(
-        app_display_name: 'My Cool App',
-        download_url: 'https://localhost/foo.apk'
-      )
-      expect(comment).to include 'You can test the changes from this Pull Request in <b>My Cool App</b>'
+    describe 'app_display_name' do
+      it 'includes the app display name as part of the intro text' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My Cool App',
+          download_url: 'https://localhost/foo.apk'
+        )
+        expect(comment).to include '📲 You can test the changes from this Pull Request in <b>My Cool App</b>'
+      end
+
+      it 'includes the app display name as part of implicit metadata' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My Cool App',
+          download_url: 'https://localhost/foo.apk'
+        )
+        expect(comment).to include '<td><b>App Name</b></td><td> My Cool App</td>'
+      end
+    end
+
+    describe 'app_icon' do
+      context 'when providing an URL' do
+        it 'includes the icon in the intro text' do
+          comment = run_described_fastlane_action(
+            app_display_name: 'My Cool App',
+            app_icon: 'https://localhost/foo.png',
+            download_url: 'https://localhost/foo.apk'
+          )
+          expect(comment).to include "<img alt='My Cool App' align='top' src='https://localhost/foo.png' width='20px' />📲 "
+        end
+
+        it 'includes the icon next to the App Name in metadata' do
+          comment = run_described_fastlane_action(
+            app_display_name: 'My Cool App',
+            app_icon: 'https://localhost/foo.png',
+            download_url: 'https://localhost/foo.apk'
+          )
+          expect(comment).to include "<td><b>App Name</b></td><td><img alt='My Cool App' align='top' src='https://localhost/foo.png' width='20px' /> My Cool App</td>"
+        end
+      end
+
+      context 'when providing an emoji code' do
+        it 'includes the icon in the intro text' do
+          comment = run_described_fastlane_action(
+            app_display_name: 'My Cool App',
+            app_icon: ':jetpack:',
+            download_url: 'https://localhost/foo.apk'
+          )
+          expect(comment).to include "<img alt='My Cool App' align='top' src='https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/jetpack.png' width='20px' />📲 "
+        end
+
+        it 'includes the icon next to the App Name in metadata' do
+          comment = run_described_fastlane_action(
+            app_display_name: 'My Cool App',
+            app_icon: ':jetpack:',
+            download_url: 'https://localhost/foo.apk'
+          )
+          expect(comment).to include "<td><b>App Name</b></td><td><img alt='My Cool App' align='top' src='https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/jetpack.png' width='20px' /> My Cool App</td>"
+        end
+      end
     end
 
     it 'includes the commit as part of the default rows' do
@@ -23,29 +75,24 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
     end
 
     it 'includes the provided footnote if one was provided explicitly' do
+      custom_footnote = '<em>Note that Google Sign-In in not available in those builds</em>'
       comment = run_described_fastlane_action(
         app_display_name: 'My App',
         download_url: 'https://localhost/foo.apk',
-        footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
+        footnote: custom_footnote
       )
-      expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
+      expect(comment).to include custom_footnote
     end
   end
 
   context 'when using App Center with explicit parameters' do
     it 'raises an error if neither `app_center_app_name` nor `download_url` is provided' do
-      expected_message = <<~ERROR
-        No URL provided to download or install the app.
-         - Either use this action right after using `appcenter_upload` and provide an `app_center_org_name` (so that this action can use the link to the App Center build)
-         - Or provide an explicit value for the `download_url` parameter
-      ERROR
-
       expect do
         run_described_fastlane_action(
           app_display_name: 'My App',
           app_center_org_name: 'BestOrg'
         )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, expected_message)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, described_class::NO_INSTALL_URL_ERROR_MESSAGE)
     end
 
     describe 'checking specific content is present' do
@@ -58,6 +105,20 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         )
         expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/My-App/releases/1337'>My-App #1337</a>"
         expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337&choe=UTF-8'
+      end
+
+      it 'uses the App Center link for the QR code even if a `download_url` is provided' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org',
+          app_center_app_name: 'My-App',
+          app_center_release_id: '1337',
+          download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
+        )
+        expect(comment).to include "<td><b>Direct Download</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
+        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337&choe=UTF-8'
+        # Inferred metadata rows: App Name, Commit, Direct Download, App Center Build
+        expect(comment).to include "<td rowspan='4'"
       end
 
       it 'includes both explicit and implicit metadata when some are provided by the user' do
@@ -83,20 +144,6 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         expect(comment).to include "<td rowspan='6'"
       end
 
-      it 'includes use the App Center link for the QR code even if a download_url is provided' do
-        comment = run_described_fastlane_action(
-          app_display_name: 'My App',
-          app_center_org_name: 'My-Org',
-          app_center_app_name: 'My-App',
-          app_center_release_id: '1337',
-          download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
-        )
-        expect(comment).to include "<td><b>Direct Download</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
-        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337&choe=UTF-8'
-        # Inferred metadata rows: App Name, Commit, Direct Download, App Center Build
-        expect(comment).to include "<td rowspan='4'"
-      end
-
       it 'includes the default footnote about App Center if not overridden' do
         comment = run_described_fastlane_action(
           app_display_name: 'My App',
@@ -104,7 +151,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           app_center_app_name: 'MyApp',
           app_center_release_id: '1337'
         )
-        expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+        expect(comment).to include described_class::DEFAULT_APP_CENTER_FOOTNOTE
       end
     end
 
@@ -214,21 +261,22 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
   end
 
   context 'when using App Center and relying on implicit info from `lane_context`' do
-    before do
-      stub_const('Fastlane::Actions::SharedValues::APPCENTER_BUILD_INFORMATION', :fake_app_center_build_info)
-
-      lane_ctx = {
+    let(:fake_lane_context) do |example|
+      {
         app_name: 'My-App-Alpha',
         app_display_name: 'My App (Alpha)',
         id: '1337',
         version: '1287003',
         short_version: '28.7',
-        app_os: 'Android',
+        app_os: example.metadata[:app_os] || 'Android',
         bundle_identifier: 'com.stubfactory.myapp',
         app_icon_url: 'https://assets.appcenter.ms/My-App-Alpha/1337/icon.png'
       }.transform_keys(&:to_s)
+    end
 
-      allow(described_class).to receive(:lane_context).and_return({ fake_app_center_build_info: lane_ctx })
+    before do
+      stub_const('Fastlane::Actions::SharedValues::APPCENTER_BUILD_INFORMATION', :fake_app_center_build_info)
+      allow(described_class).to receive(:lane_context).and_return({ fake_app_center_build_info: fake_lane_context })
     end
 
     describe 'checking specific content is present' do
@@ -241,9 +289,20 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8'
       end
 
-      it 'includes and prioritize user-provided metadata over implicit ones' do
+      it 'uses the App Center link for the QR code even if a `download_url` is provided' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org',
+          download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
+        )
+        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8'
+        # Inferred metadata rows: App Name, Build Number, Version, Application ID, Commit, Direct Download, App Center Build
+        expect(comment).to include "<td rowspan='7'"
+      end
+
+      it 'includes and prioritizes user-provided metadata over implicit ones' do
         metadata = {
-          'Version': '42.3',
+          Version: '42.3',
           'Build Number': '4203008',
           'Build Config': 'Prototype'
         }
@@ -256,9 +315,27 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         expect(comment).not_to include '<td><b>Version</b></td><td>28.7</td>' # otherwise implicitly added if it were not overridden
         expect(comment).to include '<td><b>Build Number</b></td><td>4203008</td>' # explicitly provided, overriding the implicit value
         expect(comment).not_to include '<td><b>Build Number</b></td><td>1287003</td>' # otherwise implicitly added if it were not overridden
-        expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>' # an explicit metadata not overriding any implicit one
+        expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>' # not overriding any implicit one
         # Additional inferred metadata rows: App Name, Application ID, Commit, App Center Build
         expect(comment).to include "<td rowspan='7'"
+      end
+
+      it 'uses "Application ID" as the name for the `bundle_identifier` value if using Android', app_os: 'Android' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org'
+        )
+        expect(comment).to include '<td><b>Application ID</b></td><td>com.stubfactory.myapp</td>'
+        expect(comment).not_to include 'Bundle ID'
+      end
+
+      it 'uses "Bundle ID" as the name for the `bundle_identifier` value if using iOS', app_os: 'iOS' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'My App',
+          app_center_org_name: 'My-Org'
+        )
+        expect(comment).to include '<td><b>Bundle ID</b></td><td>com.stubfactory.myapp</td>'
+        expect(comment).not_to include 'Application ID'
       end
 
       it 'includes the direct link if one is provided' do
@@ -277,35 +354,118 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           app_display_name: 'My App',
           app_center_org_name: 'BestOrg'
         )
-        expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+        expect(comment).to include described_class::DEFAULT_APP_CENTER_FOOTNOTE
       end
 
       it 'includes the provided footnote if one was provided explicitly' do
+        custom_footnote = '<em>Note that Google Sign-In in not available in those builds</em>'
         comment = run_described_fastlane_action(
           app_display_name: 'My App',
           app_center_org_name: 'My-Org',
-          footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
+          footnote: custom_footnote
         )
-        expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
+        expect(comment).to include custom_footnote
+        expect(comment).not_to include described_class::DEFAULT_APP_CENTER_FOOTNOTE
       end
     end
 
-    describe 'validating full comment' # TODO
+    describe 'validating full comment' do
+      it 'generates a standard HTML table comment by default, with all the information provided' do
+        metadata = {
+          Configuration: 'Debug'
+        }
+
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          app_center_org_name: 'BestOrg',
+          metadata: metadata,
+          footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+        )
+
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <p><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' />📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
+          <table>
+          <tr>
+            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8' width='250' height='250' /></td>
+            <td><b>App Name</b></td><td><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' /> The Best App</td>
+          </tr>
+          <tr><td><b>Configuration</b></td><td>Debug</td></tr>
+          <tr><td><b>Build Number</b></td><td>1287003</td></tr>
+          <tr><td><b>Version</b></td><td>28.7</td></tr>
+          <tr><td><b>Application ID</b></td><td>com.stubfactory.myapp</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/My-App-Alpha/releases/1337'>My App (Alpha) \#1337</a></td></tr>
+          </table>
+          <em>Note: Google Sign-In in not available in those builds</em>
+        EXPECTED_COMMENT
+      end
+
+      it 'generates a HTML table comment including the direct link if provided' do
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          app_center_org_name: 'BestOrg',
+          download_url: 'https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'
+        )
+
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <p><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' />📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
+          <table>
+          <tr>
+            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8' width='250' height='250' /></td>
+            <td><b>App Name</b></td><td><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' /> The Best App</td>
+          </tr>
+          <tr><td><b>Build Number</b></td><td>1287003</td></tr>
+          <tr><td><b>Version</b></td><td>28.7</td></tr>
+          <tr><td><b>Application ID</b></td><td>com.stubfactory.myapp</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>Direct Download</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><code>bestapp-pr1357-a1b2c3f.apk</code></a></td></tr>
+          <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/My-App-Alpha/releases/1337'>My App (Alpha) \#1337</a></td></tr>
+          </table>
+          <em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>
+        EXPECTED_COMMENT
+      end
+
+      it 'generates a HTML table in a spoiler block if fold is true' do
+        metadata = {
+          'Google Login': 'Disabled'
+        }
+
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          app_center_org_name: 'BestOrg',
+          fold: true,
+          metadata: metadata,
+          footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+        )
+
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <details><summary><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' />📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</summary>
+          <table>
+          <tr>
+            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8' width='250' height='250' /></td>
+            <td><b>App Name</b></td><td><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' /> The Best App</td>
+          </tr>
+          <tr><td><b>Google Login</b></td><td>Disabled</td></tr>
+          <tr><td><b>Build Number</b></td><td>1287003</td></tr>
+          <tr><td><b>Version</b></td><td>28.7</td></tr>
+          <tr><td><b>Application ID</b></td><td>com.stubfactory.myapp</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/My-App-Alpha/releases/1337'>My App (Alpha) \#1337</a></td></tr>
+          </table>
+          <em>Note: Google Sign-In in not available in those builds</em>
+          </details>
+        EXPECTED_COMMENT
+      end
+    end
   end
 
   context 'when not using App Center' do
     it 'raises an error if no `download_url` is provided' do
-      expected_message = <<~ERROR
-        No URL provided to download or install the app.
-         - Either use this action right after using `appcenter_upload` and provide an `app_center_org_name` (so that this action can use the link to the App Center build)
-         - Or provide an explicit value for the `download_url` parameter
-      ERROR
-
       expect do
         run_described_fastlane_action(
           app_display_name: 'My App'
         )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, expected_message)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, described_class::NO_INSTALL_URL_ERROR_MESSAGE)
     end
 
     describe 'checking specific content is present' do
@@ -330,7 +490,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           app_display_name: 'My App',
           download_url: 'https://localhost/foo.apk'
         )
-        expect(comment).not_to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+        expect(comment).not_to include described_class::DEFAULT_APP_CENTER_FOOTNOTE
       end
 
       it 'includes the provided footnote if one was provided explicitly' do
@@ -343,6 +503,72 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       end
     end
 
-    describe 'validating full comment' # TODO
+    describe 'validating full comment' do
+      it 'generates a standard HTML table comment by default, with all the information provided' do
+        metadata = {
+          'Version Name': '28.2',
+          'Version Code': '1280200108',
+          Flavor: 'Celray'
+        }
+
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          download_url: 'https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk',
+          metadata: metadata,
+          footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+        )
+
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <p>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
+          <table>
+          <tr>
+            <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Fbestfront.cloudfront.net%2Ffeed42%2Fbestapp-pr1357-a1b2c3f.apk&choe=UTF-8' width='250' height='250' /></td>
+            <td><b>App Name</b></td><td> The Best App</td>
+          </tr>
+          <tr><td><b>Version Name</b></td><td>28.2</td></tr>
+          <tr><td><b>Version Code</b></td><td>1280200108</td></tr>
+          <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>Direct Download</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><code>bestapp-pr1357-a1b2c3f.apk</code></a></td></tr>
+          </table>
+          <em>Note: Google Sign-In in not available in those builds</em>
+        EXPECTED_COMMENT
+      end
+
+      it 'generates a HTML table in a spoiler block if fold is true' do
+        metadata = {
+          'Version Name': '28.2',
+          'Version Code': '1280200108',
+          Flavor: 'Celray',
+          Configuration: 'Debug'
+        }
+
+        comment = run_described_fastlane_action(
+          app_display_name: 'The Best App',
+          download_url: 'https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk',
+          fold: true,
+          metadata: metadata,
+          footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+        )
+
+        expect(comment).to eq <<~EXPECTED_COMMENT
+          <details><summary>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</summary>
+          <table>
+          <tr>
+            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Fbestfront.cloudfront.net%2Ffeed42%2Fbestapp-pr1357-a1b2c3f.apk&choe=UTF-8' width='250' height='250' /></td>
+            <td><b>App Name</b></td><td> The Best App</td>
+          </tr>
+          <tr><td><b>Version Name</b></td><td>28.2</td></tr>
+          <tr><td><b>Version Code</b></td><td>1280200108</td></tr>
+          <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+          <tr><td><b>Configuration</b></td><td>Debug</td></tr>
+          <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
+          <tr><td><b>Direct Download</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><code>bestapp-pr1357-a1b2c3f.apk</code></a></td></tr>
+          </table>
+          <em>Note: Google Sign-In in not available in those builds</em>
+          </details>
+        EXPECTED_COMMENT
+      end
+    end
   end
 end

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -87,7 +87,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
-        <p>📲 You can test the changes from this Pull Request in <strong>BestApp</strong> by scanning the QR code below to install the corresponding build via App Center.</p>
+        <p>📲 You can test the changes from this Pull Request in <b>BestApp</b> by scanning the QR code below to install the corresponding build via App Center.</p>
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
@@ -118,7 +118,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
-        <p>📲 You can test the changes from this Pull Request in <strong>BestApp</strong> by scanning the QR code below to install the corresponding build via App Center.</p>
+        <p>📲 You can test the changes from this Pull Request in <b>BestApp</b> by scanning the QR code below to install the corresponding build via App Center.</p>
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
@@ -152,7 +152,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
-        <details><summary>📲 You can test the changes from this Pull Request in <strong>BestApp</strong> by scanning the QR code below to install the corresponding build via App Center.</summary>
+        <details><summary>📲 You can test the changes from this Pull Request in <b>BestApp</b> by scanning the QR code below to install the corresponding build via App Center.</summary>
         <table>
         <tr>
           <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -6,89 +6,128 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
     ENV['BUILDKITE_COMMIT'] = 'a1b2c3f'
   end
 
-  it 'generates the proper AppCenter link and QR code given an org, app name and release ID' do
-    comment = run_described_fastlane_action(
-      appcenter_app_name: 'MyApp',
-      appcenter_release_id: 1337
-    )
-    expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/MyApp/releases/1337'>Build #1337</a>"
-    expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMyApp%2Freleases%2F1337&choe=UTF-8'
+  describe 'expected info is included' do
+    it 'generates the proper AppCenter link and QR code given an org, app name and release ID' do
+      comment = run_described_fastlane_action(
+        appcenter_app_name: 'MyApp',
+        appcenter_release_id: 1337
+      )
+      expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/MyApp/releases/1337'>Build #1337</a>"
+      expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMyApp%2Freleases%2F1337&choe=UTF-8'
+    end
+
+    it 'includes the commit as part of the default rows' do
+      comment = run_described_fastlane_action(
+        appcenter_app_name: 'MyApp',
+        appcenter_release_id: 1337
+      )
+      expect(comment).to include '<td><b>Commit</b></td><td><tt>a1b2c3f</tt></td>'
+    end
+
+    it 'correctly includes additional metadata when some are provided' do
+      metadata = {
+        'Version:Short': '28.1',
+        'Version:Long': '281003',
+        'Build Config': 'Prototype'
+      }
+      comment = run_described_fastlane_action(
+        appcenter_app_name: 'MyApp',
+        appcenter_release_id: 1337,
+        metadata: metadata
+      )
+      expect(comment).to include "<td rowspan='6'>"
+      expect(comment).to include '<td><b>Version:Short</b></td><td>28.1</td>'
+      expect(comment).to include '<td><b>Version:Long</b></td><td>281003</td>'
+      expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>'
+    end
+
+    it 'includes the default footnote by default' do
+      comment = run_described_fastlane_action(
+        appcenter_org_name: 'BestOrg',
+        appcenter_app_name: 'MyApp',
+        appcenter_release_id: 1337
+      )
+      expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
+    end
+
+    it 'includes the provided footnote if any' do
+      comment = run_described_fastlane_action(
+        appcenter_app_name: 'MyApp',
+        appcenter_release_id: 1337,
+        footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
+      )
+      expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
+    end
   end
 
-  it 'includes the commit as part of the default rows' do
-    comment = run_described_fastlane_action(
-      appcenter_app_name: 'MyApp',
-      appcenter_release_id: 1337
-    )
-    expect(comment).to include '<td><b>Commit</b></td><td><tt>a1b2c3f</tt></td>'
-  end
+  describe 'full comment' do
+    it 'generates a standard HTML table comment by default, with all the information provided' do
+      metadata = {
+        'Version:Short': '28.2',
+        'Version:Long': '28.2.0.108',
+        Flavor: 'Celray'
+      }
 
-  it 'correctly includes additional metadata when some are provided' do
-    metadata = {
-      'Version:Short': '28.1',
-      'Version:Long': '281003',
-      'Build Config': 'Prototype'
-    }
-    comment = run_described_fastlane_action(
-      appcenter_app_name: 'MyApp',
-      appcenter_release_id: 1337,
-      metadata: metadata
-    )
-    expect(comment).to include "<td rowspan='6'>"
-    expect(comment).to include '<td><b>Version:Short</b></td><td>28.1</td>'
-    expect(comment).to include '<td><b>Version:Long</b></td><td>281003</td>'
-    expect(comment).to include '<td><b>Build Config</b></td><td>Prototype</td>'
-  end
+      comment = run_described_fastlane_action(
+        appcenter_org_name: 'BestOrg',
+        appcenter_app_name: 'BestApp',
+        appcenter_release_id: 8888,
+        metadata: metadata,
+        footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+      )
 
-  it 'includes the default footnote by default' do
-    comment = run_described_fastlane_action(
-      appcenter_org_name: 'BestOrg',
-      appcenter_app_name: 'MyApp',
-      appcenter_release_id: 1337
-    )
-    expect(comment).to include '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
-  end
+      expect(comment).to eq <<~EXPECTED_COMMENT
+        <p>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</p>
+        <table>
+        <tr>
+          <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+          <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
+        </tr>
+        <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
+        <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
+        <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
+        <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
+        </table>
+        <em>Note: Google Sign-In in not available in those builds</em>
+      EXPECTED_COMMENT
+    end
 
-  it 'includes the provided footnote if any' do
-    comment = run_described_fastlane_action(
-      appcenter_app_name: 'MyApp',
-      appcenter_release_id: 1337,
-      footnote: '<em>Note that Google Sign-In in not available in those builds</em>'
-    )
-    expect(comment).to include '<em>Note that Google Sign-In in not available in those builds</em>'
-  end
+    it 'generates a HTML table in a spoiler block if fold is true' do
+      metadata = {
+        'Version:Short': '28.2',
+        'Version:Long': '28.2.0.108',
+        Flavor: 'Celray',
+        Configuration: 'Debug'
+      }
 
-  it 'generates a fully formatted HTML comment with all the information provided' do
-    metadata = {
-      'Version:Short': '28.2',
-      'Version:Long': '28.2.0.108',
-      Flavor: 'Celray',
-      Panel: false
-    }
+      comment = run_described_fastlane_action(
+        appcenter_org_name: 'BestOrg',
+        appcenter_app_name: 'BestApp',
+        appcenter_release_id: 8888,
+        fold: true,
+        metadata: metadata,
+        footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
+      )
 
-    comment = run_described_fastlane_action(
-      appcenter_org_name: 'BestOrg',
-      appcenter_app_name: 'BestApp',
-      appcenter_release_id: 8888,
-      metadata: metadata,
-      footnote: '<em>Note: Google Sign-In in not available in those builds</em>'
-    )
-
-    expect(comment).to eq <<~EXPECTED_COMMENT
-      <p>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</p>
-      <table>
-      <tr>
-        <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-        <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
-      </tr>
-      <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
-      <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
-      <tr><td><b>Flavor</b></td><td>Celray</td></tr>
-      <tr><td><b>Panel</b></td><td>false</td></tr>
-      <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
-      <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
-      </table>
-      <em>Note: Google Sign-In in not available in those builds</em>
-    EXPECTED_COMMENT
+      expect(comment).to eq <<~EXPECTED_COMMENT
+        <details>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</details>
+        <summary>
+        <table>
+        <tr>
+          <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+          <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
+        </tr>
+        <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
+        <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
+        <tr><td><b>Flavor</b></td><td>Celray</td></tr>
+        <tr><td><b>Configuration</b></td><td>Debug</td></tr>
+        <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
+        <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
+        </table>
+        <em>Note: Google Sign-In in not available in those builds</em>
+        </summary>
+      EXPECTED_COMMENT
+    end
   end
 end

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         appcenter_app_name: 'MyApp',
         appcenter_release_id: 1337
       )
-      expect(comment).to include '<td><b>Commit</b></td><td><code>a1b2c3f</code></td>'
+      expect(comment).to include '<td><b>Commit</b></td><td>a1b2c3f</td>'
     end
 
     it 'correctly includes additional metadata when some are provided' do
@@ -91,13 +91,13 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td><code>BestApp</code></td>
+          <td width='150px'><b>App Name</b></td><td>BestApp</td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
         <tr><td><b>Flavor</b></td><td>Celray</td></tr>
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
-        <tr><td><b>Commit</b></td><td><code>a1b2c3f</code></td></tr>
+        <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
         </table>
         <em>Note: Google Sign-In in not available in those builds</em>
       EXPECTED_COMMENT
@@ -122,13 +122,13 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td><code>BestApp</code></td>
+          <td width='150px'><b>App Name</b></td><td>BestApp</td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
         <tr><td><b>Direct Link</b></td><td><a href='https://bestfront.cloudfront.net/feed42/bestapp-pr1357-a1b2c3f.apk'><code>bestapp-pr1357-a1b2c3f.apk</code></a></td></tr>
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/8888'>Build \#8888</a></td></tr>
-        <tr><td><b>Commit</b></td><td><code>a1b2c3f</code></td></tr>
+        <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
         </table>
         <em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>
       EXPECTED_COMMENT
@@ -156,14 +156,14 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App Name</b></td><td><code>BestApp</code></td>
+          <td width='150px'><b>App Name</b></td><td>BestApp</td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
         <tr><td><b>Flavor</b></td><td>Celray</td></tr>
         <tr><td><b>Configuration</b></td><td>Debug</td></tr>
         <tr><td><b>App Center Build</b></td><td><a href='https://install.appcenter.ms/orgs/BestOrg/apps/BestApp/releases/1234'>Build \#1234</a></td></tr>
-        <tr><td><b>Commit</b></td><td><code>a1b2c3f</code></td></tr>
+        <tr><td><b>Commit</b></td><td>a1b2c3f</td></tr>
         </table>
         <em>Note: Google Sign-In in not available in those builds</em>
         </details>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -153,8 +153,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
       )
 
       expect(comment).to eq <<~EXPECTED_COMMENT
-        <details>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</details>
-        <summary>
+        <details><summary>📲 You can test the changes from this Pull Request by scanning the QR code below with your phone to install the corresponding <strong>BestApp</strong> build from App Center.</summary>
         <table>
         <tr>
           <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
@@ -168,7 +167,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <tr><td><b>Commit</b></td><td><tt>a1b2c3f</tt></td></tr>
         </table>
         <em>Note: Google Sign-In in not available in those builds</em>
-        </summary>
+        </details>
       EXPECTED_COMMENT
     end
   end

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -91,7 +91,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
+          <td width='150px'><b>App Name</b></td><td><tt>BestApp</tt></td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
@@ -122,7 +122,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='6'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
+          <td width='150px'><b>App Name</b></td><td><tt>BestApp</tt></td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>
@@ -156,7 +156,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
         <table>
         <tr>
           <td rowspan='7'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
-          <td width='150px'><b>App</b></td><td><tt>BestApp</tt></td>
+          <td width='150px'><b>App Name</b></td><td><tt>BestApp</tt></td>
         </tr>
         <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
         <tr><td><b>Version:Long</b></td><td>28.2.0.108</td></tr>

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
   end
 
   describe 'expected info is included' do
-    it 'generates the proper AppCenter link and QR code given an org, app name and release ID' do
+    it 'generates the proper App Center link and QR code given an org, app name and release ID' do
       comment = run_described_fastlane_action(
         appcenter_app_name: 'MyApp',
         appcenter_release_id: 1337


### PR DESCRIPTION
## What does it do?

Many of our client apps are configured to generate a Prototype Build (aka Installable Build), then make a comment on the PR with a QR code and some additional info to download the build directly from App Center.

Since the HTML content of those comments are a bit annoying and verbose to hardcode directly in the Fastfile of each of our apps, while they all look the same, I've decided to DRY the generation of this content in a dedicated action that generates a nice HTML table (with the QR code + some metadata) for us, ensuring we use the same nice format in all our client apps.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.