### PR TITLE
`configure_update`: Add "Mobile Secrets" to current branch message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Add "Mobile Secrets" to `configure_update` current branch message to clarify which repo it's referring to. [#455]
 
 ## 7.0.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -46,7 +46,7 @@ module Fastlane
 
       def self.prompt_to_switch_branches
         branch_name_to_display = current_branch.nil? ? current_hash : current_branch
-        if UI.confirm("The current branch is `#{branch_name_to_display}`. Would you like to switch branches?")
+        if UI.confirm("The current Mobile Secrets branch is `#{branch_name_to_display}`. Would you like to switch branches?")
           new_branch = UI.select("Select the branch you'd like to switch to: ", get_branches)
           checkout_branch(new_branch)
           update_configure_file


### PR DESCRIPTION
## What does it do?

This PR just adds "Mobile Secrets" to the current branch message when running `configure_update`. I run `configure_update` infrequently enough that this always make me second guess which repo it's referring to when it says "The current branch is `#{branch_name_to_display}`. Would you like to switch branches?" so I thought this would be helpful for clarifying that it's referring to Mobile Secrets. 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.