### PR TITLE
Update dependencies: `octokit`, `buildkite-test_collector` and `danger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Updates `octokit` to `6.1.1`, `danger` to `9.3.1` and `buildkite-test_collector` to `2.3.1`. [#491]
 
 ## 8.1.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'codecov', require: false
 gem 'webmock', require: false
 gem 'yard'
 
-gem 'buildkite-test_collector', '~> 2.2'
+gem 'buildkite-test_collector', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       git (~> 1.3)
       google-cloud-storage (~> 1.31)
       nokogiri (~> 1.11)
-      octokit (~> 5.6)
+      octokit (~> 6.1)
       parallel (~> 1.14)
       plist (~> 3.1)
       progress_bar (~> 1.3)
@@ -55,7 +55,7 @@ GEM
     bigdecimal (1.4.4)
     buildkit (1.5.0)
       sawyer (>= 0.6)
-    buildkite-test_collector (2.2.0)
+    buildkite-test_collector (2.3.1)
       activesupport (>= 4.2)
     chroma (0.2.0)
     claide (1.1.0)
@@ -112,18 +112,18 @@ GEM
       colored2 (~> 3.1)
     crack (0.4.5)
       rexml
-    danger (9.3.0)
+    danger (9.3.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
       faraday (>= 0.9.0, < 3.0)
       faraday-http-cache (~> 2.0)
-      git (~> 1.13.0)
+      git (~> 1.13)
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
-      octokit (~> 5.0)
+      octokit (~> 6.0)
       terminal-table (>= 1, < 4)
     danger-rubocop (0.10.0)
       danger
@@ -160,7 +160,7 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
-    faraday-http-cache (2.4.1)
+    faraday-http-cache (2.5.0)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
@@ -288,7 +288,7 @@ GEM
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    octokit (5.6.1)
+    octokit (6.1.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
@@ -413,7 +413,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  buildkite-test_collector (~> 2.2)
+  buildkite-test_collector (~> 2.3)
   bundler (~> 2.0)
   cocoapods (~> 1.10)
   codecov

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'diffy', '~> 3.3'
   spec.add_dependency 'git', '~> 1.3'
   spec.add_dependency 'nokogiri', '~> 1.11' # Needed for AndroidLocalizeHelper
-  spec.add_dependency 'octokit', '~> 5.6'
+  spec.add_dependency 'octokit', '~> 6.1'
   spec.add_dependency 'parallel', '~> 1.14'
   spec.add_dependency 'plist', '~> 3.1'
   spec.add_dependency 'progress_bar', '~> 1.3'


### PR DESCRIPTION
## What does it do?

This PR updates the `octokit`, `buildkite-test_collector` and `danger` gems. Danger's recent 9.3.1 release allows for `octokit` to be updated past version 5. 

`octokit` 6.0 is a breaking change, but as the [release notes mention](https://github.com/octokit/octokit.rb/releases/tag/v6.0.0), they removed APIs that haven't been used for a while. I verified that the Release Toolkit isn't using those APIs anywhere.

The Buildkite checks for this PR show up in Test Analytics, so that verifies that the Test Collector update is working correctly.   

These aren't breaking changes for the Release Toolkit as there aren't any API changes. 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [X] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the approprioate existing `###` subsection of the existing `## Trunk` section.