### PR TITLE
Remove unused dependencies bigdecimal and activesupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
 - The `create_release` action now prints and returns the URL of the created GitHub Release. [#503]
+- Removes two dependencies bigdecimal and activesupport. [#504]
 
 ### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)
+      fastlane (~> 2.213)
       git (~> 1.3)
       google-cloud-storage (~> 1.31)
       nokogiri (~> 1.11)
@@ -171,7 +172,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.212.2)
+    fastlane (2.213.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -195,7 +196,7 @@ GEM
       json (< 3.0.0)
       jwt (>= 2.1.0, < 3)
       mini_magick (>= 4.9.4, < 5.0.0)
-      multipart-post (~> 2.0.0)
+      multipart-post (>= 2.0.0, < 3.0.0)
       naturally (~> 2.2)
       optparse (~> 0.1.1)
       plist (>= 3.1.0, < 4.0.0)
@@ -431,4 +432,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.4
+   2.4.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ PATH
   remote: .
   specs:
     fastlane-plugin-wpmreleasetoolkit (8.1.0)
-      activesupport (>= 6.1.7.1)
-      bigdecimal (~> 1.4)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -53,7 +51,6 @@ GEM
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
-    bigdecimal (1.4.4)
     buildkit (1.5.0)
       sawyer (>= 0.6)
     buildkite-test_collector (2.3.1)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
-  spec.add_dependency 'activesupport', '>= 6.1.7.1'
   spec.add_dependency 'buildkit', '~> 1.5'
   spec.add_dependency 'chroma', '0.2.0'
   spec.add_dependency 'diffy', '~> 3.3'
@@ -40,13 +39,6 @@ Gem::Specification.new do |spec|
 
   # `google-cloud-storage` is required by fastlane, but we pin it in case it's not in the future
   spec.add_dependency 'google-cloud-storage', '~> 1.31'
-
-  # Some of the upstream code uses `BigDecimal.new` which version 2.0 of the
-  # `bigdecimal` gem removed. Until we'll find the time to identify the
-  # dependencies and see if we can move them to something compatible with
-  # modern `bigdecimal`, let's constrain the gem to a version still supporting
-  # `.new` but which warns about it deprecation.
-  spec.add_dependency 'bigdecimal', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'cocoapods', '~> 1.10'

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'buildkit', '~> 1.5'
   spec.add_dependency 'chroma', '0.2.0'
   spec.add_dependency 'diffy', '~> 3.3'
+  spec.add_dependency 'fastlane', '~> 2.213'
   spec.add_dependency 'git', '~> 1.3'
   spec.add_dependency 'nokogiri', '~> 1.11' # Needed for AndroidLocalizeHelper
   spec.add_dependency 'octokit', '~> 6.1'


### PR DESCRIPTION
## What does it do?

I don't know much about the history of the two removed dependencies bigdecimal and activesupport, but they appear to not being used by this library.


There was this https://github.com/wordpress-mobile/release-toolkit/issues/289 issue documenting a version clash between this library and some app's gems. But I can't find what the app was, and don't know if that issue is still relevant. I'm happy to dig deeper if someone can provide more context around these two dependencies. Thanks!

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
