### PR TITLE
Add `create_branch` and `checkout_and_pull` actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ _None_
 ### New Features
 
 - Added optional `build_gradle_path` and `version_properties_path` config items to actions that previously used the `PROJECT_ROOT_FOLDER` environment variable [#519]
+- Added a `checkout_and_pull` git action [#532]
+- Added a `create_branch` git action [#532]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/checkout_and_pull.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/checkout_and_pull.rb
@@ -1,0 +1,39 @@
+require 'fastlane/action'
+require_relative '../../helper/git_helper'
+module Fastlane
+  module Actions
+    class CheckoutAndPullAction < Action
+      def self.run(params)
+        branch_name = params[:branch_name]
+
+        Fastlane::Helper::GitHelper.checkout_and_pull(branch_name)
+      end
+
+      def self.description
+        'Checkout and pull the specified branch'
+      end
+
+      def self.return_value
+        'True if it succeeded switching and pulling, false if there was an error during the switch or pull.'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :branch_name,
+                                       env_name: 'BRANCH_NAME_TO_CHECKOUT_AND_PULL',
+                                       description: 'The name of the branch to checkout and pull',
+                                       optional: false,
+                                       type: String),
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_branch.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_branch.rb
@@ -1,0 +1,45 @@
+require 'fastlane/action'
+require_relative '../../helper/git_helper'
+module Fastlane
+  module Actions
+    class CreateBranchAction < Action
+      def self.run(params)
+        branch_name = params[:branch_name]
+        from = params[:from]
+
+        Fastlane::Helper::GitHelper.create_branch(branch_name, from: from)
+      end
+
+      def self.description
+        'Create a new branch named `branch_name`, cutting it from branch/commit/tag `from`'
+      end
+
+      def self.details
+        'If the branch with that name already exists, it will instead switch to it and pull new commits.'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :branch_name,
+                                       env_name: 'BRANCH_NAME_TO_CREATE',
+                                       description: 'The full name of the new branch to create, e.g. "release/1.2"',
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :from,
+                                       env_name: 'BRANCH_OR_COMMIT_TO_CUT_FROM',
+                                       description: 'The branch/tag/commit from which to cut the branch from. If `nil`, will cut the new branch from the current commit. Otherwise, will checkout that commit/branch/tag before cutting the branch.',
+                                       optional: true,
+                                       type: String),
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does it do?

Adds two new actions: 
- `create_branch`
- `checkout_and_pull`

These are wrappers for the [GitHelper methods](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb) of the same names. There are currently dozens of instances across the A8C apps where those methods are being called directly. As discussed in paaHJt-5v4-p2, we're moving away from calling Release Toolkit helper methods directly and instead work through actions. 

I thought about adding unit tests for these actions or at least the underlying GitHelper methods, but the methods are basically running git commands and not much else. I'm open to discussing this, though! I also wasn't sure how we'd be able to test the `pull` part of the `checkout_and_pull` action in a test. 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [X] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [X] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.