### PR TITLE
Make create_release print & return the release URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### New Features
 
 - Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
+- The `create_release` action now prints and returns the URL of the created GitHub Release. [#503]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_action.rb
@@ -23,7 +23,7 @@ module Fastlane
         end
 
         github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
-        github_helper.create_release(
+        url = github_helper.create_release(
           repository: repository,
           version: version,
           target: params[:target],
@@ -32,7 +32,8 @@ module Fastlane
           prerelease: prerelease,
           is_draft: is_draft
         )
-        UI.message('Done')
+        UI.success("Successfully created GitHub Release. You can see it at '#{url}'")
+        url
       end
 
       def self.description
@@ -44,7 +45,7 @@ module Fastlane
       end
 
       def self.return_value
-        # If your method provides a return value, you can describe here what it does
+        'The URL of the created GitHub Release'
       end
 
       def self.details

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -134,6 +134,7 @@ module Fastlane
         assets.each do |file_path|
           client.upload_asset(release[:url], file_path, content_type: 'application/octet-stream')
         end
+        release[:url]
       end
 
       # Downloads a file from the given GitHub tag

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -134,7 +134,7 @@ module Fastlane
         assets.each do |file_path|
           client.upload_asset(release[:url], file_path, content_type: 'application/octet-stream')
         end
-        release[:url]
+        release[:html_url]
       end
 
       # Downloads a file from the given GitHub tag

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -399,7 +399,7 @@ describe Fastlane::Helper::GithubHelper do
     it 'has the correct options' do
       options = { body: test_description, draft: true, name: test_tag, prerelease: false, target_commitish: test_target }
       expect(client).to receive(:create_release).with(test_repo, test_tag, options)
-      allow(client).to receive(:create_release).and_return(url: release_url)
+      allow(client).to receive(:create_release).and_return(html_url: release_url)
       create_release(is_draft: true)
     end
 
@@ -415,7 +415,7 @@ describe Fastlane::Helper::GithubHelper do
     it 'creates a draft release if is_draft is set to true' do
       options_draft_release = { body: test_description, draft: true, name: test_tag, prerelease: false, target_commitish: test_target }
       expect(client).to receive(:create_release).with(test_repo, test_tag, options_draft_release)
-      allow(client).to receive(:create_release).and_return(url: release_url)
+      allow(client).to receive(:create_release).and_return(html_url: release_url)
       url = create_release(is_draft: true)
       expect(url).to eq(release_url)
     end
@@ -423,7 +423,7 @@ describe Fastlane::Helper::GithubHelper do
     it 'creates a final (non-draft) release if is_draft is set to false' do
       options_final_release = { body: test_description, draft: false, name: test_tag, prerelease: false, target_commitish: test_target }
       expect(client).to receive(:create_release).with(test_repo, test_tag, options_final_release)
-      allow(client).to receive(:create_release).and_return(url: release_url)
+      allow(client).to receive(:create_release).and_return(html_url: release_url)
       url = create_release(is_draft: false)
       expect(url).to eq(release_url)
     end

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -381,6 +381,7 @@ describe Fastlane::Helper::GithubHelper do
     let(:test_repo) { 'repo-test/project-test' }
     let(:test_tag) { '1.0' }
     let(:test_target) { 'dummysha123456' }
+    let(:release_url) { 'https://github.com/org/repo/releases/tag/1.2.3' }
     let(:test_description) { 'Hey Im a Test Description' }
     let(:client) do
       instance_double(
@@ -398,6 +399,7 @@ describe Fastlane::Helper::GithubHelper do
     it 'has the correct options' do
       options = { body: test_description, draft: true, name: test_tag, prerelease: false, target_commitish: test_target }
       expect(client).to receive(:create_release).with(test_repo, test_tag, options)
+      allow(client).to receive(:create_release).and_return(url: release_url)
       create_release(is_draft: true)
     end
 
@@ -413,13 +415,17 @@ describe Fastlane::Helper::GithubHelper do
     it 'creates a draft release if is_draft is set to true' do
       options_draft_release = { body: test_description, draft: true, name: test_tag, prerelease: false, target_commitish: test_target }
       expect(client).to receive(:create_release).with(test_repo, test_tag, options_draft_release)
-      create_release(is_draft: true)
+      allow(client).to receive(:create_release).and_return(url: release_url)
+      url = create_release(is_draft: true)
+      expect(url).to eq(release_url)
     end
 
     it 'creates a final (non-draft) release if is_draft is set to false' do
       options_final_release = { body: test_description, draft: false, name: test_tag, prerelease: false, target_commitish: test_target }
       expect(client).to receive(:create_release).with(test_repo, test_tag, options_final_release)
-      create_release(is_draft: false)
+      allow(client).to receive(:create_release).and_return(url: release_url)
+      url = create_release(is_draft: false)
+      expect(url).to eq(release_url)
     end
 
     def create_release(is_draft:, assets: [])


### PR DESCRIPTION
 - Make the `create_release` action print a `UI.success` with the URL of the created GitHub Release (similar to how `create_pull_request` and `buildkite_trigger_build` do), so that it can be easily command-clickable from the Terminal to jump directly to it.
 - Make the `create_release` action return the URL too, so that it can be used at call site (e.g. to add a Buildkite annotation with it or send Slack messages linking to it etc)