### PR TITLE
Add versioning method to check if a release is a hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _None_
 ### New Features
 
 - Added optional `has_alpha_version` config item to actions that previously used the `HAS_ALPHA_VERSION` environment variable [#522]
+- Added a versioning method to check if a release is a hotfix [#530]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/abstract_version_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/abstract_version_calculator.rb
@@ -79,6 +79,16 @@ module Fastlane
 
           new_version
         end
+
+        # Calculate whether a release is a hotfix release.
+        #
+        # @param [AppVersion] version The version to check.
+        #
+        # @return [Boolean] Whether the release is a hotfix release.
+        #
+        def release_is_hotfix(version:)
+          version.patch.positive?
+        end
       end
     end
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/abstract_version_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/abstract_version_calculator.rb
@@ -86,7 +86,7 @@ module Fastlane
         #
         # @return [Boolean] Whether the release is a hotfix release.
         #
-        def release_is_hotfix(version:)
+        def release_is_hotfix?(version:)
           version.patch.positive?
         end
       end

--- a/spec/abstract_version_calculator_spec.rb
+++ b/spec/abstract_version_calculator_spec.rb
@@ -5,8 +5,8 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionCalculator do
     it 'increments the major version by 1 and sets the minor, patch, and build number to 0' do
       version = Fastlane::Models::AppVersion.new(19, 20, 21, 22)
       bumped_version = described_class.new.next_major_version(version: version)
-      # Test that the original version is not modified
 
+      # Test that the original version is not modified
       expect(version.to_s).to eq('19.20.21.22')
       expect(bumped_version.to_s).to eq('20.0.0.0')
     end
@@ -14,8 +14,8 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionCalculator do
     it 'increments the minor version by 1 and sets the patch and build number to 0' do
       version = Fastlane::Models::AppVersion.new(19, 20, 21, 22)
       bumped_version = described_class.new.next_minor_version(version: version)
-      # Test that the original version is not modified
 
+      # Test that the original version is not modified
       expect(version.to_s).to eq('19.20.21.22')
       expect(bumped_version.to_s).to eq('19.21.0.0')
     end
@@ -23,8 +23,8 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionCalculator do
     it 'increments the patch version by 1 and sets the build number to 0' do
       version = Fastlane::Models::AppVersion.new(19, 20, 21, 22)
       bumped_version = described_class.new.next_patch_version(version: version)
-      # Test that the original version is not modified
 
+      # Test that the original version is not modified
       expect(version.to_s).to eq('19.20.21.22')
       expect(bumped_version.to_s).to eq('19.20.22.0')
     end
@@ -32,8 +32,8 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionCalculator do
     it 'increments the build number by 1' do
       version = Fastlane::Models::AppVersion.new(19, 20, 21, 22)
       bumped_version = described_class.new.next_build_number(version: version)
-      # Test that the original version is not modified
 
+      # Test that the original version is not modified
       expect(version.to_s).to eq('19.20.21.22')
       expect(bumped_version.to_s).to eq('19.20.21.23')
     end
@@ -43,10 +43,26 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionCalculator do
     it 'decrements the patch version by 1 and sets the build number to 0' do
       version = Fastlane::Models::AppVersion.new(13, 2, 1, 3)
       previous_version = described_class.new.previous_patch_version(version: version)
-      # Test that the original version is not modified
 
+      # Test that the original version is not modified
       expect(version.to_s).to eq('13.2.1.3')
       expect(previous_version.to_s).to eq('13.2.0.0')
+    end
+  end
+
+  describe 'calculates whether a release is a hotfix' do
+    it 'calculates that a hotfix release version is a hotfix' do
+      version = Fastlane::Models::AppVersion.new(1, 0, 3, 0)
+      hotfix = described_class.new.release_is_hotfix(version: version)
+
+      expect(hotfix).to be true
+    end
+
+    it 'calculates that a non-hotfix release version is not a hotfix' do
+      version = Fastlane::Models::AppVersion.new(1, 2, 0, 4)
+      hotfix = described_class.new.release_is_hotfix(version: version)
+
+      expect(hotfix).to be false
     end
   end
 end

--- a/spec/abstract_version_calculator_spec.rb
+++ b/spec/abstract_version_calculator_spec.rb
@@ -53,14 +53,14 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionCalculator do
   describe 'calculates whether a release is a hotfix' do
     it 'calculates that a hotfix release version is a hotfix' do
       version = Fastlane::Models::AppVersion.new(1, 0, 3, 0)
-      hotfix = described_class.new.release_is_hotfix(version: version)
+      hotfix = described_class.new.release_is_hotfix?(version: version)
 
       expect(hotfix).to be true
     end
 
     it 'calculates that a non-hotfix release version is not a hotfix' do
       version = Fastlane::Models::AppVersion.new(1, 2, 0, 4)
-      hotfix = described_class.new.release_is_hotfix(version: version)
+      hotfix = described_class.new.release_is_hotfix?(version: version)
 
       expect(hotfix).to be false
     end


### PR DESCRIPTION
## What does it do?

Fixes https://github.com/wordpress-mobile/release-toolkit/issues/527 by adding a method to the new versioning tooling to check whether a version number is a hotfix. `ios_current_branch_is_hotfix` will be deprecated soon. 

## How to Test: 
1. In the DayOne-Apple repo, check out the `test/release-is-hotfix` branch
2. Run `bundle install` so it correctly points to this RT development branch
3. Run `bundle exec fastlane test_hotfix_check`
4. The output should be :

```
Driving the lane 'test_hotfix_check' 🚀
Is the iOS release version `2024.1` a hotfix? - false
Is the Mac release version `2024.1.1` a hotfix? - true
fastlane.tools finished successfully 🎉
```

For an example of what code that test lane is running, see: https://github.com/bloom/DayOne-Apple/commit/942133b3f9c900d2a3411da880ef2fb0030fe204#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688 


## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [X] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
