### PR TITLE
Restore activesupport dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Adds `if_exists` parameter to `upload_to_s3` action, with possible values `:skip`, `:fail`, and `:replace`. [#495]
 - The `create_release` action now prints and returns the URL of the created GitHub Release. [#503]
-- Removes two dependencies bigdecimal and activesupport. [#504]
+- Removes `bigdecimal` dependency. [#504] [#507]
 - Supports Ruby 3. [#492, #493, #497, and #504]
 
 ### Bug Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     fastlane-plugin-wpmreleasetoolkit (8.1.0)
+      activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -432,4 +433,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.13
+   2.4.14

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  spec.add_dependency 'activesupport', '>= 6.1.7.1' # Required for fastlane to not crash when importing this plugin
   spec.add_dependency 'buildkit', '~> 1.5'
   spec.add_dependency 'chroma', '0.2.0'
   spec.add_dependency 'diffy', '~> 3.3'


### PR DESCRIPTION
To fix error when loading plugin, since we still had a `require 'active_support/all'` in `PromoScreenshotsAction`

See https://github.com/wordpress-mobile/release-toolkit/pull/504#issuecomment-1642259343