### PR TITLE
Rename a few metadata update helper classes

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -71,17 +71,17 @@ module Fastlane
         @blocks = []
 
         # Inits default handler
-        @blocks.push Fastlane::Helper::UnknownMetadataBlock.new
+        @blocks.push Fastlane::Helper::AnUnknownMetadataBlock.new
 
         # Init special handlers
         block_files.each do |key, file_path|
           case key
           when :release_note
-            @blocks.push Fastlane::Helper::ReleaseNoteMetadataBlock.new(key, file_path, release_version)
+            @blocks.push Fastlane::Helper::AnReleaseNoteMetadataBlock.new(key, file_path, release_version)
           when :release_note_short
-            @blocks.push Fastlane::Helper::ReleaseNoteShortMetadataBlock.new(key, file_path, release_version)
+            @blocks.push Fastlane::Helper::AnReleaseNoteShortMetadataBlock.new(key, file_path, release_version)
           else
-            @blocks.push Fastlane::Helper::StandardMetadataBlock.new(key, file_path)
+            @blocks.push Fastlane::Helper::AnStandardMetadataBlock.new(key, file_path)
           end
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb
@@ -1,7 +1,7 @@
 module Fastlane
   module Helper
     # Basic line handler
-    class MetadataBlock
+    class AnMetadataBlock
       attr_reader :block_key
 
       def initialize(block_key)
@@ -17,7 +17,7 @@ module Fastlane
       end
     end
 
-    class UnknownMetadataBlock < MetadataBlock
+    class AnUnknownMetadataBlock < AnMetadataBlock
       attr_reader :content_file_path
 
       def initialize
@@ -25,7 +25,7 @@ module Fastlane
       end
     end
 
-    class StandardMetadataBlock < MetadataBlock
+    class AnStandardMetadataBlock < AnMetadataBlock
       attr_reader :content_file_path
 
       def initialize(block_key, content_file_path)
@@ -67,7 +67,7 @@ module Fastlane
       end
     end
 
-    class ReleaseNoteMetadataBlock < StandardMetadataBlock
+    class AnReleaseNoteMetadataBlock < AnStandardMetadataBlock
       attr_reader :new_key, :keep_key, :rel_note_key, :release_version
 
       def initialize(block_key, content_file_path, release_version)
@@ -131,7 +131,7 @@ module Fastlane
       end
     end
 
-    class ReleaseNoteShortMetadataBlock < ReleaseNoteMetadataBlock
+    class AnReleaseNoteShortMetadataBlock < AnReleaseNoteMetadataBlock
       def initialize(block_key, content_file_path, release_version)
         super(block_key, content_file_path, release_version)
         @rel_note_key = 'release_note_short'

--- a/spec/an_metadata_update_helper_spec.rb
+++ b/spec/an_metadata_update_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'tmpdir'
 require_relative './spec_helper'
 
-describe Fastlane::Helper::StandardMetadataBlock do
+describe Fastlane::Helper::AnStandardMetadataBlock do
   it 'strips any trailing newline when generating the block for a single-line input' do
     Dir.mktmpdir do |dir|
       input = "Single line message with new line\n"

--- a/spec/an_update_metadata_source_spec.rb
+++ b/spec/an_update_metadata_source_spec.rb
@@ -3,4 +3,47 @@ require 'shared_examples_for_update_metadata_source_action'
 
 describe Fastlane::Actions::AnUpdateMetadataSourceAction do
   include_examples 'update_metadata_source_action', whats_new_fails: true
