### PR TITLE
Add `ios_get_build_number` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ _None_
 
 - Add `ios_get_build_number` action to get the current build number from an `xcconfig` file. [#458]
 
-_None_
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ _None_
 
 ### New Features
 
+- Add `ios_get_build_number` action to get the current build number from an `xcconfig` file. [#458]
+
 _None_
 
 ### Bug Fixes

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
@@ -4,9 +4,8 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/ios/ios_version_helper'
 
-        UI.user_error!('You need to set at least the PUBLIC_CONFIG_FILE env var to the path to the public xcconfig file') unless ENV['PUBLIC_CONFIG_FILE']
-
-        Fastlane::Helper::Ios::VersionHelper.get_build_number
+        public_version_xcconfig_file = params[:public_version_xcconfig_file]
+        Fastlane::Helper::Ios::VersionHelper.get_xcconfig_build_number(xcconfig_file: public_version_xcconfig_file)
       end
 
       #####################################################
@@ -22,7 +21,15 @@ module Fastlane
       end
 
       def self.available_options
-        # Define all options your action supports.
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :public_version_xcconfig_file,
+            env_name: 'FL_IOS_PUBLIC_VERSION_XCCONFIG_FILE',
+            description: 'Path to the .xcconfig file containing the public build number',
+            type: String,
+            optional: false
+          ),
+        ]
       end
 
       def self.output

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
@@ -28,7 +28,7 @@ module Fastlane
             description: 'Path to the .xcconfig file containing the build number',
             is_string: false,
             optional: false
-          )
+          ),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
@@ -4,8 +4,8 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/ios/ios_version_helper'
 
-        public_version_xcconfig_file = params[:public_version_xcconfig_file]
-        Fastlane::Helper::Ios::VersionHelper.get_build_number(xcconfig_file: public_version_xcconfig_file)
+        xcconfig_file_path = params[:xcconfig_file_path]
+        Fastlane::Helper::Ios::VersionHelper.read_build_number_from_config_file(xcconfig_file_path)
       end
 
       #####################################################
@@ -13,22 +13,22 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Gets the public build number of the app'
+        'Gets the build number of the app'
       end
 
       def self.details
-        'Gets the public build number of the app'
+        'Gets the build number of the app'
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(
-            key: :public_version_xcconfig_file,
-            env_name: 'FL_IOS_PUBLIC_VERSION_XCCONFIG_FILE',
-            description: 'Path to the .xcconfig file containing the public build number',
-            type: String,
+            key: :xcconfig_file_path,
+            env_name: 'FL_IOS_XCCONFIG_FILE_PATH',
+            description: 'Path to the .xcconfig file containing the build number',
+            is_string: false,
             optional: false
-          ),
+          )
         ]
       end
 
@@ -38,7 +38,7 @@ module Fastlane
 
       def self.return_value
         # If you method provides a return value, you can describe here what it does
-        'Return the public build number of the app'
+        'Return the build number of the app'
       end
 
       def self.authors

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
@@ -26,7 +26,7 @@ module Fastlane
             key: :xcconfig_file_path,
             env_name: 'FL_IOS_XCCONFIG_FILE_PATH',
             description: 'Path to the .xcconfig file containing the build number',
-            is_string: false,
+            type: String,
             optional: false
           ),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
@@ -5,7 +5,7 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
 
         public_version_xcconfig_file = params[:public_version_xcconfig_file]
-        Fastlane::Helper::Ios::VersionHelper.get_xcconfig_build_number(xcconfig_file: public_version_xcconfig_file)
+        Fastlane::Helper::Ios::VersionHelper.get_build_number(xcconfig_file: public_version_xcconfig_file)
       end
 
       #####################################################

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
@@ -1,0 +1,47 @@
+module Fastlane
+  module Actions
+    class IosGetAppVersionAction < Action
+      def self.run(params)
+        require_relative '../../helper/ios/ios_version_helper'
+
+        UI.user_error!('You need to set at least the PUBLIC_CONFIG_FILE env var to the path to the public xcconfig file') unless ENV['PUBLIC_CONFIG_FILE']
+
+        Fastlane::Helper::Ios::VersionHelper.get_build_number
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Gets the public build number of the app'
+      end
+
+      def self.details
+        'Gets the public build number of the app'
+      end
+
+      def self.available_options
+        # Define all options your action supports.
+      end
+
+      def self.output
+        # Define the shared values you are going to provide
+      end
+
+      def self.return_value
+        # If you method provides a return value, you can describe here what it does
+        'Return the public build number of the app'
+      end
+
+      def self.authors
+        # So no one will ever forget your contribution to fastlane :) You are awesome btw!
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_number.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module Actions
-    class IosGetAppVersionAction < Action
+    class IosGetBuildNumberAction < Action
       def self.run(params)
         require_relative '../../helper/ios/ios_version_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -180,14 +180,6 @@ module Fastlane
           get_version_strings()[1]
         end
 
-        # Returns the current value of the `BUILD_NUMBER` key from the public xcconfig file
-        #
-        # @return [String] The current build number according to the public xcconfig file.
-        #
-        def self.get_build_number(xcconfig_file)
-          read_build_number_from_config_file(xcconfig_file)
-        end
-
         # Prints the current and next release version numbers to stdout, then return the next release version
         #
         # @return [String] The next release version to use after bumping the currently used public version.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -185,7 +185,7 @@ module Fastlane
         # @return [String] The current build number according to the public xcconfig file.
         #
         def self.get_build_number
