### PR TITLE
Add/Expand actions to manipulate GitHub branch protections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
- - Renamed `addbranchprotection` to `update_branch_protection`, and allow it to provide additional optional protection
+ - Renamed `addbranchprotection` to `set_branch_protection`, and allow it to provide additional optional protection
    settings to set/update on the target branch (like `lock_branch`, `required_ci_checks`, etc).
    The `addbranchprotection` action name still exists for backward compatibility for now (with a deprecation notice),
    but it will be removed in a future major release. [#513]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ _None_
 
 ### New Features
 
-_None_
+ - Renamed `addbranchprotection` to `update_branch_protection`, and allow it to provide additional optional protection
+   settings to set/update on the target branch (like `lock_branch`, `required_ci_checks`, etc).
+   The `addbranchprotection` action name still exists for backward compatibility for now (with a deprecation notice),
+   but it will be removed in a future major release. [#513]
+ - Renamed `removebranchprotection` to `remove_branch_protection`.
+   The `removebranchprotection` action name still exists for now for backward compatibility (with a deprecation notice),
+   but it will be removed in a future major release. [#513]
+ - Added `copy_branch_protection` action to replicate the branch protection settings of one branch onto another. [#513]
 
 ### Bug Fixes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,10 @@
 # Migration Instructions for Major Releases
 
+## From `9.0.0` to `10.0.0`
+
+ - Action `addbranchprotection` has been renamed `update_branch_protection`. Besides, you might want to use the new `copy_branch_protection(from_branch: to_branch:)` instead (especially for protecting the `release/*` branch after code-freeze).
+ - Action `removebranchprotection` has been renamed `remove_branch_protection`.
+
 ## From `8.0.0` to `9.0.0`
 
 - The deprecated actions `ios_localize_project` and `ios_update_metadata` were now completely removed. If your project is still using them, please use the new tooling instead.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## From `9.0.0` to `10.0.0`
 
- - Action `addbranchprotection` has been renamed `update_branch_protection`. Besides, you might want to use the new `copy_branch_protection(from_branch: to_branch:)` instead (especially for protecting the `release/*` branch after code-freeze).
+ - Action `addbranchprotection` has been renamed `set_branch_protection`. Besides, you might want to use the new `copy_branch_protection(from_branch: to_branch:)` instead (especially for protecting the `release/*` branch after code-freeze).
  - Action `removebranchprotection` has been renamed `remove_branch_protection`.
 
 ## From `8.0.0` to `9.0.0`

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/copy_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/copy_branch_protection_action.rb
@@ -1,0 +1,80 @@
+require 'fastlane/action'
+require_relative '../../helper/github_helper'
+
+module Fastlane
+  module Actions
+    class CopyBranchProtectionAction < Action
+      def self.run(params)
+        repository = params[:repository]
+        from_branch = params[:from_branch]
+        to_branch = params[:to_branch]
+
+        github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
+
+        response = begin
+          github_helper.get_branch_protection(
+            repository: repository,
+            branch: from_branch
+          )
+        rescue Octokit::NotFound
+          UI.user_error!("Branch `#{from_branch}` of repository `#{repository}` was not found.")
+        end
+        UI.user_error!("Branch `#{from_branch}` does not have any branch protection set up.") if response.nil?
+        settings = Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(response)
+
+        response = begin
+          github_helper.set_branch_protection(
+            repository: repository,
+            branch: to_branch,
+            **settings
+          )
+        rescue Octokit::NotFound
+          UI.user_error!("Branch `#{to_branch}` of repository `#{repository}` was not found.")
+        end
+
+        Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(response)
+      end
+
+      def self.description
+        'Copies the branch protection settings of one branch onto another branch'
+      end
+
+      def self.details
+        description
+      end
+
+      def self.return_value
+        'The hash corresponding to the response returned by the API request, and containing the applied protection settings'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :repository,
+                                       env_name: 'GHHELPER_REPOSITORY',
+                                       description: 'The remote path of the GH repository on which we work',
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :from_branch,
+                                       env_name: 'GHHELPER_FROM_BRANCH',
+                                       description: 'The branch to copy the protection settings from',
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :to_branch,
+                                       env_name: 'GHHELPER_TO_BRANCH',
+                                       description: 'The branch to copy the protection settings to',
+                                       optional: false,
+                                       type: String),
+          Fastlane::Helper::GithubHelper.github_token_config_item,
+        ]
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/remove_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/remove_branch_protection_action.rb
@@ -8,18 +8,15 @@ module Fastlane
         repository = params[:repository]
         branch_name = params[:branch]
 
-        branch_url = "https://api.github.com/repos/#{repository}/branches/#{branch_name}"
-        restrictions = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
-        required_pull_request_reviews = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
-
         github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
         github_helper.remove_branch_protection(
           repository: repository,
-          branch: branch_name,
-          restrictions: restrictions,
-          enforce_admins: nil,
-          required_pull_request_reviews: required_pull_request_reviews
+          branch: branch_name
         )
+      rescue Octokit::NotFound
+        UI.user_error!("Branch `#{branch_name}` of repository `#{repository}` was not found.")
+      rescue Octokit::BranchNotProtected
+        UI.message("Note: Branch `#{branch_name}` was not protected in the first place.")
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/remove_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/remove_branch_protection_action.rb
@@ -3,7 +3,7 @@ require_relative '../../helper/github_helper'
 
 module Fastlane
   module Actions
-    class RemovebranchprotectionAction < Action
+    class RemoveBranchProtectionAction < Action
       def self.run(params)
         repository = params[:repository]
         branch_name = params[:branch]
@@ -23,20 +23,15 @@ module Fastlane
       end
 
       def self.description
-        "Removes the 'release branch' protection state for the specified branch"
+        'Removes the protection settings for the specified branch'
       end
 
-      def self.authors
-        ['Automattic']
+      def self.details
+        description
       end
 
       def self.return_value
         # If your method provides a return value, you can describe here what it does
-      end
-
-      def self.details
-        # Optional:
-        "Sets the 'release branch' protection state for the specified branch"
       end
 
       def self.available_options
@@ -55,8 +50,23 @@ module Fastlane
         ]
       end
 
+      def self.authors
+        ['Automattic']
+      end
+
       def self.is_supported?(platform)
         true
+      end
+    end
+
+    # For backwards compatibility
+    class RemovebranchprotectionAction < RemoveBranchProtectionAction
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        "This action has been renamed `#{superclass.action_name}`"
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/set_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/set_branch_protection_action.rb
@@ -3,7 +3,7 @@ require_relative '../../helper/github_helper'
 
 module Fastlane
   module Actions
-    class UpdateBranchProtectionAction < Action
+    class SetBranchProtectionAction < Action
       def self.run(params)
         repository = params[:repository]
         branch_name = params[:branch]
@@ -140,7 +140,7 @@ module Fastlane
     end
 
     # For backwards compatibility
-    class SetbranchprotectionAction < UpdateBranchProtectionAction
+    class SetbranchprotectionAction < SetBranchProtectionAction
       def self.category
         :deprecated
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_branch_protection_action.rb
@@ -3,7 +3,7 @@ require_relative '../../helper/github_helper'
 
 module Fastlane
   module Actions
-    class SetbranchprotectionAction < Action
+    class UpdateBranchProtectionAction < Action
       def self.run(params)
         repository = params[:repository]
         branch_name = params[:branch]
@@ -23,20 +23,15 @@ module Fastlane
       end
 
       def self.description
-        "Sets the 'release branch' protection state for the specified branch"
+        'Sets the protection state for the specified branch'
       end
 
-      def self.authors
-        ['Automattic']
+      def self.details
+        description
       end
 
       def self.return_value
         # If your method provides a return value, you can describe here what it does
-      end
-
-      def self.details
-        # Optional:
-        "Sets the 'release branch' protection state for the specified branch"
       end
 
       def self.available_options
@@ -55,8 +50,23 @@ module Fastlane
         ]
       end
 