+
+  it 'combines the given `release_version` and `release_notes` in a new block, keeps the n-1 ones, and deletes the others' do
+    in_tmp_dir do |dir|
+      output_path = File.join(dir, 'output.po')
+      dummy_text = <<~PO
+        msgctxt "release_note_0122"
+        msgid "previous version notes required to have current one added"
+        msgstr ""
+        msgctxt "release_note_0121"
+        msgid "this older release notes block should be removed"
+        msgstr ""
+        msgctxt "release_note_0120"
+        msgid "this older release notes block should be removed"
+        msgstr ""
+      PO
+      File.write(output_path, dummy_text)
+
+      release_notes_path = File.join(dir, 'release_notes.txt')
+      File.write(release_notes_path, "- release notes\n- more release notes")
+
+      run_described_fastlane_action(
+        po_file_path: output_path,
+        release_version: '1.23',
+        source_files: {
+          release_note: release_notes_path
+        }
+      )
+
+      expected = <<~'PO'
+        msgctxt "release_note_0123"
+        msgid ""
+        "1.23:\n"
+        "- release notes\n"
+        "- more release notes\n"
+        msgstr ""
+
+        msgctxt "release_note_0122"
+        msgid "previous version notes required to have current one added"
+        msgstr ""
+      PO
+      expect(File.read(output_path).inspect).to eq(expected.inspect)
+    end
+  end
 end

--- a/spec/shared_examples_for_update_metadata_source_action.rb
+++ b/spec/shared_examples_for_update_metadata_source_action.rb
@@ -117,47 +117,4 @@ RSpec.shared_examples 'update_metadata_source_action' do |options|
       expect(File.read(output_path)).to eq(expected)
     end
   end
-
-  it 'combines the given `release_version` and `release_notes` in a new block, keeps the n-1 ones, and deletes the others' do
-    in_tmp_dir do |dir|
-      output_path = File.join(dir, 'output.po')
-      dummy_text = <<~PO
-        msgctxt "release_note_0122"
-        msgid "previous version notes required to have current one added"
-        msgstr ""
-        msgctxt "release_note_0121"
-        msgid "this older release notes block should be removed"
-        msgstr ""
-        msgctxt "release_note_0120"
-        msgid "this older release notes block should be removed"
-        msgstr ""
-      PO
-      File.write(output_path, dummy_text)
-
-      release_notes_path = File.join(dir, 'release_notes.txt')
-      File.write(release_notes_path, "- release notes\n- more release notes")
-
-      run_described_fastlane_action(
-        po_file_path: output_path,
-        release_version: '1.23',
-        source_files: {
-          release_note: release_notes_path
-        }
-      )
-
-      expected = <<~'PO'
-        msgctxt "release_note_0123"
-        msgid ""
-        "1.23:\n"
-        "- release notes\n"
-        "- more release notes\n"
-        msgstr ""
-
-        msgctxt "release_note_0122"
-        msgid "previous version notes required to have current one added"
-        msgstr ""
-      PO
-      expect(File.read(output_path).inspect).to eq(expected.inspect)
-    end
-  end
 end


### PR DESCRIPTION
## Issue

A few classes (`Fastlane::Helper::MetadataBlock` & co.) with the same names are defined in two source files: [`metadata_update_helper.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb) and [`an_metadata_update_helper.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb). That means when you use those classes, there really isn't any guarantee which implementation you'll get at runtime.

