### PR TITLE
Update release notes parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### New Features
 
 - Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
-- Release note files can now include Markdown headers (`#`, `##`, etc.) and list items (Starting with `-`) at the top of the file. [#508]
+- Adds additional formatting options for release note files. They can now include Markdown headers (`#`, `##`, etc.) and list items (Starting with `-`) at the top of the file. [#508]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### New Features
 
 - Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
+- Release note files can now include Markdown headers (`#`, `##`, etc.) and list items (Starting with `-`) at the top of the file. [#508]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
@@ -11,7 +11,13 @@ module Fastlane
 
         # Find the index of the first non-empty line that is also NOT a comment.
         # That way we keep commment headers as the very top of the file
-        line_idx = lines.find_index { |l| !l.start_with?('***') && !l.start_with?('//') && !l.chomp.empty? }
+        line_idx = lines.find_index do |l|
+          !l.start_with?('***') &&
+            !l.start_with?('//') &&
+            !l.start_with?('#') &&
+            !l.start_with?('- ') &&
+            !l.chomp.empty?
+        end
         # Put back the header, then the new entry, then the rest
         # (note: '...' excludes the higher bound of the range, unlike '..')
         new_lines = lines[0...line_idx] + ["#{section_title}\n", "-----\n", "\n", "\n"] + lines[line_idx..]

--- a/spec/release_notes_helper_spec.rb
+++ b/spec/release_notes_helper_spec.rb
@@ -21,6 +21,23 @@ describe Fastlane::Helper::ReleaseNotesHelper do
 
     HEADER
   end
+  
+  it 'adds a new section after any `#` comments on top' do
+    run_release_notes_test <<~HEADER
+      # This is a Markdown header
+      ## This is another kind of Markdown header
+      ### This is an H3 Markdown header
+
+    HEADER
+  end
+  
+  it 'adds a new section after any `- ` comments on top' do
+    run_release_notes_test <<~HEADER
+      - This is a line item
+      - And this is another line item that we want to include
+
+    HEADER
+  end
 
   it 'does consider empty lines as header' do
     run_release_notes_test("\n\n\n")
@@ -34,19 +51,19 @@ describe Fastlane::Helper::ReleaseNotesHelper do
       *** It contains some mixed style of comments
       *** with both double-slash style comment lines
       *** and triple-star style ones.
-
+      
+      - List item
+      - Another list item
+      
+      # Markdown Header
+      ## H2 Markdown Header
+      
+      
 
 
       // It also contains some empty lines we want to count as part of the pinned lines.
 
     HEADER
-  end
-
-  it 'does not consider # as comments' do
-    prefix = <<~NOT_HEADER
-      # This is not a comment
-    NOT_HEADER
-    run_release_notes_test('', prefix + FAKE_CONTENT)
   end
 
   it 'does not consider ** as comments' do

--- a/spec/release_notes_helper_spec.rb
+++ b/spec/release_notes_helper_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane::Helper::ReleaseNotesHelper do
 
     HEADER
   end
-  
+
   it 'adds a new section after any `#` comments on top' do
     run_release_notes_test <<~HEADER
       # This is a Markdown header
@@ -30,7 +30,7 @@ describe Fastlane::Helper::ReleaseNotesHelper do
 
     HEADER
   end
-  
+
   it 'adds a new section after any `- ` comments on top' do
     run_release_notes_test <<~HEADER
       - This is a line item
@@ -51,14 +51,14 @@ describe Fastlane::Helper::ReleaseNotesHelper do
       *** It contains some mixed style of comments
       *** with both double-slash style comment lines
       *** and triple-star style ones.
-      
+
       - List item
       - Another list item
-      
+
       # Markdown Header
       ## H2 Markdown Header
-      
-      
+
+
 
 
       // It also contains some empty lines we want to count as part of the pinned lines.


### PR DESCRIPTION
## What does it do?

This PR adds more parsing options to the `release_notes_helper.rb` so that Markdown headers and lists can be used at the top of the release notes/changelog files. 

@mokagio suggested this change so that a client could use this kind of formatting in their release notes file: 

```
# Release Notes

## Importance Indicators
- Use `[+++]` to call out major new features.
- Use `[++]` to describe other interesting improvements
- Use `[+]` to describe minor improvements or bugfixes.

## Platforms
- Please add `iOS`, `Mac`, or `Both` to indicate which platform the change affects
- Example:
- [+++] Mac: Added a new photo picker
```

This remains backwards-compatible with the existing client release note formatting. 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [X] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
