### PR TITLE
Adds ensure_current_branch_using_HEAD git helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Adds `ensure_current_branch_using_HEAD` git helper. [#520]
 
 ### Bug Fixes
 
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Deprecates `ensure_on_branch!` in favor of `ensure_current_branch_using_HEAD` [#520]
 
 ## 9.1.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -228,6 +228,8 @@ module Fastlane
         !Action.sh('git', 'branch', '--list', branch_name).empty?
       end
 
+      # DEPRECATED!
+      #
       # Ensure that we are on the expected branch, and abort if not.
       #
       # @param [String] branch_name The name of the branch we expect to be on
@@ -235,6 +237,7 @@ module Fastlane
       # @raise [UserError] Raises a user_error! and interrupts the lane if we are not on the expected branch.
       #
       def self.ensure_on_branch!(branch_name)
+        UI.important 'Warning: This helper is deprecated, please use Fastlane::Helper::GitHelper.ensure_current_branch_using_HEAD instead!'
         current_branch_name = Action.sh('git', 'symbolic-ref', '-q', 'HEAD')
         UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -193,6 +193,31 @@ module Fastlane
         Fastlane::Actions.git_branch_name_using_HEAD
       end
 
+      # Raises an exception and stop the lane execution if the repo is not on a specific branch
+      # It uses the the `current_git_branch` method which doesn't allow for environment variable modifications.
+      #
+      # Modified from fastlane's original `ensure_git_branch` implementation:
+      #
+      # https://github.com/fastlane/fastlane/blob/2.213.0/fastlane/lib/fastlane/actions/ensure_git_branch.rb
+      #
+      # Note that picking a proper name for this method is a bit hard as the following considerations need
+      # to be taken into account:
+      #
+      # 1. fastlane's original action is called `ensure_git_branch`.
+      # 2. We have a deprecated helper called `ensure_on_branch`. We could have used this name, but
+      # the implementation is different, so it'd be a breaking change for all clients.
+      # 3. This method relies on the `current_git_branch` helper which internally
+      # uses the `git_branch_name_using_HEAD` fastlane helper.
+      def self.ensure_current_branch_using_HEAD(branch)
+        current_branch = current_git_branch
+        branch_expr = /#{branch}/
+        if current_branch =~ branch_expr
+          UI.success("Git branch matches `#{branch}`, all good! 💪")
+        else
+          UI.user_error!("Git is not on a branch matching `#{branch}`. Current branch is `#{current_branch}`! Please ensure the repo is checked out to the correct branch.")
+        end
+      end
+
       # Checks if a branch exists locally.
       #
       # @param [String] branch_name The name of the branch to check for

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -66,6 +66,19 @@ describe Fastlane::Helper::GitHelper do
     expect(described_class.has_git_lfs?).to be false
   end
 
+  it 'can ensure currently on release branch' do
+    allow(described_class).to receive(:current_git_branch).and_return('release/23.5')
+    expect(described_class.ensure_current_branch_using_HEAD('^release/')).to be true
+  end
+
+  it 'fails for unexpected git branch' do
+    current_branch = 'trunk'
+    branch = '^release/'
+    expected_error = "Git is not on a branch matching `#{branch}`. Current branch is `#{current_branch}`! Please ensure the repo is checked out to the correct branch."
+    allow(described_class).to receive(:current_git_branch).and_return('trunk')
+    expect(described_class.ensure_current_branch_using_HEAD(branch)).to raise_error(FastlaneCore::Interface::FastlaneError, expected_error)
+  end
+
   context('commit(message:, files:)') do
     before(:each) do
       allow_fastlane_action_sh


### PR DESCRIPTION
## What does it do?

As part of the versioning changes @spencertransier worked on, we have started using [`ensure_git_branch`](https://docs.fastlane.tools/actions/ensure_git_branch/) fastlane action. Unfortunately this action relies on [`git_branch`](https://docs.fastlane.tools/actions/git_branch/#git_branch) action which uses environment variables to modify the result. This is not what we want in Buildkite because it'll ensure which branch the CI build is started from and ignore any branch switches.

We had to introduce our own helper `git_current_branch` in https://github.com/wordpress-mobile/release-toolkit/pull/463 to replace `git_branch`. Similarly, this PR adds `ensure_current_branch_using_HEAD` that we should use instead of `ensure_git_branch` so the release actions work as expected in Buildkite.

* I couldn't find a good name for this helper and I'd love some suggestions. I've explained some naming considerations in the code comments which I think will be useful regardless of which name we pick.
* Even though this is a modification of the official fastlane method, I thought having some unit tests would be helpful. Unfortunately I couldn't get the error case to work correctly - I am possibly missing something about the syntax - and I'd appreciate some help with that.
* I've also deprecated the `ensure_on_branch!` helper method. Since this is not an action, I am not entirely sure how it should be deprecated. I added a comment and started printing a warning, but please let me know if there is an official way to do this.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
