### PR TITLE
Remove line that requires MFA for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Remove `rubygems_mfa_required` from the `gemspec`. [#475]
 
 ## 7.1.0
 

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -60,5 +60,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-require_tools', '~> 0.1.2'
   spec.add_development_dependency 'rubocop-rspec', '2.3.0'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
-  spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
## What does it do?

This PR removes the line that was accidentally added in https://github.com/wordpress-mobile/release-toolkit/pull/464/commits/a5e7cecc498359fdffa2cee952291c8e4b6ec1f3#diff-6e255cbfaf7dd800d9a43902bba94e09f67b5cf711db37e3231e987a6d857f17R63 which required MFA for publishing new versions of the Release Toolkit. See p1683817235590059-slack-C02KLTL3MKM for the discussion. 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [X] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.