### PR TITLE
Removes `skip_if_exists` parameter from` upload_to_s3` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 ### Breaking Changes
 
-_None_
+- Replace `skip_if_exists` parameter in `upload_to_s3` action with `if_exists`. Possible values `:skip`, `:fail`, and `:replace`. [#495, #496]
 
 ### New Features
 
-- Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
+_None_
 
 ### Bug Fixes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,10 @@
 # Migration Instructions for Major Releases
 
-### From `7.0.0` to `8.0.0`
+### From `8.x` to `9.0.0`
+
+In `upload_to_s3` calls, replace `skip_if_exists: true` with `if_exists: :skip` and `skip_if_exists: false` with `if_exists: :fail`. I `skip_if_exists` is not specified, no change is necessary.
+
+### From `7.x` to `8.0.0`
 
 We are no longer pushing to remote after creating a new commit or a branch. That means, developers need to manually push the changes or add push commands in the project's `Fastfile`. Most importantly, we can no longer immediately trigger beta/final builds after creating a new commit because the changes will not be in remote yet. If you want to keep the existing behavior, you'll need to add a push command before these triggers.
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -23,16 +23,6 @@ module Fastlane
         if file_is_already_uploaded?(bucket, key)
           message = "File already exists in S3 bucket #{bucket} at #{key}"
 
-          # skip_if_exists is deprecated but to keep backward compatibility we still support it by reading it only if if_exists is not set.
-          if params[:if_exists].nil?
-            if params[:skip_if_exists]
-              UI.important("#{message}. Skipping upload.")
-              return key
-            else
-              UI.user_error!(message)
-            end
-          end
-
           case params[:if_exists].to_sym
           when :fail
             UI.user_error!(message)
@@ -124,18 +114,11 @@ module Fastlane
             type: Boolean
           ),
           FastlaneCore::ConfigItem.new(
-            key: :skip_if_exists,
-            description: '[DEPRECATED: Use if_exists instead]. If the file already exists in the S3 bucket, skip the upload (and report it in the logs), instead of failing with `user_error!`. When if_exists is set, this option is ignored',
-            optional: true,
-            default_value: false,
-            type: Boolean
-          ),
-          FastlaneCore::ConfigItem.new(
             key: :if_exists,
             description: 'What do to if the file file already exists in the S3 bucket. Possible values :skip, :replace, :fail. When set, overrides the deprecated skip_if_exists option',
             optional: true,
             is_string: false,
-            default_value: nil, # Using nil under the hood until we remove skip_if_exists
+            default_value: :fail,
             verify_block: proc do |value|
               next if value.nil?
 

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -169,7 +169,8 @@ describe Fastlane::Actions::UploadToS3Action do
             run_described_fastlane_action(
               bucket: test_bucket,
               key: 'existing-key-2',
-              file: file_path
+              file: file_path,
+              skip_if_exists: false
             )
           end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
         end


### PR DESCRIPTION
Update: Closing given the original PR is now doing a better job at handling the deprecated `skip_if_exists` option.

We'll remove it whenever there'll be a stronger need to ship a breaking change.

---

Builds on top of https://github.com/wordpress-mobile/release-toolkit/pull/495. It makes the code simpler but introduces a breaking change.

Thought I'd leave it here in case we want to go down this route.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
