### PR TITLE
Merge release 9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Fix metadata `po` generation for iOS projects removing the final `\n`. [#498]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 9.0.1
+
+### Bug Fixes
+
+- Fix metadata `po` generation for iOS projects removing the final `\n`. [#498]
 
 ## 9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-- Fix metadata `po` generation for iOS projects removing the final `\n` [#498]
+- Fix metadata `po` generation for iOS projects removing the final `\n`. [#498]
 
 ### Internal Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (9.0.0)
+    fastlane-plugin-wpmreleasetoolkit (9.0.1)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
@@ -433,4 +433,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.14
+   2.3.24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,4 +433,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.24
+   2.4.14

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '9.0.0'
+    VERSION = '9.0.1'
   end
 end


### PR DESCRIPTION
Includes: #498 

@mokagio: Be sure to create a GitHub Release and tag once this PR gets merged.

---

This new version will be useful for iOS releases but not necessarily at code freeze time, only when generating the release notes and ASC metadata `po[t]` file. I'll be starting the WordPress and Jetpack iOS code freeze shortly but will not wait for this to be merged and released, but I'll update the gem in the release branch once it's time to generate new release notes for translations.