### PR TITLE
Support Ruby 3.2.2

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   env: &xcode_image
-    IMAGE_ID: xcode-14.1
+    IMAGE_ID: xcode-14.3.1
   plugins:
   - &docker_plugin
     docker#v3.8.0:
@@ -21,27 +21,39 @@ steps:
   #################
   # Build and Test
   #################
-  - label: "🧪 Build and Test"
+  - group: 🧪 Build and Test"
     key: test
-    command: |
-      # We only need this for tasks running on a Mac
-      brew install pkg-config git-lfs libxml2 imagemagick@6
+    steps:
+      - label: "🧪 Build and Test using Ruby {{ matrix.ruby }}"
+        command: |
+          echo "--- :ruby: Using ruby {{ matrix.ruby }}"
+          export RBENV_VERSION={{ matrix.ruby }}
+          ruby --version
 
-      echo "--- :git: Setting up git-lfs"
-      git-lfs install
+          echo "--- :package: Installing homebrew packages"
+          # We only need this for tasks running on a Mac
+          brew install pkg-config git-lfs libxml2 imagemagick@6
 
-      echo "--- :rubygems: Setting up Gems"
-      # https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler
-      install_gems
+          echo "--- :git: Setting up git-lfs"
+          git-lfs install
 
-      echo "--- :rspec: Run Rspec"
-      bundle exec rspec --profile 10 --format progress
-    env: *xcode_image
-    plugins:
-      - automattic/a8c-ci-toolkit#2.15.0
-    agents:
-      queue: "mac"
+          echo "--- :rubygems: Setting up Gems"
+          # https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
+          gem install bundler
+          install_gems
+
+          echo "--- :rspec: Run Rspec"
+          bundle exec rspec --profile 10 --format progress
+        env: *xcode_image
+        plugins:
+          - automattic/a8c-ci-toolkit#2.15.0
+        agents:
+          queue: "mac"
+        matrix:
+          setup:
+            ruby:
+              - 2.7.4
+              - 3.2.2
 
   #################
   # Lint
@@ -79,7 +91,7 @@ steps:
      - test
      - rubocop
      - danger
-    # Note: We intentionally call a separate `.sh` script here (as opposed to having all the 
+    # Note: We intentionally call a separate `.sh` script here (as opposed to having all the
     # commands written inline) to avoid leaking a key used in the process in clear in the
     # BUILDKITE_COMMAND environment variable.
     command: .buildkite/gem-push.sh

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ require:
 # Enable new cops when we update rubocop to a newer version
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.7
 
 ########## Lint / CodeStyle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
 - The `create_release` action now prints and returns the URL of the created GitHub Release. [#503]
 - Removes two dependencies bigdecimal and activesupport. [#504]
+- Supports Ruby 3. [#492, #493, #497, and #504]
 
 ### Bug Fixes
 


### PR DESCRIPTION
## What does it do?

Ruby 3.2.2 support has been addressed in previous PRs (#493, #497, and #504). This PR updates the CI checks to ensure this library continues to be compatible with Ruby 3.2.2.

The "required ruby version" settings in the gemspec file stays unchanged—the library should stay compatible with 2.7.4.

I have updated the "Build and Test" CI step to run with both Ruby 3.2.2 and 2.7.4. Since there are no ruby source code changes in this PR, tests using Ruby 2.7.4 all passed as expected. However, there are some test failures when using Ruby 3.2.2. I'll look into those later.

I have also configured the rubocop to use 2.7 as the oldest Ruby version, so that it won't report issues like "please use this new Ruby syntax and API".

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