+      def self.authors
+        ['Automattic']
+      end
+
       def self.is_supported?(platform)
         true
+      end
+    end
+
+    # For backwards compatibility
+    class SetbranchprotectionAction < UpdateBranchProtectionAction
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        "This action has been renamed `#{superclass.action_name}`"
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_branch_protection_action.rb
@@ -7,19 +7,65 @@ module Fastlane
       def self.run(params)
         repository = params[:repository]
         branch_name = params[:branch]
-
-        branch_url = "https://api.github.com/repos/#{repository}/branches/#{branch_name}"
-        restrictions = { url: "#{branch_url}/protection/restrictions", users_url: "#{branch_url}/protection/restrictions/users", teams_url: "#{branch_url}/protection/restrictions/teams", users: [], teams: [] }
-        required_pull_request_reviews = { url: "#{branch_url}/protection/required_pull_request_reviews", dismiss_stale_reviews: false, require_code_owner_reviews: false }
-
         github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
-        github_helper.set_branch_protection(
+
+        settings = if params[:keep_existing_settings_unchanged]
+                     Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(
+                       github_helper.get_branch_protection(repository: repository, branch: branch_name)
+                     )
+                   else
+                     {}
+                   end
+
+        # `required_status_checks` field — only override existing `checks` subfield if param provided
+        unless params[:required_ci_checks].nil?
+          if params[:required_ci_checks].empty?
+            settings[:required_status_checks] = nil # explicitly completely delete existing check requirement
+          else
+            settings[:required_status_checks] ||= { strict: false }
+            settings[:required_status_checks][:checks] = params[:required_ci_checks].map { |ctx| { context: ctx } }
+          end
+        end
+
+        # `enforce_admins` field — only override existing value if param provided
+        if params[:enforce_admins].nil?
+          settings[:enforce_admins] ||= nil # parameter is required to be provided, even if nil (aka false) value
+        else
+          settings[:enforce_admins] = params[:enforce_admins]
+        end
+
+        # `required_pull_request_reviews` field — only override `required_approving_review_count` subfield if param provided
+        settings[:required_pull_request_reviews] ||= {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false
+        }
+        unless params[:required_approving_review_count].nil?
+          settings[:required_pull_request_reviews][:required_approving_review_count] = params[:required_approving_review_count]
+        end
+
+        # `restrictions` field
+        settings[:restrictions] ||= { users: [], teams: [] }
+
+        # `allow_force_pushes` field — only override existing value if param provided
+        unless params[:allow_force_pushes].nil?
+          settings[:allow_force_pushes] = params[:allow_force_pushes]
+        end
+
+        # `lock_branch` field — only override existing value if param provided
+        unless params[:lock_branch].nil?
+          settings[:lock_branch] = params[:lock_branch]
+        end
+
+        # API Call - See https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
+        response = github_helper.set_branch_protection(
           repository: repository,
           branch: branch_name,
-          restrictions: restrictions,
-          enforce_admins: nil,
-          required_pull_request_reviews: required_pull_request_reviews
+          **settings
         )
+
+        Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(response)
+      rescue Octokit::NotFound => e
+        UI.user_error!("Branch `#{branch_name}` of repository `#{repository}` was not found.\n#{e.message}")
       end
 
       def self.description
@@ -31,21 +77,55 @@ module Fastlane
       end
 
       def self.return_value
-        # If your method provides a return value, you can describe here what it does
+        'The hash corresponding to the response returned by the API request, and containing the applied protection settings'
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :repository,
                                        env_name: 'GHHELPER_REPOSITORY',
-                                       description: 'The remote path of the GH repository on which we work',
+                                       description: 'The slug of the GH repository on which we work',
                                        optional: false,
                                        type: String),
