### PR TITLE
Remove git push commands after creating a new commit or branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-_None_
+- Remove git push commands after creating a new commit or branch. [#472] See `MIGRATION.md` for instructions.
 
 ### New Features
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,6 @@
-###From `7.0.0` to `8.0.0`
+# Migration Instructions for Major Releases
+
+### From `7.0.0` to `8.0.0`
 
 We are no longer pushing to remote after creating a new commit or a branch. That means, developers need to manually push the changes or add push commands in the project's `Fastfile`. Most importantly, we can no longer immediately trigger beta/final builds after creating a new commit because the changes will not be in remote yet. If you want to keep the existing behavior, you'll need to add a push command before these triggers.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,5 @@
+###From `7.0.0` to `8.0.0`
+
+We are no longer pushing to remote after creating a new commit or a branch. That means, developers need to manually push the changes or add push commands in the project's `Fastfile`. Most importantly, we can no longer immediately trigger beta/final builds after creating a new commit because the changes will not be in remote yet. If you want to keep the existing behavior, you'll need to add a push command before these triggers.
+
+For example, in [WordPress-Android's `new_beta_release` lane](https://github.com/wordpress-mobile/WordPress-Android/blob/0c64cb84c256e004473e97d72b4ac6682ebc140b/fastlane/lanes/release.rb#L86), we download translations, bump the beta version and then trigger a new build in CI. After migrating to `8.0.0` of `release-toolkit`, we'll need to add [`push_to_git_remote`](https://docs.fastlane.tools/actions/push_to_git_remote/) command before this trigger to keep the existing behavior.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
@@ -26,7 +26,7 @@ module Fastlane
           Action.sh('./gradlew', params[:lint_task])
         end
 
-        Fastlane::Helper::GitHelper.commit(message: 'Update translations', files: res_dir, push: true) unless params[:skip_commit]
+        Fastlane::Helper::GitHelper.commit(message: 'Update translations', files: res_dir) unless params[:skip_commit]
       end
 
       #####################################################
@@ -38,7 +38,7 @@ module Fastlane
       end
 
       def self.details
-        'Download translations from GlotPress, update local strings.xml files accordingly, lint, commit the changes, and push to the remote'
+        'Download translations from GlotPress, update local strings.xml files accordingly, lint, commit the changes'
       end
 
       def self.available_options
@@ -90,7 +90,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :skip_commit,
             env_name: 'FL_DOWNLOAD_TRANSLATIONS_SKIP_COMMIT',
-            description: 'If set to true, will skip the commit/push step. Otherwise, it will commit the changes and push them (the default)',
+            description: 'If set to true, will skip the commit step',
             type: Boolean,
             default_value: false
           ),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -12,7 +12,7 @@ module Fastlane
         next_version = Fastlane::Helper::Android::VersionHelper.calc_next_release_short_version(params[:new_version])
 
         Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
-        Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path, push: true)
+        Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path)
 
         UI.message 'Done.'
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -18,7 +18,6 @@ module Fastlane
         repo_clean = repo_status.empty?
         unless repo_clean
           Action.sh('git commit -m "Update metadata strings"')
-          Action.sh('git push')
         end
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -12,7 +12,7 @@ module Fastlane
         next_version = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(params[:new_version])
 
         Fastlane::Helper::ReleaseNotesHelper.add_new_section(path: path, section_title: next_version)
-        Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path, push: true)
+        Fastlane::Helper::GitHelper.commit(message: "Release Notes: add new section for next version (#{next_version})", files: path)
 
         UI.message 'Done.'
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -4,9 +4,10 @@ module Fastlane
       # Helper methods to execute git-related operations that are specific to Android projects
       #
       module GitHelper
-        # Commit and push the files that are modified when we bump version numbers on an iOS project
+        # Commit the files that are modified when we bump version numbers on an Android project
         #
-        # This typically commits and pushes the `build.gradle` file inside the project subfolder.
+        # This typically commits the `version.properties` inside root folder or `build.gradle` file
+        # inside the project subfolder.
         #
         # @env PROJECT_ROOT_FOLDER The path to the git root of the project
         # @env PROJECT_NAME The name of the directory containing the project code (especially containing the `build.gradle` file)
