### PR TITLE
Add the branch information to the 'this is not a release branch' error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _None_
 
 - Add "Mobile Secrets" to `configure_update` current branch message to clarify which repo it's referring to. [#455]
 - `buildkite_trigger_build` now prints the web URL of the newly scheduled build, to allow you to easily open it via cmd-click. [#460]
+- Add the branch information to the 'This is not a release branch' error that's thrown from complete code freeze lane. [#461]
 
 ## 7.0.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -7,7 +7,7 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
-        UI.user_error!('This is not a release branch. Abort.') unless other_action.git_branch.start_with?('release/')
+        UI.user_error!("Current branch - '#{other_action.git_branch}' - is not a release branch. Abort.") unless other_action.git_branch.start_with?('release/')
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version
         message = "Completing code freeze for: #{version}\n"

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -7,7 +7,7 @@ module Fastlane
         require_relative '../../helper/ios/ios_version_helper'
         require_relative '../../helper/ios/ios_git_helper'
 
-        UI.user_error!('This is not a release branch. Abort.') unless other_action.git_branch.start_with?('release/')
+        UI.user_error!("Current branch - '#{other_action.git_branch}' - is not a release branch. Abort.") unless other_action.git_branch.start_with?('release/')
 
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
         message = "Completing code freeze for: #{version}\n"


### PR DESCRIPTION
## What does it do?
Adds information about the current branch to the `This is not a release branch. Abort.` error thrown from complete code freeze lane.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.