### PR TITLE
Print the URL of a Buildkite build after triggering it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _None_
 ### Internal Changes
 
 - Add "Mobile Secrets" to `configure_update` current branch message to clarify which repo it's referring to. [#455]
+- `buildkite_trigger_build` now prints the web URL of the newly scheduled build, to allow you to easily open it via cmd-click. [#460]
 
 ## 7.0.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -23,7 +23,11 @@ module Fastlane
           options
         )
 
-        response.state == 'scheduled' ? UI.message('Done!') : UI.crash!("Failed to start job\nError: [#{response}]")
+        if response.state == 'scheduled'
+          UI.message("Successfully scheduled new build. You can see it at '#{response.web_url}'")
+        else
+          UI.crash!("Failed to start job\nError: [#{response}]")
+        end
       end
 
       #####################################################


### PR DESCRIPTION
## What does it do?

Print the URL of a Buildkite build after triggering it.

Inspired by GitHub's `gh pr create` CLI—which similarly prints the URL of the PR once created—which is a feature I constantly use, by command-clicking on the printed URL in my Terminal to open it in my web browser directly.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] ~Add Unit Tests (aka `specs/*_spec.rb`) if applicable~
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.