### PR TITLE
Adds the option to auto-retry for downloading metadata from GlotPress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Adds auto_retry option to `gp_downloadmetadata_action`. [#474]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -10,12 +10,13 @@ module Fastlane
         UI.message "Locales: #{params[:locales].inspect}"
         UI.message "Source locale: #{params[:source_locale].nil? ? '-' : params[:source_locale]}"
         UI.message "Path: #{params[:download_path]}"
+        UI.message "Auto-retry: #{params[:auto_retry]}"
 
         # Check download path
         FileUtils.mkdir_p(params[:download_path])
 
         # Download
-        downloader = Fastlane::Helper::MetadataDownloader.new(params[:download_path], params[:target_files])
+        downloader = Fastlane::Helper::MetadataDownloader.new(params[:download_path], params[:target_files], params[:auto_retry])
 
         params[:locales].each do |loc|
           if loc.is_a?(Array)
@@ -68,6 +69,12 @@ module Fastlane
                                        env_name: 'FL_DOWNLOAD_METADATA_DOWNLOAD_PATH',
                                        description: 'The path of the target files',
                                        type: String),
+          FastlaneCore::ConfigItem.new(key: :auto_retry,
+                                       env_name: 'FL_DOWNLOAD_METADATA_AUTO_RETRY',
+                                       description: 'Whether to auto retry downloads after Too Many Requests error',
+                                       type: FastlaneCore::Boolean,
+                                       optional: true,
+                                       default_value: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -74,7 +74,7 @@ module Fastlane
                                        description: 'Whether to auto retry downloads after Too Many Requests error',
                                        type: FastlaneCore::Boolean,
                                        optional: true,
-                                       default_value: false),
+                                       default_value: true),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -5,6 +5,7 @@ module Fastlane
   module Helper
     class MetadataDownloader
       AUTO_RETRY_SLEEP_TIME = 20
+      MAX_AUTO_RETRY_ATTEMPTS = 30
 
       attr_reader :target_folder, :target_files
 
@@ -13,6 +14,7 @@ module Fastlane
         @target_files = target_files
         @auto_retry = auto_retry
         @alternates = {}
+        @auto_retry_attempt_counter = 0
       end
 
       # Downloads data from GlotPress, in JSON format
@@ -116,9 +118,10 @@ module Fastlane
           download(locale, response.header['location'], is_source)
         when '429'
           # We got rate-limited, auto_retry or offer to try again with a prompt
-          if @auto_retry
+          if @auto_retry && @auto_retry_attempt_counter <= MAX_AUTO_RETRY_ATTEMPTS
             UI.message("Received 429 for `#{locale}`. Auto retrying in #{AUTO_RETRY_SLEEP_TIME} seconds...")
             sleep(AUTO_RETRY_SLEEP_TIME)
+            @auto_retry_attempt_counter += 1
             download(locale, response.uri, is_source)
           elsif UI.confirm("Retry downloading `#{locale}` after receiving 429 from the API?")
             download(locale, response.uri, is_source)


### PR DESCRIPTION
## What does it do?

This PR adds `auto_retry` option to `gp_downloadmetadataAction`. This is an important feature for release management in CI because we can't interact with the process.

The implementation is pretty basic. If we get `429: Too Many Requests` error, we wait for `20` seconds and we try again. If we auto retry `30` times, we'll stop auto retrying, but the manual retry will still work. When I manually retry, I typically do it in a few seconds, but in CI we have the luxury of waiting, so I randomly selected `20` seconds. For the max retries, I thought `10` minutes of total retrying would be a reasonable one. However, I am happy to change these numbers if you have any feedback.

@mokagio You might especially be interested in this PR as WPiOS release manager.

**To Test**

I found testing these changes to be a bit tricky because we don't know whether we'll get `429` from the server or not. So, I prepared a test branch `test/auto-retry-gp_downloadmetadata` which switches the `200` and `429` status codes, so we can reproduce the scenario easily. I also changed the `MAX_AUTO_RETRY_ATTEMPTS` to `3`, so we can easily test that as well.

* Checkout the `test/auto-retry-gp_downloadmetadata` **WordPress-Android** branch. This branch is already [setup to use the correct branch for testing this PR](https://github.com/wordpress-mobile/WordPress-Android/commit/c6c3f86bcb6fbb08e7a152e66174f0fae2c00184) and has [`auto_retry` enabled](https://github.com/wordpress-mobile/WordPress-Android/commit/38fb8d3c4457a9a1a98577e9a96d6b6b8d8885d2).
* Run `bundle exec fastlane download_metadata_strings`
* Verify the log `Received 429 for `ar`. Auto retrying in 20 seconds...` 4 times. First is the original attempt, and then 3 auto retry attempts (It's very unlikely but you might get a different locale than `ar`)
* Verify the log `Retry downloading `ar` after receiving 429 from the API? (y/n)`
* Abort the process - You can type `n` and then quickly do `ctrl+c`. Otherwise you might get stuck in a loop 😅 

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.