+          # NOTE: GitHub branch protection API doesn't allow wildcard characters for the branch parameter
           FastlaneCore::ConfigItem.new(key: :branch,
                                        env_name: 'GHHELPER_BRANCH',
                                        description: 'The branch to protect',
                                        optional: false,
                                        type: String),
+          FastlaneCore::ConfigItem.new(key: :keep_existing_settings_unchanged,
+                                       description: 'If set to true, will only change the settings that are explicitly provided to the action, ' \
+                                       + 'while keeping the values of other existing protection settings (if any) unchanged. If false, it will ' \
+                                       + 'discard any existing branch protection setting if any before setting just the ones provided ' \
+                                       + '(and leaving the rest with default GitHub values)',
+                                       default_value: true,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :required_ci_checks,
+                                       description: 'If provided, specifies the list of CI status checks to mark as required. If not provided (nil), will keep existing ones',
+                                       optional: true,
+                                       default_value: nil,
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :required_approving_review_count,
+                                       description: 'If not nil, change the number of approving reviews required to merge the PR. ' \
+                                       + 'Acceptable values are `nil` (do not change), 0 (disable) or a number between 1–6',
+                                       optional: true,
+                                       default_value: nil,
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :enforce_admins,
+                                       description: 'If provided, will update the setting of whether admins can bypass restrictions (false) or not (true)',
+                                       optional: true,
+                                       default_value: nil,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :allow_force_pushes,
+                                       description: 'If provided, will update the setting of whether to allow force pushes on the branch',
+                                       optional: true,
+                                       default_value: nil,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :lock_branch,
+                                       description: 'If provided, will update the locked (aka readonly) state of the branch',
+                                       optional: true,
+                                       default_value: nil,
+                                       type: Boolean),
           Fastlane::Helper::GithubHelper.github_token_config_item,
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -250,6 +250,16 @@ module Fastlane
         client.unprotect_branch(repository, branch)
       end
 
+      # Get the list of branch protection settings for a given branch of a repository
+      #
+      # @param [String] repository The repository name (including the organization)
+      # @param [String] branch The branch name
+      # @see https://docs.github.com/en/rest/branches/branch-protection#get-branch-protection
+      #
+      def get_branch_protection(repository:, branch:, **options)
+        client.branch_protection(repository, branch)
+      end
+
       # Protects a single branch from a repository
       #
       # @param [String] repository The repository name (including the organization)
@@ -270,6 +280,8 @@ module Fastlane
       # @see https://docs.github.com/en/rest/branches/branch-protection
       #
       def self.branch_protection_api_response_to_normalized_hash(response)
+        return {} if response.nil?
+
         normalize_values = lambda do |hash|
           hash.each do |k, v|
             # Boolean values appear as { "enabled" => true/false } in the Response, while they must appear as true/false in Request
@@ -285,7 +297,8 @@ module Fastlane
             v.each { |item| normalize_values.call(item) if item.is_a?(Hash) } if v.is_a?(Array)
           end
         end
-        hash = response&.to_hash || {}
+
+        hash = response.to_hash
         normalize_values.call(hash)
 
         # Response contains both (legacy) `:contexts` key and new `:checks` key, but only one of the two should be passed in Request

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -244,11 +244,10 @@ module Fastlane
       #
       # @param [String] repository The repository name (including the organization)
       # @param [String] branch The branch name
-      # @param [Hash] options A customizable set of options.
-      # @see https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection
+      # @see https://docs.github.com/en/rest/branches/branch-protection#delete-branch-protection
       #
-      def remove_branch_protection(repository:, branch:, **options)
-        client.unprotect_branch(repository, branch, options)
+      def remove_branch_protection(repository:, branch:)
+        client.unprotect_branch(repository, branch)
       end
 
       # Protects a single branch from a repository

--- a/spec/copy_branch_protection_action_spec.rb
+++ b/spec/copy_branch_protection_action_spec.rb
@@ -37,7 +37,7 @@ describe Fastlane::Actions::CopyBranchProtectionAction do
     allow(client).to receive(:branch_protection).with(repo, from_branch).and_return(stub_response(existing_settings))
 
     new_settings = Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(existing_settings)