@@ -16,14 +17,12 @@ module Fastlane
           if File.exist?(Fastlane::Helper::Android::VersionHelper.version_properties_file)
             Fastlane::Helper::GitHelper.commit(
               message: 'Bump version number',
-              files: File.join(ENV['PROJECT_ROOT_FOLDER'], 'version.properties'),
-              push: true
+              files: File.join(ENV['PROJECT_ROOT_FOLDER'], 'version.properties')
             )
           else
             Fastlane::Helper::GitHelper.commit(
               message: 'Bump version number',
-              files: File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], 'build.gradle'),
-              push: true
+              files: File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], 'build.gradle')
             )
           end
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -95,17 +95,15 @@ module Fastlane
       end
 
       # `git add` the specified files (if any provided) then commit them using the provided message.
-      # Optionally, push the commit to the remote too.
       #
       # @param [String] message The commit message to use
       # @param [String|Array<String>] files A file or array of files to git-add before creating the commit.
       #        Use `nil` or `[]` if you already added the files in a separate step and don't wan't this method to add any new file before commit.
       #        Also accepts the special symbol `:all` to add all the files (`git commit -a -m …`).
-      # @param [Bool] push If true, will `git push` to `origin` after the commit has been created. Defaults to `false`.
       #
-      # @return [Bool] True if commit and push were successful, false if there was an issue during commit & push (most likely being "nothing to commit").
+      # @return [Bool] True if commit was successful, false if there was an issue (most likely being "nothing to commit").
       #
-      def self.commit(message:, files: nil, push: false)
+      def self.commit(message:, files: nil)
         files = [files] if files.is_a?(String)
         args = []
         if files == :all
@@ -115,7 +113,6 @@ module Fastlane
         end
         begin
           Action.sh('git', 'commit', *args, '-m', message)
-          Action.sh('git', 'push', 'origin', 'HEAD') if push
           return true
         rescue
           return false

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -73,16 +73,15 @@ module Fastlane
         Action.sh('git', 'submodule', 'update', '--init', '--recursive')
       end
 
-      # Create a new branch named `branch_name`, cutting it from branch/commit/tag `from`, and push it
+      # Create a new branch named `branch_name`, cutting it from branch/commit/tag `from`
       #
       # If the branch with that name already exists, it will instead switch to it and pull new commits.
       #
       # @param [String] branch_name The full name of the new branch to create, e.g "release/1.2"
       # @param [String?] from The branch or tag from which to cut the branch from.
       #        If `nil`, will cut the new branch from the current commit. Otherwise, will checkout that commit/branch/tag before cutting the branch.
-      # @param [Bool] push If true, will also push the branch to `origin`, tracking the upstream branch with the local one.
       #
-      def self.create_branch(branch_name, from: nil, push: true)
+      def self.create_branch(branch_name, from: nil)
         if branch_exists?(branch_name)
           UI.message("Branch #{branch_name} already exists. Skipping creation.")
           Action.sh('git', 'checkout', branch_name)
@@ -90,7 +89,6 @@ module Fastlane
         else
           Action.sh('git', 'checkout', from) unless from.nil?
           Action.sh('git', 'checkout', '-b', branch_name)
-          Action.sh('git', 'push', '-u', 'origin', branch_name) if push
         end
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_git_helper.rb
@@ -4,9 +4,9 @@ module Fastlane
       # Helper methods to execute git-related operations that are specific to iOS projects
       #
       module GitHelper
-        # Commit and push the files that are modified when we bump version numbers on an iOS project
+        # Commit the files that are modified when we bump version numbers on an iOS project
         #
-        # This typically commits and pushes:
+        # This typically commits:
         #  - The files in `./config/*` – especially `Version.*.xcconfig` files
         #  - The `fastlane/Deliverfile` file (which contains the `app_version` line)
         #  - The `<ProjectRoot>/<ProjectName>/Resources/AppStoreStrings.pot` file, containing a key for that version's release notes
@@ -25,10 +25,10 @@ module Fastlane
             files_list.append File.join(ENV['PROJECT_ROOT_FOLDER'], ENV['PROJECT_NAME'], 'Resources', ENV['APP_STORE_STRINGS_FILE_NAME'])
           end
 
-          Fastlane::Helper::GitHelper.commit(message: 'Bump version number', files: files_list, push: true)
+          Fastlane::Helper::GitHelper.commit(message: 'Bump version number', files: files_list)
         end
 
-        # Calls the `Scripts/localize.py` script in the project root folder and push the `*.strings` files
+        # Calls the `Scripts/localize.py` script in the project root folder and commit the `*.strings` files
         #
         # That script updates the `.strings` files with translations from GlotPress.
         #
