### PR TITLE
Deprecate ios_final_tag and ios_clear_intermediate_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ _None_
 - Adds `ignore_pipeline_branch_filters=true` parameter to the API call triggering a Buildkite build [#468]
 - Replace all instances of `is_string` with `type` [#469]
 - Use `git_branch_name_using_HEAD` instead of `git_branch` so that the return value is not modified by environment variables. This has no impact to our current release flow, that's why it's not in "Breaking changes" section. [#463]
-- Deprecate `ios_clear_intermediate_tags` & `ios_final_tag` actions. [#470]
+- Deprecate `ios_clear_intermediate_tags` & `ios_final_tag` actions. [#471]
 
 ## 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ _None_
 - Adds `ignore_pipeline_branch_filters=true` parameter to the API call triggering a Buildkite build [#468]
 - Replace all instances of `is_string` with `type` [#469]
 - Use `git_branch_name_using_HEAD` instead of `git_branch` so that the return value is not modified by environment variables. This has no impact to our current release flow, that's why it's not in "Breaking changes" section. [#463]
+- Deprecate `ios_clear_intermediate_tags` & `ios_final_tag` actions. [#470]
 
 ## 7.0.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -2,6 +2,8 @@ module Fastlane
   module Actions
     class IosClearIntermediateTagsAction < Action
       def self.run(params)
+        return unless UI.confirm("#{deprecated_notes} Would you like to continue with the action?")
+
         UI.message("Deleting tags for version: #{params[:version]}")
 
         require_relative '../../helper/git_helper'
@@ -46,6 +48,12 @@ module Fastlane
       end
 
       def self.return_value
+      end
+
+      def self.deprecated_notes
+        "This action is deprecated as we don't believe it's currently in use in our projects.
+        However, just to be sure that it's not in use, we decided to deprecate it first. If you
+        believe that this is a mistake, please let us know on Slack."
       end
 
       def self.authors

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -50,6 +50,10 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
       def self.deprecated_notes
         "This action is deprecated as we don't believe it's currently in use in our projects.
         However, just to be sure that it's not in use, we decided to deprecate it first. If you

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_clear_intermediate_tags.rb
@@ -28,11 +28,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Cleans all the intermediate tags for the given version'
+        '(DEPRECATED) Cleans all the intermediate tags for the given version'
       end
 
       def self.details
-        'Cleans all the intermediate tags for the given version'
+        '(DEPRECATED) Cleans all the intermediate tags for the given version'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -2,6 +2,8 @@ module Fastlane
   module Actions
     class IosFinalTagAction < Action
       def self.run(params)
+        return unless UI.confirm("#{deprecated_notes} Would you like to continue with the action?")
+
         require_relative '../../helper/ios/ios_git_helper'
         require_relative '../../helper/ios/ios_version_helper'
         version = Fastlane::Helper::Ios::VersionHelper.get_public_version
@@ -38,6 +40,12 @@ module Fastlane
       end
 
       def self.return_value
+      end
+
+      def self.deprecated_notes
+        "This action is deprecated as we don't believe it's currently in use in our projects.
+        However, just to be sure that it's not in use, we decided to deprecate it first. If you
+        believe that this is a mistake, please let us know on Slack."
       end
 
       def self.authors

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -20,11 +20,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Finalize a relasae'
+        '(DEPRECATED) Finalize a relasae'
       end
 
       def self.details
-        'Removes the temp tags and pushes the final one'
+        '(DEPRECATED) Removes the temp tags and pushes the final one'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_final_tag.rb
@@ -42,6 +42,10 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
       def self.deprecated_notes
         "This action is deprecated as we don't believe it's currently in use in our projects.
         However, just to be sure that it's not in use, we decided to deprecate it first. If you


### PR DESCRIPTION
## What does it do?

This PR deprecates `ios_final_tag` & `ios_clear_intermediate_tags` actions. We don't believe these actions are used anymore, but just to be sure, we wanted to deprecate them first.

In order to deprecate the actions, here is a list of changes I've made:
* Added `:deprecated` category
* Added `deprecated_notes`
* Added a confirmation to the action noting that the action is deprecated - as suggested by @jkmassel 
* Added `(DEPRECATED)` prefix to the `details` & `description` of each action

Hopefully this ^ is the correct approach to deprecate these actions. Please let me know if I missed anything or if you have any suggestions.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.