### PR TITLE
Fix `prototype_build_details_comment_action` args

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -168,7 +168,7 @@ module Fastlane
             key: :app_display_name,
             env_name: 'FL_PROTOTYPE_BUILD_DETAILS_COMMENT_APP_DISPLAY_NAME',
             description: 'The display name to use for the app in the comment message',
-            optional: false,
+            optional: true,
             type: String
           ),
           FastlaneCore::ConfigItem.new(
@@ -176,7 +176,7 @@ module Fastlane
             env_name: 'APPCENTER_OWNER_NAME', # Intentionally the same as the one used by the `appcenter_upload` action
             description: 'The name of the organization in App Center (if you used `appcenter_upload` to distribute your Prototype build)',
             type: String,
-            optional: true
+            optional: false
           ),
           FastlaneCore::ConfigItem.new(
             key: :app_center_app_name,


### PR DESCRIPTION
Fix which parameters are required or not for that action
 - Only `app_center_org_name` is required
 - All other parameters can be decided from the `lane_context` (assuming `appcenter_upload` was called before that lane)

The was never right, and never caused any trouble because all other repos that called this action have all provided an `app_display_name` explicitly)

@mokagio I'm targeting `release/9.0.1` because it seems there's still time to include this small fix into a patch release 🤞 