-    expect(client).to receive(:protect_branch).with(repo, to_branch, **new_settings)
+    expect(client).to receive(:protect_branch).with(repo, to_branch, new_settings)
 
     run_described_fastlane_action(
       repository: repo,
@@ -77,7 +77,7 @@ describe Fastlane::Actions::CopyBranchProtectionAction do
     existing_settings = fixture('existing_branch_protection.json')
     allow(client).to receive(:branch_protection).with(repo, from_branch).and_return(stub_response(existing_settings))
     new_settings = Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(existing_settings)
-    allow(client).to receive(:protect_branch).with(repo, to_branch, **new_settings).and_raise(Octokit::NotFound)
+    allow(client).to receive(:protect_branch).with(repo, to_branch, new_settings).and_raise(Octokit::NotFound)
 
     expect do
       run_described_fastlane_action(

--- a/spec/copy_branch_protection_action_spec.rb
+++ b/spec/copy_branch_protection_action_spec.rb
@@ -5,6 +5,7 @@ describe Fastlane::Actions::CopyBranchProtectionAction do
   let(:repo) { 'automattic/demorepo' }
   let(:from_branch) { 'trunk' }
   let(:to_branch) { 'release/12.3' }
+  let(:github_token) { 'stubbed-gh-token' }
   let(:client) do
     instance_double(
       Octokit::Client,
@@ -41,7 +42,8 @@ describe Fastlane::Actions::CopyBranchProtectionAction do
     run_described_fastlane_action(
       repository: repo,
       from_branch: from_branch,
-      to_branch: to_branch
+      to_branch: to_branch,
+      github_token: github_token
     )
   end
 
@@ -52,7 +54,8 @@ describe Fastlane::Actions::CopyBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         from_branch: from_branch,
-        to_branch: to_branch
+        to_branch: to_branch,
+        github_token: github_token
       )
     end.to raise_error(FastlaneCore::Interface::FastlaneError, "Branch `#{from_branch}` of repository `#{repo}` was not found.")
   end
@@ -64,7 +67,8 @@ describe Fastlane::Actions::CopyBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         from_branch: from_branch,
-        to_branch: to_branch
+        to_branch: to_branch,
+        github_token: github_token
       )
     end.to raise_error(FastlaneCore::Interface::FastlaneError, "Branch `#{from_branch}` does not have any branch protection set up.")
   end
@@ -79,7 +83,8 @@ describe Fastlane::Actions::CopyBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         from_branch: from_branch,
-        to_branch: to_branch
+        to_branch: to_branch,
+        github_token: github_token
       )
     end.to raise_error(FastlaneCore::Interface::FastlaneError, "Branch `#{to_branch}` of repository `#{repo}` was not found.")
   end

--- a/spec/copy_branch_protection_action_spec.rb
+++ b/spec/copy_branch_protection_action_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'tmpdir'
+
+describe Fastlane::Actions::CopyBranchProtectionAction do
+  let(:repo) { 'automattic/demorepo' }
+  let(:from_branch) { 'trunk' }
+  let(:to_branch) { 'release/12.3' }
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      user: instance_double('User', name: 'test'),
+      'auto_paginate=': nil
+    )
+  end
+
+  def fixture(file)
+    path = File.join(File.dirname(__FILE__), 'test-data', 'github_branch_protection', file)
+    JSON.parse(File.read(path), symbolize_names: true)
+  end
+
+  def stub_response(hash)
+    stubs = Faraday::Adapter::Test::Stubs.new
+    agent = Sawyer::Agent.new 'http://release-toolkit.com/specs' do |conn|
+      conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
+      conn.adapter :test, stubs
+    end
+    Sawyer::Resource.new(agent, hash)
+  end
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+  end
+
+  it 'copies the branch protection settings when all parameters are valid' do
+    existing_settings = fixture('existing_branch_protection.json')
+    allow(client).to receive(:branch_protection).with(repo, from_branch).and_return(stub_response(existing_settings))
+
+    new_settings = Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(existing_settings)
+    expect(client).to receive(:protect_branch).with(repo, to_branch, **new_settings)
+
+    run_described_fastlane_action(
+      repository: repo,
+      from_branch: from_branch,
+      to_branch: to_branch
+    )
+  end
+
+  it 'reports an error if the `from_branch` does not exist' do
+    allow(client).to receive(:branch_protection).with(repo, from_branch).and_raise(Octokit::NotFound)
+
+    expect do
+      run_described_fastlane_action(
+        repository: repo,
+        from_branch: from_branch,
+        to_branch: to_branch
+      )
+    end.to raise_error(FastlaneCore::Interface::FastlaneError, "Branch `#{from_branch}` of repository `#{repo}` was not found.")
+  end
+
+  it 'reports an error if the `from_branch` is not protected' do
+    allow(client).to receive(:branch_protection).with(repo, from_branch).and_return(nil)
+
+    expect do
+      run_described_fastlane_action(
+        repository: repo,
+        from_branch: from_branch,
+        to_branch: to_branch
+      )
+    end.to raise_error(FastlaneCore::Interface::FastlaneError, "Branch `#{from_branch}` does not have any branch protection set up.")
+  end
+
+  it 'reports an error if the `to_branch` does not exist' do
+    existing_settings = fixture('existing_branch_protection.json')
+    allow(client).to receive(:branch_protection).with(repo, from_branch).and_return(stub_response(existing_settings))
+    new_settings = Fastlane::Helper::GithubHelper.branch_protection_api_response_to_normalized_hash(existing_settings)
+    allow(client).to receive(:protect_branch).with(repo, to_branch, **new_settings).and_raise(Octokit::NotFound)
+
+    expect do
+      run_described_fastlane_action(
+        repository: repo,
+        from_branch: from_branch,
+        to_branch: to_branch
+      )
+    end.to raise_error(FastlaneCore::Interface::FastlaneError, "Branch `#{to_branch}` of repository `#{repo}` was not found.")
+  end
+end

--- a/spec/remove_branch_protection_action_spec.rb
+++ b/spec/remove_branch_protection_action_spec.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 describe Fastlane::Actions::RemoveBranchProtectionAction do
   let(:repo) { 'automattic/demorepo' }
   let(:branch) { 'release/12.3' }
