### PR TITLE
Test branch protection settings on GitHub PRs

### DIFF
--- a/some-random-change.txt
+++ b/some-random-change.txt
@@ -1,0 +1,1 @@
+Testing GitHub branch protection locking settings


### PR DESCRIPTION
This is a dummy PR to test the behavior of GitHub's branch protection regarding.

Scenarios being tested:

1. Release branch locking
    - The head branch (`test-branch-locking-change`) acts like a feature branch in an app repo
    - The `test-branch-locking` base branch acts like the `release/12.3` branch that would be currently in locked in read-only mode (Lock Branch set)
    - We want to test that GitHub will prevent us from merging the PR, telling us that the target branch is locked
2. Release finalization:
    - The head branch (`test-branch-locking-change`) acts like the `release/12.3` branch for an app repo
    - The `test-branch-locking` base branch acts like the `release/12.4` we're trying to backmerge into
    - We want to check that if `test-branch-locking-change` has some branch protection configured, with Lock Branch set to true but "Allow Deletions" also set to true, then that branch will be auto-deleted by GitHub once the PR is merged.