### PR TITLE
Revert ConfigItem type to `is_string: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Revert the `gp_downloadmetadata_action` `locales` item type from `type: Hash` to `is_string: false`. [#478]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -59,7 +59,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :locales,
                                        env_name: 'FL_DOWNLOAD_METADATA_LOCALES',
                                        description: 'The hash with the GlotPress locale and the project locale association',
-                                       type: Hash),
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :source_locale,
                                        env_name: 'FL_DOWNLOAD_METADATA_SOURCE_LOCALE',
                                        description: 'The source locale code',


### PR DESCRIPTION
## What does it do?

This PR reverts `gp_downloadmetadata_action` `locales` item type from `type: Hash` to `is_string: false`. This isn't the correct type and was breaking metadata downloads. See https://github.com/wordpress-mobile/release-toolkit/pull/469/files#r1191989936 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.