### PR TITLE
`nokogiri`: Add version upper bound

### DIFF
--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fastlane', '~> 2.213'
   spec.add_dependency 'git', '~> 1.3'
   spec.add_dependency 'java-properties', '~> 0.3.0'
-  spec.add_dependency 'nokogiri', '~> 1.11' # Needed for AndroidLocalizeHelper
+  spec.add_dependency 'nokogiri', '~> 1.11', '< 1.16' # Needed for AndroidLocalizeHelper. The upper bound can be removed once the Release Toolkit is migrated from Ruby 2.7 to Ruby 3
   spec.add_dependency 'octokit', '~> 6.1'
   spec.add_dependency 'parallel', '~> 1.14'
   spec.add_dependency 'plist', '~> 3.1'


### PR DESCRIPTION
## What does it do?

This PR adds an upper bound to the `nokogiri` dependency version. `nokogiri`'s `1.16.0` release [dropped support for Ruby 2.7](https://github.com/sparklemotion/nokogiri/releases/tag/v1.16.0). 

The latest Release Toolkit release [failed with this error](https://buildkite.com/automattic/release-toolkit/builds/1476#018ceee9-fbfd-4cb5-97b6-bd6b0b8887aa/183-341):

 

> [2024-01-09T15:56:26Z] 	The last version of nokogiri (~> 1.11) to support your Ruby & RubyGems was 1.15.5. Try installing it with `gem install nokogiri -v 1.15.5` and then running the current command again
> [2024-01-09T15:56:26Z] 	nokogiri requires Ruby version >= 3.0, < 3.4.dev. The current ruby version is 2.7.4.191.



## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [X] I didn't add an entry to the changelog because this was just a dependency change and we haven't normally added those to the changelog unless there's a specific reason ~Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.~
- [X] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
