### PR TITLE
Update `buildkite-test_collector` to `2.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _None_
 - `buildkite_trigger_build` now prints the web URL of the newly scheduled build, to allow you to easily open it via cmd-click. [#460]
 - Add the branch information to the 'This is not a release branch' error that's thrown from complete code freeze lane. [#461]
 - Update `octokit` to `5.6.1` and `danger` to `9.3.0`. These are both major version changes, but as the dependency is internal-only, it shouldn't be a breaking change for clients. [#464]
+- Replace `rspec-buildkite-analytics` with `buildkite-test_collector` (Buildkite renamed the gem) and update it to `2.2.0`. This is another internal-only change and is not a breaking change for clients. [#465]
 
 ## 7.0.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'codecov', require: false
 gem 'webmock', require: false
 gem 'yard'
 
-gem 'buildkite-test_collector', '~> 2.1'
+gem 'buildkite-test_collector', '~> 2.2'

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'codecov', require: false
 gem 'webmock', require: false
 gem 'yard'
 
-gem 'rspec-buildkite-analytics', '~> 0.8.1'
+gem 'buildkite-test_collector', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
     bigdecimal (1.4.4)
     buildkit (1.5.0)
       sawyer (>= 0.6)
+    buildkite-test_collector (2.2.0)
+      activesupport (>= 4.2)
     chroma (0.2.0)
     claide (1.1.0)
     claide-plugins (0.9.2)
@@ -323,11 +325,6 @@ GEM
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-buildkite-analytics (0.8.2)
-      activesupport (>= 5.2, < 8)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      websocket (~> 1.2)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -398,7 +395,6 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.1)
-    websocket (1.2.9)
     word_wrap (1.0.0)
     xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -417,6 +413,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  buildkite-test_collector (~> 2.1)
   bundler (~> 2.0)
   cocoapods (~> 1.10)
   codecov
@@ -427,7 +424,6 @@ DEPENDENCIES
   pry (~> 0.12.2)
   rmagick (~> 4.1)
   rspec (~> 3.8)
-  rspec-buildkite-analytics (~> 0.8.1)
   rspec_junit_formatter (~> 0.4.1)
   rubocop (~> 1.0)
   rubocop-require_tools (~> 0.1.2)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ SimpleCov.formatter = SimpleCov::Formatter::Codecov if code_coverage_token
 
 # Buildkite Test Analytics
 WebMock.disable_net_connect!(allow: 'analytics-api.buildkite.com')
-Buildkite::TestCollector.configure(token: ENV.fetch('BUILDKITE_ANALYTICS_TOKEN', nil))
+Buildkite::TestCollector.configure(hook: :rspec)
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'simplecov'
 require 'codecov'
 require 'webmock/rspec'
-require 'rspec/buildkite/analytics'
+require 'buildkite/test_collector'
 
 # SimpleCov.minimum_coverage 95
 SimpleCov.start
@@ -15,7 +15,7 @@ SimpleCov.formatter = SimpleCov::Formatter::Codecov if code_coverage_token
 
 # Buildkite Test Analytics
 WebMock.disable_net_connect!(allow: 'analytics-api.buildkite.com')
-RSpec::Buildkite::Analytics.configure(token: ENV.fetch('BUILDKITE_ANALYTICS_TOKEN', nil))
+Buildkite::TestCollector.configure(token: ENV.fetch('BUILDKITE_ANALYTICS_TOKEN', nil))
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper


### PR DESCRIPTION
## What does it do?

This PR replaces the `rspec-buildkite-analytics` gem with `buildkite-test_collector` (it's the same gem but Buildkite renamed it a while ago) and updates it to `2.2.0`. This is an internal-only change and is not a breaking change for clients.

I followed the breaking change update steps from the `1.0.0` and `2.1.0` releases. 

I'm merging into `update/octokit` because there are a lot of dependency changes there and I thought this would be a good way to avoid conflicts on those. 

## How to Test

You can verify that the Test Analytics report for this PR successfully shows up in Buildkite: https://buildkite.com/organizations/automattic/analytics/suites/release-toolkit/runs/85caafb1-865e-4eaa-8a1d-c720a2957c43

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.