### PR TITLE
Update a8c-ci-toolkit Buildkite plugin to new name and latest version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -39,7 +39,7 @@ steps:
       bundle exec rspec --profile 10 --format progress
     env: *xcode_image
     plugins:
-      automattic/bash-cache#2.0.0: ~
+      - automattic/a8c-ci-toolkit#2.15.0
     agents:
       queue: "mac"
 


### PR DESCRIPTION
## What does it do?

- Update the `bash-cache` Buildkite plugin name to `a8c-ci-toolkit`
- Update the `a8c-ci-toolkit` plugin to version `2.15.0` 

## Testing

Ensure that CI is green and that all checks passed.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations - N/A
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable - N/A
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass - N/A
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.

> A note about the CHANGELOG.md entry. I wasn't sure if I should add one for internal tooling changes like these. Please let me know if we're supposed to, and I'll be happy to add it. 