### PR TITLE
Make success message in `buildkite_trigger_build` print in green

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -28,7 +28,7 @@ module Fastlane
         )
 
         if response.state == 'scheduled'
-          UI.message("Successfully scheduled new build. You can see it at '#{response.web_url}'")
+          UI.success("Successfully scheduled new build. You can see it at '#{response.web_url}'")
         else
           UI.crash!("Failed to start job\nError: [#{response}]")
         end


### PR DESCRIPTION
Trivial change that makes the scheduled Buildkite build URL more visible.

Before that change, the message was printed in white:

<img width="887" alt="image" src="https://github.com/wordpress-mobile/release-toolkit/assets/216089/961ae1df-34d7-47fc-99c4-ad36f2ba3758">

While, for comparison, the similar message from the `create_pull_request` action is printed in green, which makes it more visible:

<img width="952" alt="image" src="https://github.com/wordpress-mobile/release-toolkit/assets/216089/4b5a7c46-1ad7-448f-9773-29c1588ce7c2">

This PR now makes `buildkite_trigger_build` print success URL in green too, just like `create_pull_request` does.