+  let(:github_token) { 'stubbed-gh-token' }
   let(:client) do
     instance_double(
       Octokit::Client,
@@ -21,7 +22,8 @@ describe Fastlane::Actions::RemoveBranchProtectionAction do
 
     run_described_fastlane_action(
       repository: repo,
-      branch: branch
+      branch: branch,
+      github_token: github_token
     )
   end
 
@@ -34,7 +36,8 @@ describe Fastlane::Actions::RemoveBranchProtectionAction do
 
     run_described_fastlane_action(
       repository: repo,
-      branch: branch
+      branch: branch,
+      github_token: github_token
     )
   end
 
@@ -45,7 +48,8 @@ describe Fastlane::Actions::RemoveBranchProtectionAction do
     expect do
       run_described_fastlane_action(
         repository: repo,
-        branch: branch
+        branch: branch,
+        github_token: github_token
       )
     end.to raise_error FastlaneCore::Interface::FastlaneError, "Branch `#{branch}` of repository `#{repo}` was not found."
   end

--- a/spec/remove_branch_protection_action_spec.rb
+++ b/spec/remove_branch_protection_action_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'tmpdir'
+
+describe Fastlane::Actions::RemoveBranchProtectionAction do
+  let(:repo) { 'automattic/demorepo' }
+  let(:branch) { 'release/12.3' }
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      user: instance_double('User', name: 'test'),
+      'auto_paginate=': nil
+    )
+  end
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+  end
+
+  it 'removes branch protection if the branch was protected' do
+    expect(client).to receive(:unprotect_branch).with(repo, branch)
+
+    run_described_fastlane_action(
+      repository: repo,
+      branch: branch
+    )
+  end
+
+  it 'does nothing if the branch was not protected in the first place' do
+    allow(client).to receive(:unprotect_branch).with(repo, branch).and_raise(Octokit::BranchNotProtected)
+    expect(client).to receive(:unprotect_branch).with(repo, branch)
+
+    allow(FastlaneCore::UI).to receive(:message)
+    expect(FastlaneCore::UI).to receive(:message).with("Note: Branch `#{branch}` was not protected in the first place.")
+
+    run_described_fastlane_action(
+      repository: repo,
+      branch: branch
+    )
+  end
+
+  it 'reports an error if the branch does not exist' do
+    allow(client).to receive(:unprotect_branch).with(repo, branch).and_raise(Octokit::NotFound)
+    expect(client).to receive(:unprotect_branch).with(repo, branch)
+
+    expect do
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch
+      )
+    end.to raise_error FastlaneCore::Interface::FastlaneError, "Branch `#{branch}` of repository `#{repo}` was not found."
+  end
+end

--- a/spec/set_branch_protection_action_spec.rb
+++ b/spec/set_branch_protection_action_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'tmpdir'
 
-describe Fastlane::Actions::UpdateBranchProtectionAction do
+describe Fastlane::Actions::SetBranchProtectionAction do
   let(:repo) { 'automattic/demorepo' }
   let(:branch) { 'release/12.3' }
   let(:restrictions) { { users: [], teams: [] } }

--- a/spec/test-data/github_branch_protection/existing_branch_protection.json
+++ b/spec/test-data/github_branch_protection/existing_branch_protection.json
@@ -1,0 +1,75 @@
+{
+  "url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection",
+  "required_status_checks": {
+    "url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/required_status_checks",
+    "strict": true,
+    "contexts": [
+      "buildkite/check1",
+      "buildkite/check2"
+    ],
+    "contexts_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/required_status_checks/contexts",
+    "checks": [
+      {
+        "context": "buildkite/check1",
+        "app_id": null
+      },
+      {
+        "context": "buildkite/check2",
+        "app_id": null
+      }
+    ]
+  },
+  "restrictions": {
+    "url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/restrictions",
+    "users_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/restrictions/users",
+    "teams_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/restrictions/teams",
+    "apps_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/restrictions/apps",
+    "users": [],
+    "teams": ["apps-infrastructure"],
+    "apps": []
+  },
+  "required_pull_request_reviews": {
+    "url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/required_pull_request_reviews",
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 2,
+    "require_last_push_approval": true,
+    "dismissal_restrictions": {
+      "url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/dismissal_restrictions",
+      "users_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/dismissal_restrictions/users",
+      "teams_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/dismissal_restrictions/teams",
+      "users": [],
+      "teams": [],
+      "apps": []
+    }
+  },
+  "required_signatures": {
+    "url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/required_signatures",
+    "enabled": false
+  },
+  "enforce_admins": {
+    "url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/enforce_admins",
+    "enabled": true
+  },
+  "required_linear_history": {
+    "enabled": true
+  },
+  "allow_force_pushes": {
+    "enabled": true
+  },
+  "allow_deletions": {
+    "enabled": true
+  },
+  "block_creations": {
+    "enabled": true
+  },
+  "required_conversation_resolution": {
+    "enabled": true
+  },
+  "lock_branch": {
+    "enabled": true
+  },
+  "allow_fork_syncing": {
+    "enabled": true
+  }
+}

--- a/spec/test-data/github_branch_protection/existing_branch_protection.json
+++ b/spec/test-data/github_branch_protection/existing_branch_protection.json
@@ -24,8 +24,45 @@
     "users_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/restrictions/users",
     "teams_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/restrictions/teams",
     "apps_url": "https://api.github.com/repos/automattic/demorepo/branches/main/protection/restrictions/apps",
