### PR TITLE
Add reference to the MIGRATION.md file to the PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,5 @@
 - [ ] Run `bundle exec rubocop` to test for code style violations and recommendations
 - [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
 - [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
-- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.
+- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
+- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.


### PR DESCRIPTION
## What does it do?

1. Fixes a small typo on the Github PR template: _describe your changes under the **approprioate**_
2. Adds a Checklist item to remind folks to consider the implications of their changes when migrating from a previous major version.

## Related PRs
- This PR is based on the initial `MIGRATION.md` discussions that started on https://github.com/wordpress-mobile/release-toolkit/pull/452

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.