### PR TITLE
Ignore pipeline branch filters when we trigger Buildkite via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _None_
 - Add "Mobile Secrets" to `configure_update` current branch message to clarify which repo it's referring to. [#455]
 - `buildkite_trigger_build` now prints the web URL of the newly scheduled build, to allow you to easily open it via cmd-click. [#460]
 - Add the branch information to the 'This is not a release branch' error that's thrown from complete code freeze lane. [#461]
+- Adds `ignore_pipeline_branch_filters=true` parameter to the API call triggering a Buildkite build [#468]
 
 ## 7.0.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -13,7 +13,11 @@ module Fastlane
           branch: params[:branch],
           commit: params[:commit],
           env: params[:environment].merge(pipeline_name),
-          message: params[:message]
+          message: params[:message],
+          # Buildkite will not trigger a build if the GitHub activity for that branch is turned off
+          # We want API triggers to work regardless of the GitHub activity settings, so this option is necessary
+          # https://forum.buildkite.community/t/request-build-error-branches-have-been-disabled-for-this-pipeline/1463/2
+          ignore_pipeline_branch_filters: true
         }.compact # remove entries with `nil` values from the Hash, if any
 
         client = Buildkit.new(token: params[:buildkite_token])


### PR DESCRIPTION
## What does it do?

While working on [release-toolkit-demo](https://github.com/wordpress-mobile/release-toolkit-demo), I've had the following error when I trigger a Buildkite build via its API:

```
POST https://api.buildkite.com/v2/organizations/automattic/pipelines/release-toolkit-demo/builds: 422 - Branches have been disabled for this pipeline
```

According to [this answer](https://forum.buildkite.community/t/request-build-error-branches-have-been-disabled-for-this-pipeline/1463/2) in Buildkite forums, this is because the GitHub activity is turned off. We don't want our GitHub activity settings to affect the API triggers because those settings are mainly for the default pipeline whereas we can use the API to trigger a completely separate pipeline.

This PR adds the `ignore_pipeline_branch_filters` to the parameters for triggering **all** Buildkite builds via API. I don't think we need to make this optional as I can't foresee a situation where we specifically want to prevent an API trigger to go through. Having said that, I might be missing a use case and I am open to suggestions.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.