-    "users": [],
-    "teams": ["apps-infrastructure"],
+    "users": [
+      {
+        "login": "release-toolkit-user",
+        "id": 12345,
+        "node_id": "AABB12cd34EfXjQ47Q==",
+        "avatar_url": "https://avatars.githubusercontent.com/u/12345?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/ReleaseToolkitUser",
+        "html_url": "https://github.com/ReleaseToolkitUser",
+        "followers_url": "https://api.github.com/users/ReleaseToolkitUser/followers",
+        "following_url": "https://api.github.com/users/ReleaseToolkitUser/following{/other_user}",
+        "gists_url": "https://api.github.com/users/ReleaseToolkitUser/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/ReleaseToolkitUser/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/ReleaseToolkitUser/subscriptions",
+        "organizations_url": "https://api.github.com/users/ReleaseToolkitUser/orgs",
+        "repos_url": "https://api.github.com/users/ReleaseToolkitUser/repos",
+        "events_url": "https://api.github.com/users/ReleaseToolkitUser/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/ReleaseToolkitUser/received_events",
+        "type": "User",
+        "site_admin": false
+      }
+    ],
+    "teams": [
+      {
+        "name": "The Power Team",
+        "id": 654321,
+        "node_id": "MDQ7WPCjcKFyUfPyNF==",
+        "slug": "the-power-team",
+        "description": "Some dummy team for tests",
+        "privacy": "secret",
+        "notification_setting": "notifications_enabled",
+        "url": "https://api.github.com/organizations/1337042/team/654321",
+        "html_url": "https://github.com/orgs/my-org/teams/the-power-team",
+        "members_url": "https://api.github.com/organizations/1337042/team/654321/members{/member}",
+        "repositories_url": "https://api.github.com/organizations/1337042/team/654321/repos",
+        "permission": "pull",
+        "parent": null
+      }
+    ],
     "apps": []
   },
   "required_pull_request_reviews": {

--- a/spec/update_branch_protection_action_spec.rb
+++ b/spec/update_branch_protection_action_spec.rb
@@ -1,0 +1,326 @@
+require 'spec_helper'
+require 'tmpdir'
+
+describe Fastlane::Actions::UpdateBranchProtectionAction do
+  let(:repo) { 'automattic/demorepo' }
+  let(:branch) { 'release/12.3' }
+  let(:restrictions) { { users: [], teams: [] } }
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      user: instance_double('User', name: 'test'),
+      'auto_paginate=': nil
+    )
+  end
+
+  def fixture(file)
+    path = File.join(File.dirname(__FILE__), 'test-data', 'github_branch_protection', file)
+    JSON.parse(File.read(path), symbolize_names: true)
+  end
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+  end
+
+  shared_examples('no protection was initially set') do |additional_options = {}|
+    it 'uses the default protection settings if no setting is provided explicitly' do
+      expected_options = {
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false
+        },
+        restrictions: restrictions
+      }
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        **additional_options
+      )
+    end
+
+    it 'unsets `required_status_checks` when an empty `required_ci_checks` is provided' do
+      expected_options = {
+        required_status_checks: nil,
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false
+        },
+        restrictions: restrictions
+      }
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        required_ci_checks: [],
+        **additional_options
+      )
+    end
+
+    it 'overrides `required_status_checks` when `required_ci_checks` param is provided' do
+      expected_options = {
+        required_status_checks: {
+          strict: false,
+          checks: [
+            { context: 'check1' },
+            { context: 'check2' },
+            { context: 'check3' },
+          ]
+        },
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false
+        },
+        restrictions: restrictions
+      }
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        required_ci_checks: %w[check1 check2 check3],
+        **additional_options
+      )
+    end
+
+    it 'overrides `required_approving_review_count` when param is provided' do
+      expected_options = {
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false,
+          required_approving_review_count: 3
+        },
+        restrictions: restrictions
+      }
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        required_approving_review_count: 3,
+        **additional_options
+      )
+    end
+
+    it 'overrides `enforce_admins` setting when param is provided' do
+      expected_options = {
+        enforce_admins: true,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false
+        },
+        restrictions: restrictions
+      }
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        enforce_admins: true,
+        **additional_options
+      )
+    end
+
+    it 'overrides `allow_force_pushes` setting when param is provided' do
+      expected_options = {
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false
+        },
+        restrictions: restrictions,
+        allow_force_pushes: true
+      }
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        allow_force_pushes: true,
+        **additional_options
+      )
+    end
+
+    it 'overrides `lock_branch` setting when param is provided' do
+      expected_options = {
+        enforce_admins: nil,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false
+        },
+        restrictions: restrictions,
+        lock_branch: true
+      }
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        lock_branch: true,
+        **additional_options
+      )
+    end
+  end
+
+  context 'when the branch is not protected yet' do
+    before do
+      allow(client).to receive(:branch_protection).with(repo, branch).and_return(nil)
+    end
+
+    it_behaves_like 'no protection was initially set'
+  end
+
+  context 'when the branch was protected but `keep_existing_settings_unchanged` is false' do
+    before do
+      existing_settings = fixture('existing_branch_protection.json')
+      allow(client).to receive(:branch_protection).with(repo, branch).and_return(existing_settings)
+    end
+
+    it_behaves_like 'no protection was initially set', keep_existing_settings_unchanged: false
+  end
+
+  context 'when the branch was protected and `keep_existing_settings_unchanged` is true' do
+    before do
+      allow(client).to receive(:branch_protection)
+        .with(repo, branch)
+        .and_return(fixture('existing_branch_protection.json'))
+    end
+
+    let(:existing_settings) do
+      {
+        allow_deletions: true,
+        allow_force_pushes: true,
+        allow_fork_syncing: true,
+        block_creations: true,
+        enforce_admins: true,
+        lock_branch: true,
+        required_conversation_resolution: true,
+        required_linear_history: true,
+        required_pull_request_reviews: {
+          dismiss_stale_reviews: true,
+          dismissal_restrictions: { apps: [], teams: [], users: [] },
+          require_code_owner_reviews: true,
+          require_last_push_approval: true,
+          required_approving_review_count: 2
+        },
+        required_signatures: false,
+        required_status_checks: {
+          strict: true,
+          checks: [
+            { context: 'buildkite/check1', app_id: nil },
+            { context: 'buildkite/check2', app_id: nil },
+          ]
+        },
+        restrictions: { apps: [], teams: ['apps-infrastructure'], users: [] }
+      }
+    end
+
+    it 'keeps the existing protection settings if no setting is provided explicitly' do
+      expect(client).to receive(:protect_branch).with(repo, branch, existing_settings)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch
+      )
+    end
+
+    it 'unsets `required_status_checks` when an empty `required_ci_checks` is provided' do
+      expected_options = existing_settings.dup
+      expected_options[:required_status_checks] = nil
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        required_ci_checks: []
+      )
+    end
+
+    it 'overrides `required_status_checks` when `required_ci_checks` param is provided' do
+      expected_options = existing_settings.dup
+      expected_options[:required_status_checks][:checks] = [
+        { context: 'new/check1' },
+        { context: 'new/check2' },
+        { context: 'new/check3' },
+      ]
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        required_ci_checks: %w[new/check1 new/check2 new/check3]
+      )
+    end
+
+    it 'overrides `required_approving_review_count` when param is provided' do
+      expect(existing_settings[:required_pull_request_reviews][:required_approving_review_count]).not_to eq(3)
+      expected_options = existing_settings.dup
+      expected_options[:required_pull_request_reviews][:required_approving_review_count] = 3
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        required_approving_review_count: 3
+      )
+    end
+
+    it 'overrides `enforce_admins` setting when param is provided' do
+      expect(existing_settings[:enforce_admins]).to be(true)
+      expected_options = existing_settings.dup
+      expected_options[:enforce_admins] = false
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        enforce_admins: false
+      )
+    end
+
+    it 'overrides `allow_force_pushes` setting when param is provided' do
+      expect(existing_settings[:allow_force_pushes]).to be(true)
+      expected_options = existing_settings.dup
+      expected_options[:allow_force_pushes] = false
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        allow_force_pushes: false
+      )
+    end
+
+    it 'overrides `lock_branch` setting when param is provided' do
+      expect(existing_settings[:lock_branch]).to be(true)
+      expected_options = existing_settings.dup
+      expected_options[:lock_branch] = false
+
+      expect(client).to receive(:protect_branch).with(repo, branch, expected_options)
+
+      run_described_fastlane_action(
+        repository: repo,
+        branch: branch,
+        lock_branch: false
+      )
+    end
+  end
+end

