### PR TITLE
Fix `create_release` log message for non-draft releases

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -16,7 +16,7 @@ module Fastlane
         prerelease = params[:prerelease]
         is_draft = params[:is_draft]
 
-        UI.message("Creating draft release #{version} in #{repository}.")
+        UI.message("Creating #{is_draft ? 'draft ' : ''}release #{version} in #{repository}.")
         # Verify assets
         assets.each do |file_path|
           UI.user_error!("Can't find file #{file_path}!") unless File.exist?(file_path)


### PR DESCRIPTION
## What does it do?

Fix a misleading log message in `create_release`, which printed that it created a draft release even when `is_draft` was false.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] ~Add Unit Tests (aka `specs/*_spec.rb`) if applicable~ No Unit Tests for this trivial change
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [ ] ~Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.~ Trivial typo fix, not worth a CHANGELOG entry.