### PR TITLE
Add `if_exists` config to `upload_to_s3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -134,6 +134,9 @@ module Fastlane
             key: :skip_if_exists,
             description: 'If the file already exists in the S3 bucket, skip the upload (and report it in the logs), instead of failing with `user_error!`',
             deprecated: 'Use if_exists instead',
+            verify_block: proc do
+              UI.important('The :skip_if_exists option is deprecated. Please use :if_exists instead.')
+            end,
             conflicting_options: [:if_exists],
             conflict_block: file_exists_conflicting_options_handler,
             optional: true,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -32,7 +32,7 @@ module Fastlane
                                  end
           end
 
-          case params[:if_exists].to_sym
+          case params[:if_exists]
           when :fail
             UI.user_error!(message)
           when :replace
@@ -133,13 +133,12 @@ module Fastlane
             key: :if_exists,
             description: 'What do to if the file file already exists in the S3 bucket. Possible values :skip, :replace, :fail. When set, overrides the deprecated skip_if_exists option',
             optional: true,
-            is_string: false,
+            type: Symbol,
             default_value: nil, # Using nil under the hood until we remove skip_if_exists
             verify_block: proc do |value|
               next if value.nil?
 
-              UI.user_error!("`if_exist` must be a symbol or convertible to a symbol, got #{value}") unless value.respond_to?(:to_sym)
-              UI.user_error!('`if_exist` must be one of :skip, :replace, :fail') unless %i[skip replace fail].include?(value.to_sym)
+              UI.user_error!('`if_exist` must be one of :skip, :replace, :fail') unless %i[skip replace fail].include?(value)
             end
           ),
         ]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -132,7 +132,7 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :skip_if_exists,
-            description: '[DEPRECATED: Use if_exists instead]. If the file already exists in the S3 bucket, skip the upload (and report it in the logs), instead of failing with `user_error!`. When if_exists is set, this option is ignored',
+            description: 'If the file already exists in the S3 bucket, skip the upload (and report it in the logs), instead of failing with `user_error!`',
             deprecated: 'Use if_exists instead',
             conflicting_options: [:if_exists],
             conflict_block: file_exists_conflicting_options_handler,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -125,6 +125,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :skip_if_exists,
             description: '[DEPRECATED: Use if_exists instead]. If the file already exists in the S3 bucket, skip the upload (and report it in the logs), instead of failing with `user_error!`. When if_exists is set, this option is ignored',
+            deprecated: 'Use if_exists instead',
             optional: true,
             default_value: false,
             type: Boolean

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -134,9 +134,6 @@ module Fastlane
             key: :skip_if_exists,
             description: 'If the file already exists in the S3 bucket, skip the upload (and report it in the logs), instead of failing with `user_error!`',
             deprecated: 'Use if_exists instead',
-            verify_block: proc do
-              UI.important('The :skip_if_exists option is deprecated. Please use :if_exists instead.')
-            end,
             conflicting_options: [:if_exists],
             conflict_block: file_exists_conflicting_options_handler,
             optional: true,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -23,14 +23,13 @@ module Fastlane
         if file_is_already_uploaded?(bucket, key)
           message = "File already exists in S3 bucket #{bucket} at #{key}"
 
-          # skip_if_exists is deprecated but to keep backward compatibility we still support it by reading it only if if_exists is not set.
+          # skip_if_exists is deprecated but we want to keep backward compatibility.
           if params[:if_exists].nil?
-            if params[:skip_if_exists]
-              UI.important("#{message}. Skipping upload.")
-              return key
-            else
-              UI.user_error!(message)
-            end
+            params[:if_exists] = if params[:skip_if_exists].nil? || params[:skip_if_exists] == false
+                                   :fail
+                                 else
+                                   :skip
+                                 end
           end
 
           case params[:if_exists].to_sym

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -190,7 +190,12 @@ describe Fastlane::Actions::UploadToS3Action do
             file: file_path,
             skip_if_exists: true
           )
-          expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
+          expect(warnings).to eq(
+            [
+              'The :skip_if_exists option is deprecated. Please use :if_exists instead.',
+              "File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload.",
+            ]
+          )
           expect(key).to eq(expected_key)
         end
       end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -169,7 +169,8 @@ describe Fastlane::Actions::UploadToS3Action do
             run_described_fastlane_action(
               bucket: test_bucket,
               key: 'existing-key-2',
-              file: file_path
+              file: file_path,
+              skip_if_exists: false
             )
           end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
         end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -227,7 +227,9 @@ describe Fastlane::Actions::UploadToS3Action do
             if_exists: :skip,
             skip_if_exists: false # using false which would make the action fails if if_exists did not take precedence
           )
-          expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
+
+          # There will also be warnings regarding the conflicting if_exists and skip_if_exists options, but we are not interested in them here.
+          expect(warnings).to include("File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload.")
           expect(key).to eq(expected_key)
         end
       end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -255,22 +255,6 @@ describe Fastlane::Actions::UploadToS3Action do
         end
       end
 
-      it 'accepts if_exists as a String argument' do
-        expected_key = 'a90dff8ba6472d733cb0a37734fe28a8078f8444/key-2'
-        stub_s3_response_for_file(expected_key)
-
-        with_tmp_file(named: 'key-2') do |file_path|
-          expect do
-            run_described_fastlane_action(
-              bucket: test_bucket,
-              key: 'key-2',
-              file: file_path,
-              if_exists: 'fail'
-            )
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
-        end
-      end
-
       it 'throws when if_exists is not one of the expected values' do
         with_tmp_file(named: 'key') do |file_path|
           expect do
@@ -281,19 +265,6 @@ describe Fastlane::Actions::UploadToS3Action do
               if_exists: :invalid
             )
           end.to raise_error(FastlaneCore::Interface::FastlaneError, '`if_exist` must be one of :skip, :replace, :fail')
-        end
-      end
-
-      it 'throws when if_exists is neither a Symbol nor a String' do
-        with_tmp_file(named: 'key') do |file_path|
-          expect do
-            run_described_fastlane_action(
-              bucket: test_bucket,
-              key: 'a8c-key1',
-              file: file_path,
-              if_exists: 123
-            )
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, '`if_exist` must be a symbol or convertible to a symbol, got 123')
         end
       end
     end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -190,12 +190,7 @@ describe Fastlane::Actions::UploadToS3Action do
             file: file_path,
             skip_if_exists: true
           )
-          expect(warnings).to eq(
-            [
-              'The :skip_if_exists option is deprecated. Please use :if_exists instead.',
-              "File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload.",
-            ]
-          )
+          expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
           expect(key).to eq(expected_key)
         end
       end


### PR DESCRIPTION
## What does it do?

The idea for this comes from @crazytonyli's suggestion [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/5856#discussion_r1230390566).

This supersedes `skip_if_exists`, but to maintain backward compatibility, the code ended up a bit convoluted. If the idea of a breaking change sounds worth it, I opened #496.

`it_exists` can assume three possible values, `:fail`, `:skip`, and `:replace`.

_Note:_ I haven't tried `:replace` IRL. I _assume_ it'll just work, but I could be wrong. I'll try it tomorrow by branching off https://github.com/wordpress-mobile/gutenberg-mobile/pull/5856 and pointing to this branch.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