--- a/spec/update_branch_protection_action_spec.rb
+++ b/spec/update_branch_protection_action_spec.rb
@@ -5,6 +5,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
   let(:repo) { 'automattic/demorepo' }
   let(:branch) { 'release/12.3' }
   let(:restrictions) { { users: [], teams: [] } }
+  let(:github_token) { 'stubbed-gh-token' }
   let(:client) do
     instance_double(
       Octokit::Client,
@@ -38,6 +39,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         branch: branch,
+        github_token: github_token,
         **additional_options
       )
     end
@@ -59,6 +61,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
         repository: repo,
         branch: branch,
         required_ci_checks: [],
+        github_token: github_token,
         **additional_options
       )
     end
@@ -87,6 +90,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
         repository: repo,
         branch: branch,
         required_ci_checks: %w[check1 check2 check3],
+        github_token: github_token,
         **additional_options
       )
     end
@@ -108,6 +112,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
         repository: repo,
         branch: branch,
         required_approving_review_count: 3,
+        github_token: github_token,
         **additional_options
       )
     end
@@ -128,6 +133,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
         repository: repo,
         branch: branch,
         enforce_admins: true,
+        github_token: github_token,
         **additional_options
       )
     end
@@ -149,6 +155,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
         repository: repo,
         branch: branch,
         allow_force_pushes: true,
+        github_token: github_token,
         **additional_options
       )
     end
@@ -170,6 +177,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
         repository: repo,
         branch: branch,
         lock_branch: true,
+        github_token: github_token,
         **additional_options
       )
     end
@@ -233,7 +241,8 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
 
       run_described_fastlane_action(
         repository: repo,
-        branch: branch
+        branch: branch,
+        github_token: github_token
       )
     end
 
@@ -246,7 +255,8 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         branch: branch,
-        required_ci_checks: []
+        required_ci_checks: [],
+        github_token: github_token
       )
     end
 
@@ -263,7 +273,8 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         branch: branch,
-        required_ci_checks: %w[new/check1 new/check2 new/check3]
+        required_ci_checks: %w[new/check1 new/check2 new/check3],
+        github_token: github_token
       )
     end
 
@@ -277,7 +288,8 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         branch: branch,
-        required_approving_review_count: 3
+        required_approving_review_count: 3,
+        github_token: github_token
       )
     end
 
@@ -291,7 +303,8 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         branch: branch,
-        enforce_admins: false
+        enforce_admins: false,
+        github_token: github_token
       )
     end
 
@@ -305,7 +318,8 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         branch: branch,
-        allow_force_pushes: false
+        allow_force_pushes: false,
+        github_token: github_token
       )
     end
 
@@ -319,7 +333,8 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
       run_described_fastlane_action(
         repository: repo,
         branch: branch,
-        lock_branch: false
+        lock_branch: false,
+        github_token: github_token
       )
     end
   end

--- a/spec/update_branch_protection_action_spec.rb
+++ b/spec/update_branch_protection_action_spec.rb
@@ -224,7 +224,7 @@ describe Fastlane::Actions::UpdateBranchProtectionAction do
             { context: 'buildkite/check2', app_id: nil },
           ]
         },
