### PR TITLE
Additional tests for `ios_get_app_version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _None_
 ### Internal Changes
 
 - Updates `activesupport` to `6.1.7.1`, addressing [a security issue](https://github.com/advisories/GHSA-j6gc-792m-qgm2). This is a major version change, but as the dependency is internal-only, it shouldn't be a breaking change for clients. [#441]
+- Add the explicit dependency to `xcodeproj (~> 1.22)`, used in this case to replace the previous manual parsing of `.xcconfig` files. [#451]
 
 ## 6.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       progress_bar (~> 1.3)
       rake (>= 12.3, < 14.0)
       rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22.0)
+      xcodeproj (~> 1.22)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       progress_bar (~> 1.3)
       rake (>= 12.3, < 14.0)
       rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22.0)
 
 GEM
   remote: https://rubygems.org/

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'progress_bar', '~> 1.3'
   spec.add_dependency 'rake', '>= 12.3', '< 14.0'
   spec.add_dependency 'rake-compiler', '~> 1.0'
-  spec.add_dependency 'xcodeproj', '~> 1.22.0'
+  spec.add_dependency 'xcodeproj', '~> 1.22'
 
   # `google-cloud-storage` is required by fastlane, but we pin it in case it's not in the future
   spec.add_dependency 'google-cloud-storage', '~> 1.31'

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'progress_bar', '~> 1.3'
   spec.add_dependency 'rake', '>= 12.3', '< 14.0'
   spec.add_dependency 'rake-compiler', '~> 1.0'
+  spec.add_dependency 'xcodeproj', '~> 1.22.0'
 
   # `google-cloud-storage` is required by fastlane, but we pin it in case it's not in the future
   spec.add_dependency 'google-cloud-storage', '~> 1.31'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -1,3 +1,5 @@
+require 'xcodeproj'
+
 module Fastlane
   module Helper
     module Ios
@@ -314,21 +316,10 @@ module Fastlane
         # @return [String] The value for the given key, or `nil` if the key was not found.
         #
         def self.read_from_config_file(key, file_path)
-          UI.user_error!("File #{file_path} not found") unless File.exist?(file_path)
+          UI.user_error!(".xcconfig file #{file_path} not found") unless File.exist?(file_path)
 
-          File.open(file_path, 'r') do |f|
-            f.each_line do |line|
-              line.strip!
-              next if line.nil? || line.empty?
-
-              key_value = line.split(/\s*=\s*/)
-              if key_value[0].strip() == key
-                return key_value[1].strip()
-              end
-            end
-          end
-
-          return nil
+          config = Xcodeproj::Config.new(file_path)
+          config.attributes[key]
         end
 
         # Ensure that the version provided is only composed of number parts and return the validated string

--- a/spec/ios_get_app_version_spec.rb
+++ b/spec/ios_get_app_version_spec.rb
@@ -44,8 +44,6 @@ describe Fastlane::Actions::IosGetAppVersionAction do
     end
 
     def expect_version(xcconfig_mock_content:, expected_version:)
-      allow(File).to receive(:exist?).and_return(true)
-
       with_tmp_file(named: 'mock_xcconfig.xcconfig', content: xcconfig_mock_content) do |tmp_file_path|
         version_result = run_described_fastlane_action(
           public_version_xcconfig_file: tmp_file_path

--- a/spec/ios_get_app_version_spec.rb
+++ b/spec/ios_get_app_version_spec.rb
@@ -9,8 +9,6 @@ describe Fastlane::Actions::IosGetAppVersionAction do
         VERSION_LONG = 6.30.0
       CONTENT
 
-      allow(File).to receive(:exist?).and_return(true)
-
       expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30')
     end
 
@@ -20,8 +18,6 @@ describe Fastlane::Actions::IosGetAppVersionAction do
         // a comment
         VERSION_LONG = 6.30.1
       CONTENT
-
-      allow(File).to receive(:exist?).and_return(true)
 
       expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30.1')
     end
@@ -42,23 +38,21 @@ describe Fastlane::Actions::IosGetAppVersionAction do
         // a comment
       CONTENT
 
-      allow(File).to receive(:exist?).and_return(true)
-
       expect do
         expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: 'n/a')
       end.to raise_error(FastlaneCore::Interface::FastlaneError)
     end
 
     def expect_version(xcconfig_mock_content:, expected_version:)
-      xcconfig_mock_file_path = File.join('mock', 'file', 'path')
+      allow(File).to receive(:exist?).and_return(true)
 
-      allow(File).to receive(:open).with(xcconfig_mock_file_path, 'r').and_yield(StringIO.new(xcconfig_mock_content))
+      with_tmp_file(named: 'mock_xcconfig.xcconfig', content: xcconfig_mock_content) do |tmp_file_path|
+        version_result = run_described_fastlane_action(
+          public_version_xcconfig_file: tmp_file_path
+        )
 
-      version_result = run_described_fastlane_action(
-        public_version_xcconfig_file: xcconfig_mock_file_path
-      )
-
-      expect(version_result).to eq(expected_version)
+        expect(version_result).to eq(expected_version)
+      end
     end
   end
 end

--- a/spec/ios_get_app_version_spec.rb
+++ b/spec/ios_get_app_version_spec.rb
@@ -5,8 +5,8 @@ describe Fastlane::Actions::IosGetAppVersionAction do
     it 'parses the xcconfig file format correctly and gets the public version' do
       xcconfig_mock_content = <<~CONTENT
         // a comment
-        VERSION_SHORT=6
-        VERSION_LONG=6.30.0
+        VERSION_SHORT = 6
+        VERSION_LONG = 6.30.0
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
@@ -16,14 +16,37 @@ describe Fastlane::Actions::IosGetAppVersionAction do
 
     it 'parses the xcconfig file format correctly and gets the public hotfix version' do
       xcconfig_mock_content = <<~CONTENT
-        VERSION_SHORT=6
+        VERSION_SHORT = 6
         // a comment
-        VERSION_LONG=6.30.1
+        VERSION_LONG = 6.30.1
       CONTENT
 
       allow(File).to receive(:exist?).and_return(true)
 
       expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30.1')
+    end
+
+    it 'throws an error when the file is not found' do
+      file_path = 'file/not/found'
+
+      expect do
+        run_described_fastlane_action(
+          public_version_xcconfig_file: file_path
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError)
+    end
+
+    it "throws an error when there isn't a version configured in the .xcconfig file" do
+      xcconfig_mock_content = <<~CONTENT
+        VERSION_SHORT = 6
+        // a comment
+      CONTENT
+
+      allow(File).to receive(:exist?).and_return(true)
+
+      expect do
+        expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: 'n/a')
+      end.to raise_error(FastlaneCore::Interface::FastlaneError)
     end
 
     def expect_version(xcconfig_mock_content:, expected_version:)

--- a/spec/ios_get_app_version_spec.rb
+++ b/spec/ios_get_app_version_spec.rb
@@ -22,6 +22,37 @@ describe Fastlane::Actions::IosGetAppVersionAction do
       expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30.1')
     end
 
+    it 'parses the xcconfig with keys without spacing and gets the public version' do
+      xcconfig_mock_content = <<~CONTENT
+        // a comment
+        VERSION_SHORT=6
+        VERSION_LONG=6.30.0
+      CONTENT
+
+      expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30')
+    end
+
+    it 'parses the xcconfig with keys without spacing and gets the public hotfix version' do
+      xcconfig_mock_content = <<~CONTENT
+        VERSION_SHORT=6
+        // a comment
+        VERSION_LONG=6.30.1
+      CONTENT
+
+      expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: '6.30.1')
+    end
+
+    it 'fails to extract the version from an xcconfig file with an invalid format' do
+      xcconfig_mock_content = <<~CONTENT
+        VERSION_SHORT = 6
+        VERSION_LONG 6.30.1
+      CONTENT
+
+      expect do
+        expect_version(xcconfig_mock_content: xcconfig_mock_content, expected_version: 'n/a')
+      end.to raise_error(FastlaneCore::Interface::FastlaneError)
+    end
+
     it 'throws an error when the file is not found' do
       file_path = 'file/not/found'
 


### PR DESCRIPTION
## What does it do?
This PR improves the existing method `Ios::VersionHelper::read_from_config_file()`, making it more reliable and robust by using the gem `xcodeproj`, as well as adding better error handling. Some additional tests cases were also implemented.

This need came up as I was testing the code and noticed that possible format variations for the `.xcconfig` file were not being treated properly and there was no error handling.

## Related PRs
- **Note**: this PR was originally created in a separate fork. See original review and discussions: https://github.com/iangmaia/release-toolkit/pull/1
- This PR builds on top of [#445](https://github.com/wordpress-mobile/release-toolkit/pull/445)

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.