### PR TITLE
Release 8.0.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Revert the `gp_downloadmetadata_action` `locales` item type from `type: Hash` to `is_string: false`. [#480]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Revert the `gp_downloadmetadata_action` `locales` item type from `type: Hash` to `is_string: false`. [#480]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 7.1.2
+
+### Bug Fixes
+
+- Revert the `gp_downloadmetadata_action` `locales` item type from `type: Hash` to `is_string: false`. [#480]
 
 ## 7.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Revert the `gp_downloadmetadata_action` `locales` item type from `type: Hash` to `is_string: false`. [#478]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 8.0.1
+
+### Bug Fixes
+
+- Revert the `gp_downloadmetadata_action` `locales` item type from `type: Hash` to `is_string: false`. [#478]
 
 ## 8.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (7.1.1)
+    fastlane-plugin-wpmreleasetoolkit (7.1.2)
       activesupport (>= 6.1.7.1)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (8.0.0)
+    fastlane-plugin-wpmreleasetoolkit (8.0.1)
       activesupport (>= 6.1.7.1)
       bigdecimal (~> 1.4)
       buildkit (~> 1.5)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -59,7 +59,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :locales,
                                        env_name: 'FL_DOWNLOAD_METADATA_LOCALES',
                                        description: 'The hash with the GlotPress locale and the project locale association',
-                                       type: Hash),
+                                       is_string: false),
           FastlaneCore::ConfigItem.new(key: :source_locale,
                                        env_name: 'FL_DOWNLOAD_METADATA_SOURCE_LOCALE',
                                        description: 'The source locale code',

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '7.1.1'
+    VERSION = '7.1.2'
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '8.0.0'
+    VERSION = '8.0.1'
   end
 end


### PR DESCRIPTION
New version 8.0.1. Be sure to create a GitHub Release and tag once this PR gets merged.