### PR TITLE
Remove Deliverfile related functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@
 - Remove the `skip_glotpress` parameter from the `ios_bump_version_release` action [#443]
 - Add the `public_version_xcconfig_file` parameter to the `ios_get_app_version` action to replace the need for an environment variable [#445]
 - Remove the `ios_localize_project` and `ios_update_metadata` actions [#447]
-- Remove the `skip_deliver` parameter from the `ios_bump_version_hotfix` action
-- Remove the `skip_deliver` parameter from the `ios_bump_version_release` action
+- Remove the `skip_deliver` parameter from `ios_bump_version_hotfix` and `ios_bump_version_release` actions
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Remove the `skip_glotpress` parameter from the `ios_bump_version_release` action [#443]
 - Add the `public_version_xcconfig_file` parameter to the `ios_get_app_version` action to replace the need for an environment variable [#445]
 - Remove the `ios_localize_project` and `ios_update_metadata` actions [#447]
-- Remove the `skip_deliver` parameter from `ios_bump_version_hotfix` and `ios_bump_version_release` actions
+- Remove the `skip_deliver` parameter from `ios_bump_version_hotfix` and `ios_bump_version_release` actions [#450]
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Remove the `skip_glotpress` parameter from the `ios_bump_version_release` action [#443]
 - Add the `public_version_xcconfig_file` parameter to the `ios_get_app_version` action to replace the need for an environment variable [#445]
 - Remove the `ios_localize_project` and `ios_update_metadata` actions [#447]
+- Remove the `skip_deliver` parameter from the `ios_bump_version_hotfix` action
+- Remove the `skip_deliver` parameter from the `ios_bump_version_release` action
 
 ### New Features
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -15,7 +15,7 @@ module Fastlane
         Fastlane::Helper::Ios::VersionHelper.update_xc_configs(@new_beta_version, @short_version, @new_internal_version)
         UI.message 'Done!'
 
-        Fastlane::Helper::Ios::GitHelper.commit_version_bump(include_deliverfile: false)
+        Fastlane::Helper::Ios::GitHelper.commit_version_bump()
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -9,18 +9,11 @@ module Fastlane
         create_config(params[:previous_version], params[:version])
         show_config()
 
-        update_deliverfile = params[:skip_deliver] == false
-        if update_deliverfile
-          UI.message 'Updating Fastlane deliver file...'
-          Fastlane::Helper::Ios::VersionHelper.update_fastlane_deliver(@new_short_version)
-          UI.message 'Done!'
-        end
-
         UI.message 'Updating XcConfig...'
         Fastlane::Helper::Ios::VersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal)
         UI.message 'Done!'
 
-        Fastlane::Helper::Ios::GitHelper.commit_version_bump(include_deliverfile: update_deliverfile)
+        Fastlane::Helper::Ios::GitHelper.commit_version_bump()
 
         UI.message 'Done.'
       end
@@ -50,16 +43,6 @@ module Fastlane
             env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_PREVIOUS_VERSION',
             description: 'The version to branch from',
             is_string: true
-          ),
-          FastlaneCore::ConfigItem.new(
-            key: :skip_deliver,
-            env_name: 'FL_IOS_BUMP_VERSION_HOTFIX_SKIP_DELIVER',
-            description: 'Skips Deliverfile key update',
-            is_string: false, # Boolean parameter
-            optional: true,
-            # Don't skip the Deliverfile by default. At the time of writing, 2 out of 3 consumers
-            # still have a Deliverfile.
-            default_value: false
           ),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -21,17 +21,11 @@ module Fastlane
         Fastlane::Helper::GitHelper.create_branch(@new_release_branch, from: default_branch)
         UI.message 'Done!'
 
-        UI.message 'Updating Fastlane deliver file...' unless params[:skip_deliver]
-        Fastlane::Helper::Ios::VersionHelper.update_fastlane_deliver(@new_short_version) unless params[:skip_deliver]
-        UI.message 'Done!' unless params[:skip_deliver]
-
         UI.message 'Updating XcConfig...'
         Fastlane::Helper::Ios::VersionHelper.update_xc_configs(@new_version, @new_short_version, @new_version_internal)
         UI.message 'Done!'
 
-        Fastlane::Helper::Ios::GitHelper.commit_version_bump(
-          include_deliverfile: !params[:skip_deliver]
-        )
+        Fastlane::Helper::Ios::GitHelper.commit_version_bump()
 
         UI.message 'Done.'
       end
@@ -50,11 +44,6 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :skip_deliver,
-                                       env_name: 'FL_IOS_CODEFREEZE_BUMP_SKIPDELIVER',
-                                       description: 'Skips Deliver key update',
-                                       type: Boolean,
-                                       default_value: false),
           FastlaneCore::ConfigItem.new(key: :default_branch,
                                        env_name: 'FL_RELEASE_TOOLKIT_DEFAULT_BRANCH',
                                        description: 'Default branch of the repository',

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -8,15 +8,11 @@ module Fastlane
         #
         # This typically commits and pushes:
         #  - The files in `./config/*` – especially `Version.*.xcconfig` files
-        #  - The `fastlane/Deliverfile` file (which contains the `app_version` line)
         #
         # @env PROJECT_ROOT_FOLDER The path to the git root of the project
         #
-        # @param [Bool] include_deliverfile If true (the default), includes the `fastlane/Deliverfile` in files being commited
-        #
-        def self.commit_version_bump(include_deliverfile: true)
+        def self.commit_version_bump
           files_list = [File.join(get_from_env!(key: 'PROJECT_ROOT_FOLDER'), 'config', '.')]
-          files_list.append File.join('fastlane', 'Deliverfile') if include_deliverfile
 
           Fastlane::Helper::GitHelper.commit(message: 'Bump version number', files: files_list, push: true)
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -215,20 +215,6 @@ module Fastlane
           return verified_version
         end
 
-        # Updates the `app_version` entry in the `Deliverfile`
-        #
-        # @param [String] new_version The new value to set the `app_version` entry to.
-        # @raise [UserError] If the Deliverfile was not found.
-        #
-        def self.update_fastlane_deliver(new_version)
-          fd_file = './fastlane/Deliverfile'
-          if File.exist?(fd_file)
-            Action.sh("sed -i '' \"s/app_version.*/app_version \\\"#{new_version}\\\"/\" #{fd_file}")
-          else
-            UI.user_error!("Can't find #{fd_file}.")
-          end
-        end
-
         # Update the `.xcconfig` files (the public one, and the internal one if it exists) with the new version strings.
         #
         # @env PUBLIC_CONFIG_FILE The path to the xcconfig file containing the public version numbers.

--- a/spec/ios_bump_version_release_spec.rb
+++ b/spec/ios_bump_version_release_spec.rb
@@ -11,34 +11,17 @@ describe Fastlane::Actions::IosBumpVersionReleaseAction do
       other_action_mock = double()
       allow(Fastlane::Action).to receive(:other_action).and_return(other_action_mock)
       allow(other_action_mock).to receive(:ensure_git_branch).with(branch: default_branch)
-
-      allow(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(default_branch)
-      allow(Fastlane::Helper::GitHelper).to receive(:create_branch).with("release/#{next_version_short}", from: default_branch)
-
       allow(Fastlane::Helper::Ios::VersionHelper).to receive(:read_from_config_file).and_return(version)
-      allow(Fastlane::Helper::Ios::VersionHelper).to receive(:update_xc_configs).with(next_version, next_version_short, nil)
     end
 
-    it 'does the fastlane deliver update' do
-      skip_deliver = false
+    it 'correctly uses the next version, short and long' do
+      expect(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(default_branch)
+      expect(Fastlane::Helper::GitHelper).to receive(:create_branch).with("release/#{next_version_short}", from: default_branch)
 
-      expect(Fastlane::Helper::Ios::VersionHelper).to receive(:update_fastlane_deliver).with(next_version_short)
-      expect(Fastlane::Helper::Ios::GitHelper).to receive(:commit_version_bump).with(include_deliverfile: !skip_deliver)
-
-      run_described_fastlane_action(
-        skip_deliver: skip_deliver,
-        default_branch: default_branch
-      )
-    end
-
-    it 'skips the fastlane deliver update properly' do
-      skip_deliver = true
-
-      expect(Fastlane::Helper::Ios::VersionHelper).not_to receive(:update_fastlane_deliver)
-      expect(Fastlane::Helper::Ios::GitHelper).to receive(:commit_version_bump).with(include_deliverfile: !skip_deliver)
+      expect(Fastlane::Helper::Ios::VersionHelper).to receive(:update_xc_configs).with(next_version, next_version_short, nil)
+      expect(Fastlane::Helper::Ios::GitHelper).to receive(:commit_version_bump)
 
       run_described_fastlane_action(
-        skip_deliver: skip_deliver,
         default_branch: default_branch
       )
     end


### PR DESCRIPTION
## What does it do?
On this [discussion I had](https://github.com/wordpress-mobile/release-toolkit/pull/443#discussion_r1085685235) with @AliSoftware he mentioned that using the `Deliverfile` to configure the app version became obsolete, so this PR removes all references to it.

It implements:
- Removal of the `include_deliverfile` parameter in `Ios::GitHelper.commit_version_bump()` and all call sites.
- Removal of the `skip_deliver` ConfigItem in the actions `ios_bump_version_hotfix` and `ios_bump_version_release.rb`.
- Removal of the method `Ios::VersionHelper::update_fastlane_deliver()`.

## Related PRs
- **Note**: this PR was originally created in a separate fork. See original review and discussions: https://github.com/iangmaia/release-toolkit/pull/3
- This PR builds on top of https://github.com/wordpress-mobile/release-toolkit/pull/447.
- This PR is also based on the work started on https://github.com/wordpress-mobile/release-toolkit/pull/443 .

## Next steps
The idea is that the current `Ios::GitHelper.commit_version_bump()` will become  obsolete, given now all it does is committing the hard-coded `/config/` folder. So based on this work, we can also remove `Ios::GitHelper.commit_version_bump()` and commit the `.xcconfig` directly from where it's being changed.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.