Based on [this `require an_metadata_update_helper.rb` statement](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb#L2), I think we would want to use the classes defined in [`an_metadata_update_helper.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb) in the `an_update_metadata_source` fastlane action. But when running in Ruby 3, the classes (for example `Fastlane::Helper::UnknownMetadataBlock`) used in that action aren't the ones defined in the `an_metadata_update_helper.rb` file.

You can reproduce this issue by inspect the class's source code location. First, make the following code changes locally.

```diff
diff --git a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
index 7f2e7cc8..ae08b860 100644
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -5,6 +5,9 @@ module Fastlane
   module Actions
     class AnUpdateMetadataSourceAction < Action
       def self.run(params)
+        puts "Ruby version: #{RUBY_VERSION}"
+        puts Fastlane::Helper::UnknownMetadataBlock.new.method(:initialize).source_location.join('#')
+        exit 1
         # fastlane will take care of reading in the parameter and fetching the environment variable:
         UI.message "Parameter .po file path: #{params[:po_file_path]}"
         UI.message "Release version: #{params[:release_version]}"
```

Check out _the trunk branch_ and run `bundle exec fastlane run an_update_metadata_source`. You should see a similar output like this:
```
[12:04:24]: ---------------------------------------
[12:04:24]: --- Step: an_update_metadata_source ---
[12:04:24]: ---------------------------------------
Ruby version: 2.7.4
/Users/tonyli/Projects/release-toolkit/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb#23
```

Checkout _branch `use-ruby-3.2.2`_ and run the same command. You should see output like this:
```
[12:05:15]: ---------------------------------------
[12:05:15]: --- Step: an_update_metadata_source ---
[12:05:15]: ---------------------------------------
Ruby version: 3.2.2
/Users/tonyli/Projects/release-toolkit/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_update_helper.rb#23
```

The result is, the code uses the same class, but different implementations get picked up at runtime.

## Solution

There are probably some historical issues underneath that I'm not aware of. And based on [some pending unit tests](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/spec/shared_examples_for_update_metadata_source_action.rb#L81), there probably was a plan to address those issues.

This PR doesn't intend to address all the issues hidden behind the duplicated symbols though. This PR simply wants to fix the duplicated symbols, by adding an `An` prefix to the classes defined in the `an_metadata_update_helper.rb` file.

I have made a major assumption here. That is the `an_update_metadata_source` fastlane action is the only one that uses the classes in `an_metadata_update_helper.rb`, which is why I only changed that one source file. It would be good to get a confirmation whether this assumption is correct.

## Failing unit tests

[One unit test](https://buildkite.com/automattic/release-toolkit/builds/1173#0188c154-4f17-44ab-830e-ffeba377eb58) doesn't agree with my changes. There are two unexpected failures in [`ios_update_metadata_source_spec.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/spec/ios_update_metadata_source_spec.rb) and [`gp_update_metadata_source_spec.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/spec/gp_update_metadata_source_spec.rb) (the failing test case is in the [`shared_examples_for_update_metadata_source_action.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/8.1.0/spec/shared_examples_for_update_metadata_source_action.rb#L45) file.)

I don't think they fail because the changes are incorrect. My assumption is those unit tests were written incorrectly. You can do a similar test as above. First, making the following code changes:

```diff
diff --git a/spec/ios_update_metadata_source_spec.rb b/spec/ios_update_metadata_source_spec.rb
index f4c33b34..ca0a9f50 100644
--- a/spec/ios_update_metadata_source_spec.rb
+++ b/spec/ios_update_metadata_source_spec.rb
@@ -14,5 +14,9 @@ describe Fastlane::Actions::IosUpdateMetadataSourceAction do
     allow(Fastlane::Actions::EnsureGitStatusCleanAction).to receive(:run)
   end
 
+  puts "Ruby version: #{RUBY_VERSION}"
+  puts Fastlane::Helper::UnknownMetadataBlock.new.method(:initialize).source_location.join('#')
+  exit 1
+
   include_examples 'update_metadata_source_action', whats_new_fails: false
 end
```

Checkout _the trunk branch_ and run `bundle exec rspec ./spec/ios_update_metadata_source_spec.rb`. You should see output like this:
```
Ruby version: 2.7.4
/Users/tonyli/Projects/release-toolkit/lib/fastlane/plugin/wpmreleasetoolkit/helper/an_metadata_update_helper.rb#23
```

That is obviously incorrect. The test case runs tests against `IosUpdateMetadataSourceAction`, but with a class defined in **an_** metadata_update_helper.rb.

What I did was moving that failing test case to the `Fastlane::Actions::AnUpdateMetadataSourceAction` test case, because maybe the expectations in it don't apply to the `ios_` and `gp_` ones. Again, I'm not familiar with po file generation logic. It'd be good to get a confirmation that this change is okay.

## Test Instructions

I'm not entirely sure how to test this, as I don't know much about what is a "po" file and how it should be generated. I'm happy to carry out some testing if you have any suggestions.

## Question

Should this change be a breaking change? The class name changes are a breaking changes, but I'm not sure if they are used outside of this library. The apps should use the actions, not the helper classes, correct?

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