-          read_build_number_from_config_file(ENV['PUBLIC_CONFIG_FILE'])
+          read_build_number_from_config_file(xcconfig_file)
         end
 
         # Prints the current and next release version numbers to stdout, then return the next release version

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -184,7 +184,7 @@ module Fastlane
         #
         # @return [String] The current build number according to the public xcconfig file.
         #
-        def self.get_build_number
+        def self.get_build_number(xcconfig_file)
           read_build_number_from_config_file(xcconfig_file)
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -180,6 +180,14 @@ module Fastlane
           get_version_strings()[1]
         end
 
+        # Returns the current value of the `BUILD_NUMBER` key from the public xcconfig file
+        #
+        # @return [String] The current build number according to the public xcconfig file.
+        #
+        def self.get_build_number
+          get_version_strings()[3]
+        end
+
         # Prints the current and next release version numbers to stdout, then return the next release version
         #
         # @return [String] The next release version to use after bumping the currently used public version.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -185,7 +185,7 @@ module Fastlane
         # @return [String] The current build number according to the public xcconfig file.
         #
         def self.get_build_number
-          get_version_strings()[3]
+          read_build_number_from_config_file(ENV['PUBLIC_CONFIG_FILE'])
         end
 
         # Prints the current and next release version numbers to stdout, then return the next release version

--- a/spec/ios_get_build_number_spec.rb
+++ b/spec/ios_get_build_number_spec.rb
@@ -43,11 +43,9 @@ describe Fastlane::Actions::IosGetBuildNumberAction do
     end
 
     it 'throws an error when the xcconfig file does not exist' do
-      file_path = 'file/not/found'
-
       expect do
         run_described_fastlane_action(
-          xcconfig_file_path: file_path
+          xcconfig_file_path: 'file/not/found'
         )
         # Ruby error for 'No such file or directory': https://ruby-doc.org/core-2.7.4/SystemCallError.html
       end.to raise_error(Errno::ENOENT)

--- a/spec/ios_get_build_number_spec.rb
+++ b/spec/ios_get_build_number_spec.rb
@@ -49,7 +49,7 @@ describe Fastlane::Actions::IosGetBuildNumberAction do
         run_described_fastlane_action(
           xcconfig_file_path: file_path
         )
-      # Ruby error for 'No such file or directory': https://ruby-doc.org/core-2.7.4/SystemCallError.html
+        # Ruby error for 'No such file or directory': https://ruby-doc.org/core-2.7.4/SystemCallError.html
       end.to raise_error(Errno::ENOENT)
     end
 

--- a/spec/ios_get_build_number_spec.rb
+++ b/spec/ios_get_build_number_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IosGetBuildNumberAction do
+  describe 'getting the build number from the provided .xcconfig file' do
+    it 'parses an xcconfig file with keys without spacing and returns the correct build number' do
+      xcconfig_mock_content = <<~CONTENT
+        // a comment
+        VERSION_SHORT=6
+        VERSION_LONG=6.30.0
+        BUILD_NUMBER=1940
+      CONTENT
+
+      expect_build_number(xcconfig_mock_content: xcconfig_mock_content, expected_build_number: '1940')
+    end
+
+    it 'parses an xcconfig file with keys with spaces and returns a nil build number' do
+      xcconfig_mock_content = <<~CONTENT
+        VERSION_SHORT = 6
+        VERSION_LONG = 6.30.1
+        BUILD_NUMBER = 1940
+      CONTENT
+
+      expect_build_number(xcconfig_mock_content: xcconfig_mock_content, expected_build_number: nil)
+    end
+
+    it 'parses an xcconfig file with an invalid format and returns a nil build number' do
+      xcconfig_mock_content = <<~CONTENT
+        VERSION_SHORT = 6
+        VERSION_LONG = 6.30.1
+        BUILD_NUMBER 1940
+      CONTENT
+
+      expect_build_number(xcconfig_mock_content: xcconfig_mock_content, expected_build_number: nil)
+    end
+
+    it 'parses an xcconfig file with no build number and returns a nil build number' do
+      xcconfig_mock_content = <<~CONTENT
+        VERSION_SHORT = 6
+        // a comment
+      CONTENT
+
+      expect_build_number(xcconfig_mock_content: xcconfig_mock_content, expected_build_number: nil)
+    end
+
+    it 'throws an error when the xcconfig file does not exist' do
+      file_path = 'file/not/found'
+
+      expect do
+        run_described_fastlane_action(
+          xcconfig_file_path: file_path
+        )
+      # Ruby error for 'No such file or directory': https://ruby-doc.org/core-2.7.4/SystemCallError.html
+      end.to raise_error(Errno::ENOENT)
+    end
+
+    def expect_build_number(xcconfig_mock_content:, expected_build_number:)
+      with_tmp_file(named: 'mock_xcconfig.xcconfig', content: xcconfig_mock_content) do |tmp_file_path|
+        build_number_result = run_described_fastlane_action(
+          xcconfig_file_path: tmp_file_path
+        )
+
+        expect(build_number_result).to eq(expected_build_number)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does it do?

This action adds an action called `ios_get_build_number` to get the current build number from an `xcconfig` file. Because Day One iOS and Mac use the build number to name builds, this new action is needed for things like GitHub release names and tags.

## How to test

1. In the `bloom/DayOne-Apple` repo, switch to the `spencer/demo-get-build-number-action` branch
2. Run `bundle exec fastlane ios test_get_build_number_action`
3. The output should be "The build number is 2392"
4. Run `bundle exec fastlane mac test_get_build_number_action`
3. The output should be "The build number is 1471"

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [X] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.