### PR TITLE
Deprecate the HAS_ALPHA_VERSION environment variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ _None_
 ### Internal Changes
 
 - Added deprecation notices to any actions or methods using the `PROJECT_ROOT_FOLDER` environment variable [#519]
-- Added optional `build_gradle_path` and `version_properties_paths` to actions that previously used the `PROJECT_ROOT_FOLDER` environment variable [#519]
+- Added optional `build_gradle_path` and `version_properties_paths` config items to actions that previously used the `PROJECT_ROOT_FOLDER` environment variable [#519]
+- Added deprecation notices to any actions or methods using the `HAS_ALPHA_VERSION` environment variable [#521]
+- Added optional `has_alpha_version` config items to actions that previously used the `HAS_ALPHA_VERSION` environment variable [#521]
+
 
 ## 9.1.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -10,6 +10,7 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         # Checkout default branch and update
         default_branch = params[:default_branch]
@@ -18,19 +19,22 @@ module Fastlane
         # Check versions
         release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         message = "The following current version has been detected: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n"
         alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         message << "The following Alpha version has been detected: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
 
         # Check branch
         app_version = Fastlane::Helper::Android::VersionHelper.get_public_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless !params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version)
 
@@ -64,12 +68,14 @@ module Fastlane
         UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::GitHelper.checkout_and_pull(release: version)
         release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         message << "Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}.\n"
         alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         message << "and Alpha Version: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
         [release_version, alpha_release_version]
@@ -111,6 +117,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -11,10 +11,11 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         message = ''
-        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version(build_gradle_path, version_properties_path) unless !params[:beta] && !params[:final]
-        alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(build_gradle_path, version_properties_path) if params[:alpha]
+        beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version(build_gradle_path, version_properties_path, has_alpha_version) unless !params[:beta] && !params[:final]
+        alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(build_gradle_path, version_properties_path, has_alpha_version) if params[:alpha]
 
         UI.user_error!("Can't build a final release out of this branch because it's configured as a beta release!") if params[:final] && Fastlane::Helper::Android::VersionHelper.is_beta_version?(beta_version)
 
@@ -73,6 +74,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -11,14 +11,17 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         new_version_beta = Fastlane::Helper::Android::VersionHelper.calc_next_beta_version(current_version, current_version_alpha)
         new_version_alpha = current_version_alpha.nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(new_version_beta, current_version_alpha)
@@ -34,7 +37,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           new_version_beta,
           new_version_alpha,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         UI.message 'Done!'
 
@@ -65,6 +69,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -11,14 +11,17 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         final_version = Fastlane::Helper::Android::VersionHelper.calc_final_release_version(current_version, current_version_alpha)
 
@@ -32,7 +35,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           final_version,
           current_version_alpha,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         UI.message 'Done!'
 
@@ -63,6 +67,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -8,12 +8,14 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         Fastlane::Helper::GitHelper.create_branch("release/#{params[:version_name]}", from: params[:previous_version_name])
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code]) # NOTE: this just puts the name/code values in a tuple, unchanged (no actual calc/bumping)
         new_release_branch = "release/#{params[:version_name]}"
@@ -28,7 +30,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           new_version,
           nil,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         UI.message 'Done!'
 
@@ -73,6 +76,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -10,6 +10,7 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         default_branch = params[:default_branch]
         other_action.ensure_git_branch(branch: default_branch)
@@ -17,16 +18,19 @@ module Fastlane
         # Create new configuration
         new_short_version = Fastlane::Helper::Android::VersionHelper.bump_version_release(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         new_version_beta = Fastlane::Helper::Android::VersionHelper.calc_next_release_version(current_version, current_version_alpha)
         new_version_alpha = current_version_alpha.nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(new_version_beta, current_version_alpha)
@@ -50,7 +54,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           new_version_beta,
           new_version_alpha,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         Fastlane::Helper::Android::GitHelper.commit_version_bump(
           build_gradle_path,
@@ -85,6 +90,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -13,6 +13,7 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         # Checkout default branch and update
         default_branch = params[:default_branch]
@@ -21,11 +22,13 @@ module Fastlane
         # Create versions
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         current_alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         next_version = Fastlane::Helper::Android::VersionHelper.calc_next_release_version(current_version, current_alpha_version)
         next_alpha_version = current_alpha_version.nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(next_version, current_alpha_version)
@@ -47,7 +50,8 @@ module Fastlane
         # Return the current version
         Fastlane::Helper::Android::VersionHelper.get_public_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
       end
 
@@ -83,6 +87,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -13,7 +13,8 @@ module Fastlane
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version(
           params[:build_gradle_path],
-          params[:version_properties_path]
+          params[:version_properties_path],
+          params[:has_alpha_version]
         )
         message = "Completing code freeze for: #{version}\n"
         if params[:skip_confirm]
@@ -54,6 +55,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
@@ -9,7 +9,8 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           params[:build_gradle_path],
-          params[:version_properties_path]
+          params[:version_properties_path],
+          params[:has_alpha_version]
         )
         Fastlane::Helper::Android::VersionHelper.is_hotfix?(version)
       end
@@ -35,6 +36,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -17,7 +17,8 @@ module Fastlane
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version(
           params[:build_gradle_path],
-          params[:version_properties_path]
+          params[:version_properties_path],
+          params[:has_alpha_version]
         )
         message = "Finalizing release: #{version}\n"
         if params[:skip_confirm]
@@ -61,6 +62,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
@@ -5,7 +5,8 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           params[:build_gradle_path],
-          params[:version_properties_path]
+          params[:version_properties_path],
+          params[:has_alpha_version]
         )
       end
 
@@ -30,6 +31,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
@@ -5,7 +5,8 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         Fastlane::Helper::Android::VersionHelper.get_public_version(
           params[:build_gradle_path],
-          params[:version_properties_path]
+          params[:version_properties_path],
+          params[:has_alpha_version]
         )
       end
 
@@ -30,6 +31,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
@@ -5,7 +5,8 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         Fastlane::Helper::Android::VersionHelper.get_release_version(
           params[:build_gradle_path],
-          params[:version_properties_path]
+          params[:version_properties_path],
+          params[:has_alpha_version]
         )
       end
 
@@ -30,6 +31,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -7,14 +7,17 @@ module Fastlane
 
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
+        has_alpha_version = params[:has_alpha_version]
 
         release_ver = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         alpha_ver = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path,
-          version_properties_path
+          version_properties_path,
+          has_alpha_version
         )
         Fastlane::Helper::GitHelper.create_tag(release_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME])
         Fastlane::Helper::GitHelper.create_tag(alpha_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]) unless alpha_ver.nil? || (params[:tag_alpha] == false)
