### PR TITLE
Use latest SwiftGen version, 6.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _None_
 ### Internal Changes
 
 - Added deprecation notices to any actions or methods using the `HAS_ALPHA_VERSION` environment variable [#522]
+- Use SwiftGen 6.6.2 to address an Apple Silicon CI issue [#534]
 
 ## 9.2.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
@@ -5,7 +5,7 @@ module Fastlane
   module Helper
     module Ios
       class L10nLinterHelper
-        SWIFTGEN_VERSION = '6.4.0'.freeze
+        SWIFTGEN_VERSION = '6.6.2'.freeze
         DEFAULT_BASE_LANG = 'en'.freeze
         CONFIG_FILE_NAME = 'swiftgen-stringtypes.yml'.freeze
 


### PR DESCRIPTION
## What does it do?

Running CI on Apple Silicon, I noticed that SwiftGen [failed](https://buildkite.com/automattic/wordpress-ios/builds/19609#018ced25-05f4-4c8b-9850-b314ea2f8d9e/1131-1330) with

```
Bad CPU type in executable
```

See https://buildkite.com/automattic/wordpress-ios/builds/19609#018ced25-05f4-4c8b-9850-b314ea2f8d9e/1131-1330

Looking at the SwiftGen releases, I noticed that version 6.5.0 introduced universal binary which looked promising to address that issue.

I could have bumped to 6.5.0, but decided to use the latest version just to be as up to date as possible.

For reference, the previous version was 6.4.0.

The Apple Silicon CI that used this commit [passed](https://buildkite.com/automattic/wordpress-ios/builds/19611#018ced36-4901-4d47-9f5a-f9fae6e58c0f). 

That made me happy, but doesn't explain _why_ the issue occurred. After all, I've been running that lane on an Apple Silicon Mac many times without ever an issue. What's the difference between my machine and what runs in CI? I don't have an explanation for this just yet and, as lazy as it might sound, I am currently satisfied with the upgrade having done the trick. _Priorities..._

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable — The existing unit tests cover SwiftGen's behavior
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider. — N.A.
