### PR TITLE
Tweak `upload_to_s3` based on #495 feedback

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -138,10 +138,12 @@ module Fastlane
             end,
             optional: true,
             type: Symbol,
-            default_value: nil, # Using nil under the hood until we remove skip_if_exists
+            # We cannot set a default value and have backward compatibility with skip_if_exists at the same time.
+            # (Short of duplicating the default value knowledge in the action implementation)
+            #
+            # We have a test for the default behavior which should hopefully remind us to uncomment this line once well remove skip_if_exists.
+            # default_value: :fail,
             verify_block: proc do |value|
-              next if value.nil?
-
               UI.user_error!('`if_exist` must be one of :skip, :replace, :fail') unless %i[skip replace fail].include?(value)
             end
           ),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -24,9 +24,7 @@ module Fastlane
           message = "File already exists in S3 bucket #{bucket} at #{key}"
 
           # skip_if_exists is deprecated but we want to keep backward compatibility.
-          if params[:if_exists].nil?
-            params[:if_exists] = params[:skip_if_exists] ? :skip : :fail
-          end
+          params[:if_exists] ||= params[:skip_if_exists] ? :skip : :fail
 
           case params[:if_exists]
           when :fail

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -125,6 +125,9 @@ module Fastlane
               UI.user_error!("You cannot set both :#{option.key} and :skip_if_exists. Please only use :if_exists.")
             end,
             optional: true,
