### PR TITLE
Replace two GitHelper methods with Fastlane actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ _None_
 ### Internal Changes
 
 - Added deprecation notices to any actions or methods using the `HAS_ALPHA_VERSION` environment variable [#522]
+- Added a deprecation notice to the `GitHelper.ensure_on_branch!` method [#531]
+- Added a deprecation notice to the `GitHelper.update_submodules` method [#531]
 
 ## 9.2.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -7,7 +7,8 @@ module Fastlane
 
         UI.user_error!("Can't build beta and final at the same time!") if params[:final] && params[:beta]
 
-        Fastlane::Helper::GitHelper.ensure_on_branch!('release') unless other_action.is_ci
+        # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
+        ensure_git_branch(branch: '^release/') unless other_action.is_ci
 
         has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -7,7 +7,8 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper'
         require_relative '../../helper/android/android_version_helper'
 
-        Fastlane::Helper::GitHelper.ensure_on_branch!('release')
+        # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
+        ensure_git_branch(branch: '^release/')
 
         has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -7,7 +7,8 @@ module Fastlane
         require_relative '../../helper/android/android_git_helper'
         require_relative '../../helper/android/android_version_helper'
 
-        Fastlane::Helper::GitHelper.ensure_on_branch!('release')
+        # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
+        ensure_git_branch(branch: '^release/')
 
         has_alpha_version = params[:has_alpha_version]
         project_root_folder = params[:project_root_folder]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
@@ -23,7 +23,10 @@ module Fastlane
 
         # Update submodules then lint translations
         unless params[:lint_task].nil? || params[:lint_task].empty?
-          Fastlane::Helper::GitHelper.update_submodules
+          git_submodule_update(
+            recursive: true,
+            init: true
+          )
           Action.sh('./gradlew', params[:lint_task])
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -7,7 +7,8 @@ module Fastlane
         require_relative '../../helper/ios/ios_git_helper'
         require_relative '../../helper/ios/ios_version_helper'
 
-        Fastlane::Helper::GitHelper.ensure_on_branch!('release')
+        # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
+        ensure_git_branch(branch: '^release/')
         create_config
         show_config
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -72,7 +72,7 @@ module Fastlane
       # @deprecated This method is going to be removed soon. Fastlane has a built-in `git_submodule_update` action that can be used instead.
       #
       def self.update_submodules
-        UI.message("DEPRECATED: The `update_submodules` Release Toolkit method will be removed soon. Please use Fastlane's `git_submodule_update` action instead.")
+        UI.deprecated("The `update_submodules` method will soon be removed from `release-toolkit`. Please use fastlane's `git_submodule_update` action instead.")
         Action.sh('git', 'submodule', 'update', '--init', '--recursive')
       end
 
@@ -219,7 +219,7 @@ module Fastlane
       #             See https://github.com/fastlane/fastlane/pull/21597 for more details.
       #
       def self.ensure_on_branch!(branch_name)
-        UI.message("DEPRECATED: The `ensure_on_branch!` Release Toolkit method will be removed soon. Please use Fastlane's `ensure_git_branch` action instead.")
+        UI.deprecated("The `ensure_on_branch!` method will soon be removed from `release-toolkit`. Please use fastlane's `ensure_git_branch` action (+ potentially set `FL_GIT_BRANCH_DONT_USE_ENV_VARS=true`) instead.")
         current_branch_name = Action.sh('git', 'symbolic-ref', '-q', 'HEAD')
         UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -69,10 +69,10 @@ module Fastlane
 
       # Update every submodule in the current git repository
       #
-      # @deprecated This method is going to be removed soon because Fastlane has a built-in `git_submodule_update` that can be used instead
+      # @deprecated This method is going to be removed soon. Fastlane has a built-in `git_submodule_update` action that can be used instead.
       #
       def self.update_submodules
-        UI.message("DEPRECATED: This method will be removed soon. Please use Fastlane's `git_submodule_update` action instead.")
+        UI.message("DEPRECATED: The `update_submodules` Release Toolkit method will be removed soon. Please use Fastlane's `git_submodule_update` action instead.")
         Action.sh('git', 'submodule', 'update', '--init', '--recursive')
       end
 
@@ -212,7 +212,10 @@ module Fastlane
       #
       # @raise [UserError] Raises a user_error! and interrupts the lane if we are not on the expected branch.
       #
+      # @deprecated This method is going to be removed soon. Fastlane has a built-in `ensure_git_branch` action that can be used instead.
+      #
       def self.ensure_on_branch!(branch_name)
+        UI.message("DEPRECATED: The `ensure_on_branch!` Release Toolkit method will be removed soon. Please use Fastlane's `ensure_git_branch` action instead.")
         current_branch_name = Action.sh('git', 'symbolic-ref', '-q', 'HEAD')
         UI.user_error!("This command works only on #{branch_name} branch") unless current_branch_name.include?(branch_name)
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -69,7 +69,10 @@ module Fastlane
 
       # Update every submodule in the current git repository
       #
+      # @deprecated This method is going to be removed soon because Fastlane has a built-in `git_submodule_update` that can be used instead
+      #
       def self.update_submodules
+        UI.message("DEPRECATED: This method will be removed soon. Please use Fastlane's `git_submodule_update` action instead.")
         Action.sh('git', 'submodule', 'update', '--init', '--recursive')
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -213,6 +213,10 @@ module Fastlane
       # @raise [UserError] Raises a user_error! and interrupts the lane if we are not on the expected branch.
       #
       # @deprecated This method is going to be removed soon. Fastlane has a built-in `ensure_git_branch` action that can be used instead.
+      #             After updating to Fastlane version `2.217.0` or later, the `FL_GIT_BRANCH_DONT_USE_ENV_VARS` environment
+      #             variable can be set to `true` to disable the use of environment variables for the `git_branch` action that
+      #             `ensure_git_branch` relies on. This will make `ensure_git_branch` work as expected in CI environments.
+      #             See https://github.com/fastlane/fastlane/pull/21597 for more details.
       #
       def self.ensure_on_branch!(branch_name)
         UI.message("DEPRECATED: The `ensure_on_branch!` Release Toolkit method will be removed soon. Please use Fastlane's `ensure_git_branch` action instead.")


### PR DESCRIPTION
## What does it do?

This PR deprecates these two methods in the GitHelper module and replaces their uses with built-in Fastlane actions: 
- `update_submodules` replaced by `git_submodule_update`
- `ensure_on_branch!` replaced by `ensure_git_branch`

I'm deprecating the methods instead of removing them because we have used some of the GitHelper methods directly instead of through Release Toolkit actions. 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [X] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
