### PR TITLE
Fix `install_gems` cache for when using `RBENV_VERSION` usage on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,24 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
 # Nodes with values to reuse in the pipeline.
 common_params:
   env: &xcode_image
     IMAGE_ID: xcode-14.3.1
   plugins:
-  - &docker_plugin
-    docker#v3.8.0:
-      image: &ruby_version "ruby:2.7.4"
-      propagate-environment: true
-      environment:
-        - "RUBYGEMS_API_KEY"
-  - &docker_plugin_with_danger_token
-    docker#v3.8.0:
-      image: *ruby_version
-      propagate-environment: true
-      environment:
-        - "DANGER_GITHUB_API_TOKEN"
+    - &ci_toolkit
+      automattic/a8c-ci-toolkit#2.18.2: ~
+    - &docker_plugin
+      docker#v3.8.0:
+        image: &ruby_version "ruby:2.7.4"
+        propagate-environment: true
+        environment:
+          - "RUBYGEMS_API_KEY"
+    - &docker_plugin_with_danger_token
+      docker#v3.8.0:
+        image: *ruby_version
+        propagate-environment: true
+        environment:
+          - "DANGER_GITHUB_API_TOKEN"
 
 
 steps:
@@ -38,15 +42,12 @@ steps:
           git-lfs install
 
           echo "--- :rubygems: Setting up Gems"
-          # https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-          gem install bundler
           install_gems
 
           echo "--- :rspec: Run Rspec"
           bundle exec rspec --profile 10 --format progress
         env: *xcode_image
-        plugins:
-          - automattic/a8c-ci-toolkit#2.15.0
+        plugins: [*ci_toolkit]
         agents:
           queue: "mac"
         matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Internal Changes
 
 - Updates `octokit` to `6.1.1`, `danger` to `9.3.1` and `buildkite-test_collector` to `2.3.1`. [#491]
+- Fix issue with gems cache on CI when testing against Ruby `3.2.2`. [#506]
 
 ## 8.1.0
 


### PR DESCRIPTION
## What

 - Adopt [this latest fix from `a8c-ci-toolkit`](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/70/files) so that our test step uses the cache based on the correct ruby version on CI for each build matrix run
 - Remove an old workaround of `gem install bundler` that is not necessary anymore, and made the `gem install bundler` command be run twice

## Testing

 - This CI build [shows that the cache key that was used for Ruby `3.2.2` now correctly uses `release-toolkit-Darwin-x86_64-ruby3.2.2-{hash}`](https://buildkite.com/automattic/release-toolkit/builds/1224#01896b22-7523-423b-b7f2-2792da06bc47/360-362), based on the value of `export RBENV_VERSION={{ matrix.ruby }}` (instead of `release-toolkit-x86_64-ruby2.7.4-{hash}` like it was using before this change)