+            # This option is deprecated but we stil set a default value to inform that the default behavior is for the action to fail when printing the action docs.
+            # See also https://github.com/wordpress-mobile/release-toolkit/pull/500#discussion_r1239642179
+            default_value: false,
             type: Boolean
           ),
           FastlaneCore::ConfigItem.new(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -25,11 +25,7 @@ module Fastlane
 
           # skip_if_exists is deprecated but we want to keep backward compatibility.
           if params[:if_exists].nil?
-            params[:if_exists] = if params[:skip_if_exists].nil? || params[:skip_if_exists] == false
-                                   :fail
-                                 else
-                                   :skip
-                                 end
+            params[:if_exists] = params[:skip_if_exists] ? :skip : :fail
           end
 
           case params[:if_exists]
@@ -131,7 +127,6 @@ module Fastlane
               UI.user_error!("You cannot set both :#{option.key} and :skip_if_exists. Please only use :if_exists.")
             end,
             optional: true,
-            default_value: false,
             type: Boolean
           ),
           FastlaneCore::ConfigItem.new(

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -145,7 +145,7 @@ describe Fastlane::Actions::UploadToS3Action do
     end
 
     context 'when the file already exists on S3' do
-      it 'fails if skip_if_exists and if_exists are both unspecified' do
+      it 'fails if skip_if_exists and if_exists are both unspecified (default behavior)' do
         expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
         stub_s3_response_for_file(expected_key)
 
@@ -160,110 +160,114 @@ describe Fastlane::Actions::UploadToS3Action do
         end
       end
 
-      it 'logs a message if skip_if_exist:true and if_exists is unspecified' do
-        expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
-        stub_s3_response_for_file(expected_key)
+      context 'when if_exists is unspecified' do
+        it 'logs a message if skip_if_exist:true' do
+          expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
+          stub_s3_response_for_file(expected_key)
 
-        warnings = []
-        allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
+          warnings = []
+          allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
 
-        with_tmp_file(named: 'existing-key') do |file_path|
-          key = run_described_fastlane_action(
-            bucket: test_bucket,
-            key: 'existing-key',
-            file: file_path,
-            skip_if_exists: true
-          )
-
-          expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
-          expect(key).to eq(expected_key)
-        end
-      end
-
-      it 'fails if skip_if_exists:false and if_exists is unspecified' do
-        expected_key = 'faf2b3798ee00168b43fc303d160e0a068e72a7c/existing-key-2'
-        stub_s3_response_for_file(expected_key)
-
-        with_tmp_file(named: 'existing-key-2') do |file_path|
-          expect do
-            run_described_fastlane_action(
-              bucket: test_bucket,
-              key: 'existing-key-2',
-              file: file_path,
-              skip_if_exists: false
-            )
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
-        end
-      end
-
-      it 'fails when if_exist is :fail' do
-        expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
-        stub_s3_response_for_file(expected_key)
-
-        with_tmp_file(named: 'existing-key') do |file_path|
-          expect do
-            run_described_fastlane_action(
+          with_tmp_file(named: 'existing-key') do |file_path|
+            key = run_described_fastlane_action(
               bucket: test_bucket,
               key: 'existing-key',
               file: file_path,
-              if_exists: :fail
+              skip_if_exists: true
             )
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
+
+            expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
+            expect(key).to eq(expected_key)
+          end
+        end
+
+        it 'fails if skip_if_exists:false' do
+          expected_key = 'faf2b3798ee00168b43fc303d160e0a068e72a7c/existing-key-2'
+          stub_s3_response_for_file(expected_key)
+
+          with_tmp_file(named: 'existing-key-2') do |file_path|
+            expect do
+              run_described_fastlane_action(
+                bucket: test_bucket,
+                key: 'existing-key-2',
+                file: file_path,
+                skip_if_exists: false
+              )
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
+          end
         end
       end
 
-      it 'logs a message without failing when if_exists is :skip' do
-        expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
-        stub_s3_response_for_file(expected_key)
+      context 'when if_exists is explicitly set' do
+        it 'fails when if_exist is :fail' do
+          expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
+          stub_s3_response_for_file(expected_key)
 
-        warnings = []
-        allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
-
-        with_tmp_file(named: 'existing-key') do |file_path|
-          key = run_described_fastlane_action(
-            bucket: test_bucket,
-            key: 'existing-key',
-            file: file_path,
-            if_exists: :skip
-          )
-
-          expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
-          expect(key).to eq(expected_key)
+          with_tmp_file(named: 'existing-key') do |file_path|
+            expect do
+              run_described_fastlane_action(
+                bucket: test_bucket,
+                key: 'existing-key',
+                file: file_path,
+                if_exists: :fail
+              )
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, "File already exists in S3 bucket #{test_bucket} at #{expected_key}")
+          end
         end
-      end
 
-      it 'upload the file overriding the existing one when if_exists is :replace' do
-        expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
-        stub_s3_response_for_file(expected_key)
+        it 'logs a message without failing when if_exists is :skip' do
+          expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
+          stub_s3_response_for_file(expected_key)
 
-        warnings = []
-        allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
+          warnings = []
+          allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
 
-        with_tmp_file(named: 'existing-key') do |file_path|
-          expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
-
-          return_value = run_described_fastlane_action(
-            bucket: test_bucket,
-            key: 'existing-key',
-            file: file_path,
-            if_exists: :replace
-          )
-
-          expect(return_value).to eq(expected_key)
-          expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
-        end
-      end
-
-      it 'throws when if_exists is not one of the expected values' do
-        with_tmp_file(named: 'key') do |file_path|
-          expect do
-            run_described_fastlane_action(
+          with_tmp_file(named: 'existing-key') do |file_path|
+            key = run_described_fastlane_action(
               bucket: test_bucket,
-              key: 'a8c-key1',
+              key: 'existing-key',
               file: file_path,
-              if_exists: :invalid
+              if_exists: :skip
             )
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, '`if_exist` must be one of :skip, :replace, :fail')
+
+            expect(warnings).to eq(["File already exists in S3 bucket #{test_bucket} at #{expected_key}. Skipping upload."])
+            expect(key).to eq(expected_key)
+          end
+        end
+
+        it 'upload the file overriding the existing one when if_exists is :replace' do
+          expected_key = '29d5f92e9ee44d4854d6dfaeefc3dc27d779fdf3/existing-key'
+          stub_s3_response_for_file(expected_key)
+
+          warnings = []
+          allow(FastlaneCore::UI).to receive(:important) { |message| warnings << message }
+
+          with_tmp_file(named: 'existing-key') do |file_path|
+            expect(client).to receive(:put_object).with(body: file_instance_of(file_path), bucket: test_bucket, key: expected_key)
+
+            return_value = run_described_fastlane_action(
+              bucket: test_bucket,
+              key: 'existing-key',
+              file: file_path,
+              if_exists: :replace
+            )
+
+            expect(return_value).to eq(expected_key)
+            expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
+          end
+        end
+
+        it 'throws when if_exists is not one of the expected values' do
+          with_tmp_file(named: 'key') do |file_path|
+            expect do
+              run_described_fastlane_action(
+                bucket: test_bucket,
+                key: 'a8c-key1',
+                file: file_path,
+                if_exists: :invalid
+              )
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, '`if_exist` must be one of :skip, :replace, :fail')
+          end
         end
       end
 

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -271,21 +271,21 @@ describe Fastlane::Actions::UploadToS3Action do
           end
         end
       end