@@ -46,6 +49,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :has_alpha_version,
+                                       description: 'Whether the app has an alpha version',
+                                       type: Boolean,
                                        optional: true),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -49,7 +49,7 @@ module Fastlane
         def self.get_release_version(build_gradle_path = nil, version_properties_path = nil, has_alpha_version = nil)
           return get_version_from_properties if File.exist?(version_properties_file(version_properties_path))
 
-          UI.important('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
+          UI.deprecated('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
           has_alpha_version_nil = ENV['HAS_ALPHA_VERSION'].nil? && has_alpha_version.nil?
 
           section = has_alpha_version_nil ? 'defaultConfig' : 'vanilla {'
@@ -93,7 +93,7 @@ module Fastlane
         def self.get_alpha_version(build_gradle_path = nil, version_properties_path = nil, has_alpha_version = nil)
           return get_version_from_properties(is_alpha: true) if File.exist?(version_properties_file(version_properties_path))
 
-          UI.important('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
+          UI.deprecated('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
           return nil if ENV['HAS_ALPHA_VERSION'].nil? && has_alpha_version.nil?
 
           section = 'defaultConfig'
@@ -327,7 +327,7 @@ module Fastlane
             end
             File.write(version_properties_file(version_properties_path), content)
           else
-            UI.important('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
+            UI.deprecated('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
             has_alpha_version_nil = ENV['HAS_ALPHA_VERSION'].nil? && has_alpha_version.nil?
 
             self.update_version(new_version_beta, has_alpha_version_nil ? 'defaultConfig' : 'vanilla {')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -30,10 +30,11 @@ module Fastlane
         #         - If this version is a hotfix (more than 2 parts and 3rd part is non-zero), returns the "X.Y.Z" formatted string
         #         - Otherwise (not a hotfix / 3rd part of version is 0), returns "X.Y" formatted version number
         #
-        def self.get_public_version(build_gradle_path = nil, version_properties_path = nil)
+        def self.get_public_version(build_gradle_path = nil, version_properties_path = nil, has_alpha_version = nil)
           version = get_release_version(
             build_gradle_path,
-            version_properties_path
+            version_properties_path,
+            has_alpha_version
           )
           vp = get_version_parts(version[VERSION_NAME])
           return "#{vp[MAJOR_NUMBER]}.#{vp[MINOR_NUMBER]}" unless is_hotfix?(version)
@@ -45,10 +46,13 @@ module Fastlane
         #
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #
-        def self.get_release_version(build_gradle_path = nil, version_properties_path = nil)
+        def self.get_release_version(build_gradle_path = nil, version_properties_path = nil, has_alpha_version = nil)
           return get_version_from_properties if File.exist?(version_properties_file(version_properties_path))
 
-          section = ENV['HAS_ALPHA_VERSION'].nil? ? 'defaultConfig' : 'vanilla {'
+          UI.important('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
+          has_alpha_version_nil = ENV['HAS_ALPHA_VERSION'].nil? && has_alpha_version.nil?
+
+          section = has_alpha_version_nil ? 'defaultConfig' : 'vanilla {'
           gradle_path = self.gradle_path(build_gradle_path)
           name = get_version_name_from_gradle_file(gradle_path, section)
           code = get_version_build_from_gradle_file(gradle_path, section)
@@ -86,10 +90,11 @@ module Fastlane
         # @return [Hash] A hash with 2 keys `"name"` and `"code"` containing the extracted version name and code, respectively,
         #                or `nil` if `$HAS_ALPHA_VERSION` is not defined.
         #
-        def self.get_alpha_version(build_gradle_path = nil, version_properties_path = nil)
+        def self.get_alpha_version(build_gradle_path = nil, version_properties_path = nil, has_alpha_version = nil)
           return get_version_from_properties(is_alpha: true) if File.exist?(version_properties_file(version_properties_path))
 
-          return nil if ENV['HAS_ALPHA_VERSION'].nil?
+          UI.important('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
+          return nil if ENV['HAS_ALPHA_VERSION'].nil? && has_alpha_version.nil?
 
           section = 'defaultConfig'
           gradle_path = self.gradle_path(build_gradle_path)
@@ -286,11 +291,12 @@ module Fastlane
         #
         # @return [String] The next release version name to use after bumping the currently used release version.
         #
-        def self.bump_version_release(build_gradle_path = nil, version_properties_path = nil)
+        def self.bump_version_release(build_gradle_path = nil, version_properties_path = nil, has_alpha_version = nil)
           # Bump release
           current_version = self.get_release_version(
             build_gradle_path,
-            version_properties_path
+            version_properties_path,
+            has_alpha_version
           )
           UI.message("Current version: #{current_version[VERSION_NAME]}")
           new_version = calc_next_release_base_version(current_version)
@@ -305,7 +311,7 @@ module Fastlane
         # @param [Hash] new_version_beta The version hash for the beta, containing values for keys "name" and "code"
         # @param [Hash] new_version_alpha The version hash for the alpha , containing values for keys "name" and "code"
         #
-        def self.update_versions(new_version_beta, new_version_alpha, version_properties_path = nil)
+        def self.update_versions(new_version_beta, new_version_alpha, version_properties_path = nil, has_alpha_version = nil)
           if File.exist?(version_properties_file(version_properties_path))
             replacements = {
               versionName: (new_version_beta || {})[VERSION_NAME],
@@ -321,7 +327,10 @@ module Fastlane
             end
             File.write(version_properties_file(version_properties_path), content)
           else
-            self.update_version(new_version_beta, ENV['HAS_ALPHA_VERSION'].nil? ? 'defaultConfig' : 'vanilla {')
+            UI.important('The `HAS_ALPHA_VERSION` environment variable is deprecated and will be removed in a future release. Please pass in an argument for `has_alpha_version` instead.') unless ENV['HAS_ALPHA_VERSION'].nil?
+            has_alpha_version_nil = ENV['HAS_ALPHA_VERSION'].nil? && has_alpha_version.nil?
+
+            self.update_version(new_version_beta, has_alpha_version_nil ? 'defaultConfig' : 'vanilla {')
             self.update_version(new_version_alpha, 'defaultConfig') unless new_version_alpha.nil?
           end
         end


### PR DESCRIPTION
## What does it do?
This PR removes the reliance on the `HAS_ALPHA_VERSION` environment variable across the Release Toolkit actions and helpers.

I added deprecation warnings to the root methods that use `HAS_ALPHA_VERSION`. Then, I added an optional parameter/config items to any methods/actions that directly or indirectly need to access that environment variable. 

Making the added parameters and config items optional everywhere means that this is not a breaking change.

Fixes https://github.com/wordpress-mobile/release-toolkit/issues/277

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [X] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