-        restrictions: { apps: [], teams: ['apps-infrastructure'], users: [] }
+        restrictions: { apps: [], teams: ['the-power-team'], users: ['release-toolkit-user'] }
       }
     end
 


### PR DESCRIPTION
This PR add/improve actions to manipulate GitHub branch protections:

# Why?

## Lock release branch after submission

As part of my project to improve Tumblr branching model (paaHJt-5ii-p2), I needed an action to lock a given branch (i.e. make it read-only), so that developers couldn't accidentally merge a PR into the release branch after the final build have already been triggered and the app have already been submitted for review.

 - In practice so far we've been doing this in Tumblr (which is a procedure we call "the lockdown" — paaHJt-4iY-p2) [via some ruby code that was duplicated in each Tumblr repo that we used while doing the branch dance for submission and code freeze](https://github.tumblr.net/TumblrMobile/orangina/blob/develop/fastlane/lib/helpers.rb#L283-L313). Once this PR lands, we plan to instead do this by setting `lock_branch: true` on the release branch
 - While we've only done this "lockdown" practice in Tumblr so far—as historically last-minute PRs were sadly more common in Tumblr (pbEOar-1c7-p2) than in other apps—I believe making the `release/*` branch read-only before triggering the final build that will be submitted for review **will be useful to other apps as well** and should actually be done for all our app.

## Set Required CI Checks on release branch

When we do the code freeze and create a new `release/*` branch, so far all our projects have only set the branch protection of those to "require 1 reviewer", but not setting any required CI checks on those `release/*` branch.

As a result, not only were people able to merge an approved PR even if it had red CI steps, but also we couldn't use the "Enable auto-merge" feature on PRs targeting `release/*` (because for that feature to be available, it needs at least one required check)

# How?

## `set_branch_protection`

<details><summary>This action was previously named <tt>addbranchprotection</tt> (without any `_`), so I renamed it for a nicer-looking name.</summary>

  - I kept `addbranchprotection` as a backwards-compatible but deprecated action, so that we don't need a new major version bump just yet though
  - In other words, calling `addbranchprotection(repo, branch)` when the branch wasn't protected yet will still work and do the same thing as before (except it will also print a deprecation notice) — since it will call the same code as `set_branch_protection(repo, branch)`, which will in turn set the same branch protection default options as what `addbranchprotection` did before this PR.
  - The only difference is that if the branch was _already_ protected, then before `addbranchprotection` would completely _overwrite_ the current branch protection settings to reduce them to the strict minimum defaults (i.e. "require 1 approval", and all other settings turned off)
</details>

The improved `set_branch_protection` action can now do much more though:
 - Set default branch protection settings (i.e. just "require a PR, with 1 approved review before merging") if the branch was not protected yet and no other parameter was passed (just like `addbranchprotection` did)
 - Set the default settings + just the settings provided as parameters if the branch was not protected yet and we pass explicit parameters (like `lock_branches: true` or `required_ci_checks: ['a', 'b', 'c']`)
 - Updates only the branch protection settings provided as parameters, while keeping the other settings unchanged, if the branch was already protected.

```
# If branch is not protected yet
set_branch_protection(repo, branch) # => protects the branch with the default settings (PR required, 1 approval)
set_branch_protection(repo, branch, allow_force_pushes: true) # => protects the branch with "PR required", "1 approval required" and "force pushes enabled"
set_branch_protection(repo, branch, required_approving_review_count: 3) # => protects the branch with "3 approval required"
set_branch_protection(repo, branch, required_approving_review_count: 3, required_ci_checks: ['buildkite/build', 'buildkite/test'], enforce_admins: true) # => protects the branch with "3 approval required", and the provided CI checks as required to go green before merge, even for admin users

# If branch is already protected
set_branch_protection(repo, branch) # => changes nothing, so it's basically a no-op
set_branch_protection(repo, branch, lock_branch: true) # => lock the branches, while keeping other existing branch protection settings (like required checks and so on) untouched
```

💡  In practice, this action and its improvements are intended especially to set `lock_branches: true` on the `release/*` branch just before we submit the final build to Apple/Google at the end of the sprint, so that people can't merge any last-minute PR into the `release/*` branch _after_ we've already submitted the build for review.

## `remove_branch_protection`

This action was previously named `removebranchprotection` (without any `_`). I just renamed it to `remove_branch_protection` for a nicer-looking name
 - I kept `removebranchprotection` as a backwards compatible but deprecated action, so that we don't need a new major version bump just yet though
 - I also simplified the implementation a bit, and added unit tests

## `copy_branch_protection(repo: from_branch:, to_branch:)`

This is a new action that copies existing branch protection onto a new branch.
 - If the `to_branch` was already protected, this will overwrite its branch protection settings completely with the values of the branch protection settings from the `from_branch`
 - If the `to_branch` was not protected yet, this will protect it with the same settings as the `from_branch`

💡  In practice, this action is intended especially to set up the branch protection settings of the `release/*` branch when we create it during code-freeze, by replicating the same settings on that new branch from the ones that are currently set on the `trunk` branch (including the required CI checks and number of approvals etc).

Currently in many app's `Fastfile` this is done by calling `setbranchprotection(repository: GHHELPER_REPO, branch: "release/#{new_version}")` at the end of the `code_freeze` lane. Once this lands, you'll be able to replace that call with `copy_branch_protection(repository: GHHELPER_REPO, from_branch: 'trunk', to_branch: "release/#{new_version|")`, and that will not only protect the newly created `release/*` branch, but also set the same required CI checks and every other settings as the ones set on `trunk`.

# Testing

Since I've added unit tests (specs) to all those actions, having the CI go green should be enough.