### PR TITLE
Deprecate the HAS_ALPHA_VERSION environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ _None_
 
 - Added deprecation notices to any actions or methods using the `PROJECT_ROOT_FOLDER` environment variable [#519]
 - Added deprecation notices to any actions or methods using the `PROJECT_NAME` environment variable [#519]
-- Added optional `build_gradle_path` and `version_properties_path` to actions that previously used the `PROJECT_ROOT_FOLDER` environment variable [#519]
+- Added deprecation notices to any actions or methods using the `HAS_ALPHA_VERSION` environment variable [#522]
+- Added optional `build_gradle_path` and `version_properties_path` config items to actions that previously used the `PROJECT_ROOT_FOLDER` and `PROJECT_NAME` environment variables [#519]
+- Added optional `has_alpha_version` config item to actions that previously used the `HAS_ALPHA_VERSION` environment variable [#522]
 
 ## 9.1.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -8,6 +8,7 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -20,19 +21,22 @@ module Fastlane
         # Check versions
         release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         message = "The following current version has been detected: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n"
         alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         message << "The following Alpha version has been detected: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
 
         # Check branch
         app_version = Fastlane::Helper::Android::VersionHelper.get_public_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         UI.user_error!("#{message}Release branch for version #{app_version} doesn't exist. Abort.") unless !params[:base_version].nil? || Fastlane::Helper::GitHelper.checkout_and_pull(release: app_version)
 
@@ -66,12 +70,14 @@ module Fastlane
         UI.user_error!("Release branch for version #{version} doesn't exist. Abort.") unless Fastlane::Helper::GitHelper.checkout_and_pull(release: version)
         release_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         message << "Looking at branch release/#{version} as requested by user. Detected version: #{release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}.\n"
         alpha_release_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         message << "and Alpha Version: #{alpha_release_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]}\n" unless alpha_release_version.nil?
         [release_version, alpha_release_version]
@@ -122,6 +128,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -9,6 +9,7 @@ module Fastlane
 
         Fastlane::Helper::GitHelper.ensure_on_branch!('release') unless other_action.is_ci
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -18,13 +19,15 @@ module Fastlane
         unless !params[:beta] && !params[:final]
           beta_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
             build_gradle_path: build_gradle_path,
-            version_properties_path: version_properties_path
+            version_properties_path: version_properties_path,
+            has_alpha_version: has_alpha_version
           )
         end
         if params[:alpha]
           alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
             build_gradle_path: build_gradle_path,
-            version_properties_path: version_properties_path
+            version_properties_path: version_properties_path,
+            has_alpha_version: has_alpha_version
           )
         end
 
@@ -94,6 +97,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -9,6 +9,7 @@ module Fastlane
 
         Fastlane::Helper::GitHelper.ensure_on_branch!('release')
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -16,11 +17,13 @@ module Fastlane
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         new_version_beta = Fastlane::Helper::Android::VersionHelper.calc_next_beta_version(current_version, current_version_alpha)
         new_version_alpha = current_version_alpha.nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(new_version_beta, current_version_alpha)
@@ -36,7 +39,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           new_version_beta,
           new_version_alpha,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         UI.message 'Done!'
 
@@ -76,6 +80,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -9,6 +9,7 @@ module Fastlane
 
         Fastlane::Helper::GitHelper.ensure_on_branch!('release')
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -16,11 +17,13 @@ module Fastlane
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         final_version = Fastlane::Helper::Android::VersionHelper.calc_final_release_version(current_version, current_version_alpha)
 
@@ -34,7 +37,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           final_version,
           current_version_alpha,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         UI.message 'Done!'
 
@@ -74,6 +78,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -6,6 +6,7 @@ module Fastlane
 
         require_relative '../../helper/android/android_git_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -15,7 +16,8 @@ module Fastlane
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         new_version = Fastlane::Helper::Android::VersionHelper.calc_next_hotfix_version(params[:version_name], params[:version_code]) # NOTE: this just puts the name/code values in a tuple, unchanged (no actual calc/bumping)
         new_release_branch = "release/#{params[:version_name]}"
@@ -30,7 +32,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           new_version,
           nil,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         UI.message 'Done!'
 
@@ -84,6 +87,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -8,6 +8,7 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -19,16 +20,19 @@ module Fastlane
         # Create new configuration
         new_short_version = Fastlane::Helper::Android::VersionHelper.bump_version_release(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
 
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         current_version_alpha = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         new_version_beta = Fastlane::Helper::Android::VersionHelper.calc_next_release_version(current_version, current_version_alpha)
         new_version_alpha = current_version_alpha.nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(new_version_beta, current_version_alpha)
@@ -52,7 +56,8 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           new_version_beta,
           new_version_alpha,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         Fastlane::Helper::Android::GitHelper.commit_version_bump(
           build_gradle_path: build_gradle_path,
@@ -96,6 +101,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -11,6 +11,7 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -23,11 +24,13 @@ module Fastlane
         # Create versions
         current_version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         current_alpha_version = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         next_version = Fastlane::Helper::Android::VersionHelper.calc_next_release_version(current_version, current_alpha_version)
         next_alpha_version = current_alpha_version.nil? ? nil : Fastlane::Helper::Android::VersionHelper.calc_next_alpha_version(next_version, current_alpha_version)
@@ -49,7 +52,8 @@ module Fastlane
         # Return the current version
         Fastlane::Helper::Android::VersionHelper.get_public_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
       end
 
@@ -94,6 +98,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -11,6 +11,7 @@ module Fastlane
         current_branch = Fastlane::Helper::GitHelper.current_git_branch
         UI.user_error!("Current branch - '#{current_branch}' - is not a release branch. Abort.") unless current_branch.start_with?('release/')
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -18,7 +19,8 @@ module Fastlane
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         message = "Completing code freeze for: #{version}\n"
         if params[:skip_confirm]
@@ -68,6 +70,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
@@ -8,6 +8,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -15,7 +16,8 @@ module Fastlane
 
         version = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         Fastlane::Helper::Android::VersionHelper.is_hotfix?(version)
       end
@@ -50,6 +52,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -15,6 +15,7 @@ module Fastlane
         current_branch = Fastlane::Helper::GitHelper.current_git_branch
         UI.user_error!("Current branch - '#{current_branch}' - is not a release branch. Abort.") unless current_branch.start_with?('release/')
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -22,7 +23,8 @@ module Fastlane
 
         version = Fastlane::Helper::Android::VersionHelper.get_public_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         message = "Finalizing release: #{version}\n"
         if params[:skip_confirm]
@@ -75,6 +77,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
@@ -4,6 +4,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -11,7 +12,8 @@ module Fastlane
 
         Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
       end
 
@@ -45,6 +47,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
@@ -4,6 +4,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -11,7 +12,8 @@ module Fastlane
 
         Fastlane::Helper::Android::VersionHelper.get_public_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
       end
 
@@ -45,6 +47,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
@@ -4,6 +4,7 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -11,7 +12,8 @@ module Fastlane
 
         Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
       end
 
@@ -45,6 +47,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -5,6 +5,7 @@ module Fastlane
         require_relative '../../helper/android/android_version_helper'
         require_relative '../../helper/android/android_git_helper'
 
+        has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]
         project_name = params[:project_name]
         build_gradle_path = params[:build_gradle_path] || (File.join(project_root_folder || '.', project_name, 'build.gradle') unless project_name.nil?)
@@ -12,11 +13,13 @@ module Fastlane
 
         release_ver = Fastlane::Helper::Android::VersionHelper.get_release_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         alpha_ver = Fastlane::Helper::Android::VersionHelper.get_alpha_version(
           build_gradle_path: build_gradle_path,
-          version_properties_path: version_properties_path
+          version_properties_path: version_properties_path,
+          has_alpha_version: has_alpha_version
         )
         Fastlane::Helper::GitHelper.create_tag(release_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME])
         Fastlane::Helper::GitHelper.create_tag(alpha_ver[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]) unless alpha_ver.nil? || (params[:tag_alpha] == false)
@@ -57,6 +60,7 @@ module Fastlane
                                                                project_root_folder]),
           Fastlane::Helper::Deprecated.project_root_folder_config_item,
           Fastlane::Helper::Deprecated.project_name_config_item,
+          Fastlane::Helper::Deprecated.has_alpha_version_config_item,
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/deprecated.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/deprecated.rb
@@ -2,6 +2,26 @@ module Fastlane
   module Helper
     # A helper class to store deprecated methods and actions
     class Deprecated
+      # Creates a has_alpha_version Fastlane ConfigItem
+      #
+      # @return [FastlaneCore::ConfigItem] The Fastlane ConfigItem for the `HAS_ALPHA_VERSION` environment variable
+      #
+      def self.has_alpha_version_config_item
+        verify_block = proc do
+          UI.deprecated('DEPRECATED: The HAS_ALPHA_VERSION environment variable and config item are deprecated and will be removed in a future version of the Release Toolkit.')
+        end
+
+        FastlaneCore::ConfigItem.new(
+          key: :has_alpha_version,
+          env_name: 'HAS_ALPHA_VERSION',
+          description: 'A boolean for whether there is an alpha version of the app or not',
+          deprecated: true,
+          optional: true,
+          verify_block: verify_block,
+          type: Boolean
+        )
+      end
+
       # Creates a project_root_folder Fastlane ConfigItem
       #
       # @return [FastlaneCore::ConfigItem] The Fastlane ConfigItem for the `PROJECT_ROOT_FOLDER` environment variable

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -83,7 +83,7 @@ describe Fastlane::Helper::Android::VersionHelper do
         allow(File).to receive(:exist?).with(VERSION_PROPERTIES_PATH).and_return(true)
         allow(File).to receive(:read).with(VERSION_PROPERTIES_PATH).and_return(original_content)
         expect(File).to receive(:write).with(VERSION_PROPERTIES_PATH, expected_content)
-        subject.update_versions(new_beta_version, nil, version_properties_path: VERSION_PROPERTIES_PATH)
+        subject.update_versions(new_beta_version, nil, version_properties_path: VERSION_PROPERTIES_PATH, has_alpha_version: nil)
       end
 
       it 'updates both the main and alpha versions if alpha provided' do
@@ -99,7 +99,7 @@ describe Fastlane::Helper::Android::VersionHelper do
         allow(File).to receive(:exist?).with(VERSION_PROPERTIES_PATH).and_return(true)
         allow(File).to receive(:read).with(VERSION_PROPERTIES_PATH).and_return(original_content)
         expect(File).to receive(:write).with(VERSION_PROPERTIES_PATH, expected_content)
-        subject.update_versions(new_beta_version, new_alpha_version, version_properties_path: VERSION_PROPERTIES_PATH)
+        subject.update_versions(new_beta_version, new_alpha_version, version_properties_path: VERSION_PROPERTIES_PATH, has_alpha_version: nil)
       end
     end
   end


### PR DESCRIPTION
## What does it do?
This PR deprecatesthe `HAS_ALPHA_VERSION` environment variable across the Release Toolkit actions and helpers.

I added a deprecated config item for the actions need `HAS_ALPHA_VERSION`. That config item value can then be passed down to the `android_version_helper` methods that use `HAS_ALPHA_VERSION`. 

Fixes https://github.com/wordpress-mobile/release-toolkit/issues/277

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [X] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