+    end
 
-      # test all combinations of skip_if_exists and if_exists
-      [true, false].product(%i[skip fail replace]).each do |skip_if_exists, if_exists|
-        it "does not allow to have both skip_if_exists and if_exists set at the same time (#{skip_if_exists}, #{if_exists})" do
-          with_tmp_file(named: 'existing-key') do |file_path|
-            expect do
-              run_described_fastlane_action(
-                bucket: test_bucket,
-                key: 'existing-key',
-                file: file_path,
-                if_exists: if_exists,
-                skip_if_exists: skip_if_exists
-              )
-            end.to raise_error(FastlaneCore::Interface::FastlaneError, 'You cannot set both :skip_if_exists and :if_exists. Please only use :if_exists.')
-          end
+    # test all combinations of skip_if_exists and if_exists
+    [true, false].product(%i[skip fail replace]).each do |skip_if_exists, if_exists|
+      it "does not allow to have both skip_if_exists and if_exists set at the same time (#{skip_if_exists}, #{if_exists})" do
+        with_tmp_file(named: 'existing-key') do |file_path|
+          expect do
+            run_described_fastlane_action(
+              bucket: test_bucket,
+              key: 'existing-key',
+              file: file_path,
+              if_exists: if_exists,
+              skip_if_exists: skip_if_exists
+            )
+          end.to raise_error(FastlaneCore::Interface::FastlaneError, 'You cannot set both :skip_if_exists and :if_exists. Please only use :if_exists.')
         end
       end
     end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -271,17 +271,20 @@ describe Fastlane::Actions::UploadToS3Action do
         end
       end
 
-      it 'does not allow to have both skip_if_exists and if_exists set at the same time' do
-        with_tmp_file(named: 'existing-key') do |file_path|
-          expect do
-            run_described_fastlane_action(
-              bucket: test_bucket,
-              key: 'existing-key',
-              file: file_path,
-              if_exists: :skip,
-              skip_if_exists: true
-            )
-          end.to raise_error(FastlaneCore::Interface::FastlaneError, 'You cannot set both :skip_if_exists and :if_exists. Please only use :if_exists.')
+      # test all combinations of skip_if_exists and if_exists
+      [true, false].product(%i[skip fail replace]).each do |skip_if_exists, if_exists|
+        it "does not allow to have both skip_if_exists and if_exists set at the same time (#{skip_if_exists}, #{if_exists})" do
+          with_tmp_file(named: 'existing-key') do |file_path|
+            expect do
+              run_described_fastlane_action(
+                bucket: test_bucket,
+                key: 'existing-key',
+                file: file_path,
+                if_exists: if_exists,
+                skip_if_exists: skip_if_exists
+              )
+            end.to raise_error(FastlaneCore::Interface::FastlaneError, 'You cannot set both :skip_if_exists and :if_exists. Please only use :if_exists.')
+          end
         end
       end
     end

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -253,6 +253,7 @@ describe Fastlane::Actions::UploadToS3Action do
             )
 
             expect(return_value).to eq(expected_key)
+            expect(warnings).to include("File already exists in S3 bucket #{test_bucket} at #{expected_key}. Will replace with the given one.")
             expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::S3_UPLOADED_FILE_PATH]).to eq(expected_key)
           end
         end


### PR DESCRIPTION
See @AliSoftware final comments in #495 

All these changes count as refactors, so no `CHANGELOG.md` update.