### PR TITLE
Add `ios_register_ci_machine` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Add `ios_register_ci_machine` action to register the current CI machine in the Apple Developer Portal.
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_register_ci_machine.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_register_ci_machine.rb
@@ -1,0 +1,71 @@
+module Fastlane
+  module Actions
+    class IosRegisterCiMachineAction < Action
+      def self.run(params)
+        return unless other_action.is_ci
+
+        require 'socket'
+        require 'open3'
+
+        hostname = Socket.gethostname
+                         .delete_suffix('.local')
+                         .delete_suffix('.shared')
+
+        device_uuid, = Open3.capture2("system_profiler SPHardwareDataType | awk '/Hardware UUID/ { print $NF }'")
+        device_uuid.strip!
+        raise 'Failed to get device UUID' if device_uuid.nil?
+
+        UI.message "Registering device #{device_uuid} for CI image #{hostname}"
+
+        other_action.register_device(
+          name: "CI - #{hostname}",
+          udid: device_uuid,
+          platform: 'mac',
+          api_key_path: params[:api_key_path],
+          team_id: params[:team_id]
+        )
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Register the current CI machine as a new device in the Apple Developer Portal'
+      end
+
+      def self.details
+        <<~DETAILS
+          Register the current CI machine as a new device in the Apple Developer Portal.
+
+          As the action name suggests, this action is only meant to be run on a CI machine and does nothing if CI environment is not detected (via the `is_ci` action).
+        DETAILS
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :api_key_path,
+            description: 'The path of the App Store Connect API key file',
+            type: String,
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :team_id,
+            description: 'The ID of the Developer Portal team',
+            type: String,
+            optional: false
+          ),
+        ]
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        platform == :mac
+      end
+    end
+  end
+end

--- a/spec/ios_register_ci_machine_spec.rb
+++ b/spec/ios_register_ci_machine_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IosRegisterCiMachineAction do
+  let(:other_action) { instance_double('other_action') }
+
+  before do
+    allow(Fastlane::OtherAction).to receive(:new).and_return(other_action)
+    allow(other_action).to receive(:register_device)
+  end
+
+  describe '#ios_register_ci_machine' do
+    it 'do nothing if not running on CI' do
+      allow(other_action).to receive(:is_ci).and_return(false)
+      expect(other_action).not_to receive(:register_device)
+      run_described_fastlane_action(api_key_path: '', team_id: '')
+    end
+
+    it 'registers the device with the proper parameters' do
+      allow(other_action).to receive(:is_ci).and_return(true)
+      expect(other_action).to receive(:register_device)
+        .with(hash_including(api_key_path: 'api-key.json', team_id: 'ABC'))
+      run_described_fastlane_action(
+        api_key_path: 'api-key.json',
+        team_id: 'ABC'
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What does it do?

Register the current macOS machine in the Apple Developer Portal, using [the fastlane built-in `register_device` action](https://docs.fastlane.tools/actions/register_device/).

In our macOS image building process, we have a manual step to register a new VM image's hardware uuid. This action is created to replace that manual step.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.