@@ -42,7 +42,7 @@ module Fastlane
         def self.localize_project
           Action.sh("cd #{get_from_env!(key: 'PROJECT_ROOT_FOLDER')} && ./Scripts/localize.py")
 
-          Fastlane::Helper::GitHelper.commit(message: 'Update strings for localization', files: strings_files, push: true) || UI.message('No new strings, skipping commit')
+          Fastlane::Helper::GitHelper.commit(message: 'Update strings for localization', files: strings_files) || UI.message('No new strings, skipping commit')
         end
 
         # Call the `Scripts/update-translations.rb` then the `fastlane/download_metadata` Scripts from the host project folder
@@ -56,11 +56,11 @@ module Fastlane
         def self.update_metadata
           Action.sh("cd #{get_from_env!(key: 'PROJECT_ROOT_FOLDER')} && ./Scripts/update-translations.rb")
 
-          Fastlane::Helper::GitHelper.commit(message: 'Update translations', files: strings_files, push: false)
+          Fastlane::Helper::GitHelper.commit(message: 'Update translations', files: strings_files)
 
           Action.sh('cd fastlane && ./download_metadata.swift')
 
-          Fastlane::Helper::GitHelper.commit(message: 'Update metadata translations', files: './fastlane/metadata/', push: true)
+          Fastlane::Helper::GitHelper.commit(message: 'Update metadata translations', files: './fastlane/metadata/')
         end
 
         def self.strings_files

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -66,7 +66,7 @@ describe Fastlane::Helper::GitHelper do
     expect(Fastlane::Helper::GitHelper.has_git_lfs?).to be false
   end
 
-  context('commit(message:, files:, push:)') do
+  context('commit(message:, files:)') do
     before(:each) do
       allow_fastlane_action_sh()
       @message = 'Some commit message with spaces'
@@ -107,18 +107,6 @@ describe Fastlane::Helper::GitHelper do
     it 'adds all pending file changes before commit if :all is provided as `files`' do
       expect_shell_command('git', 'commit', '-a', '-m', @message)
       Fastlane::Helper::GitHelper.commit(message: @message, files: :all)
-    end
-
-    it 'does not push to origin if not asked' do
-      expect_shell_command('git', 'commit', '-m', @message)
-      expect_shell_command('git', 'push', any_args).never
-      Fastlane::Helper::GitHelper.commit(message: @message)
-    end
-
-    it 'does push to origin if asked' do
-      expect_shell_command('git', 'commit', '-m', @message)
-      expect_shell_command('git', 'push', 'origin', 'HEAD').once
-      Fastlane::Helper::GitHelper.commit(message: @message, push: true)
     end
   end
 


### PR DESCRIPTION
Closes #308.

## What does it do?

This PR removes the `git push` commands after creating a new commit or a branch. The goal for this change is to leave the decision for pushing the changes to remote to the developer or the project configuration.

For projects where a developer manages the release in their local environment, this gives them the flexibility to check the diff before pushing. It also removes the inconsistency where some actions were pushing the changes to remote and others weren't. A minor drawback that needs to be taken into account is that we can't trigger a beta/final build in CI before we push the change. So, we'd potentially need to add a push command to the project's `Fastfile` before these triggers.

For projects where the release is managed in CI, this allows us to decide the best time to push the changes to remote which in most cases should be after we are done with all the necessary changes. If we only push the changes when everything is successful, there will be less changes to revert if something goes wrong. Note that there might still be changes that needs to be reverted, such as closing a milestone, because these actions are not related to git commits. However, with release management in CI, we'll likely not need to worry about these either.

---

The code changes in this PR are very straightforward. I removed all the `push` commands, the arguments them and any mention of it in the documentation. Since this is a breaking change which requires extra steps, I've also added a new `MIGRATION.md` file which has steps to migrate `release-toolkit` from `7.0.0` to `8.0.0`.

---

Note that the only remaining push command is in `create_tag`. I don't know if this action makes much sense without pushing to remote, because we don't really care about local tags. On the bright side, I don't think the actions that use this helper is being used at the moment. #471 proposes the deprecation of `ios_final_tag` & `ios_clear_intermediate_tags` actions and I intend to follow that up with another PR that proposes the deprecation of `android_tag_build`. This is because we no longer tag our builds and instead create a draft GitHub release which upon publishing will create the tag for us. So, we'll likely end up removing the `create_tag` helper as well.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.