### PR TITLE
Use goqr.me/api for QR Code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Updated QRCode generated images (for Prototype Build) to use https://goqr.me/api as a replacement to the now-discontinued Google service. [#537]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -90,7 +90,7 @@ module Fastlane
           extra_metadata['App Center Build'] = "<a href='#{install_url}'>#{app_center_info.display_name} ##{app_center_info.release_id}</a>"
         end
         UI.user_error!(NO_INSTALL_URL_ERROR_MESSAGE) if install_url.nil?
-        qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{CGI.escape(install_url)}&choe=UTF-8"
+        qr_code_url = "https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=#{CGI.escape(install_url)}"
         [qr_code_url, extra_metadata]
       end
 

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -104,7 +104,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           app_center_release_id: '1337'
         )
         expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/My-App/releases/1337'>My-App #1337</a>"
-        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337&choe=UTF-8'
+        expect(comment).to include 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337'
       end
 
       it 'uses the App Center link for the QR code even if a `download_url` is provided' do
@@ -116,7 +116,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
         )
         expect(comment).to include "<td><b>Direct Download</b></td><td><a href='https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'><code>myapp-prototype-build-pr1337-a1b2c3f.apk</code></a></td>"
-        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337&choe=UTF-8'
+        expect(comment).to include 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App%2Freleases%2F1337'
         # Inferred metadata rows: App Name, Commit, Direct Download, App Center Build
         expect(comment).to include "<td rowspan='4'"
       end
@@ -176,7 +176,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <p>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
           <table>
           <tr>
-            <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='6' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888' width='250' height='250' /></td>
             <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
@@ -208,7 +208,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <p>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
           <table>
           <tr>
-            <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='6' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F8888' width='250' height='250' /></td>
             <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
@@ -243,7 +243,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <details><summary>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</summary>
           <table>
           <tr>
-            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='7' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FBestApp%2Freleases%2F1234' width='250' height='250' /></td>
             <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version:Short</b></td><td>28.2</td></tr>
@@ -286,7 +286,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           app_center_org_name: 'My-Org'
         )
         expect(comment).to include "<a href='https://install.appcenter.ms/orgs/My-Org/apps/My-App-Alpha/releases/1337'>My App (Alpha) #1337</a>"
-        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8'
+        expect(comment).to include 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App-Alpha%2Freleases%2F1337'
       end
 
       it 'uses the App Center link for the QR code even if a `download_url` is provided' do
@@ -295,7 +295,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           app_center_org_name: 'My-Org',
           download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
         )
-        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8'
+        expect(comment).to include 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FMy-Org%2Fapps%2FMy-App-Alpha%2Freleases%2F1337'
         # Inferred metadata rows: App Name, Build Number, Version, Application ID, Commit, Direct Download, App Center Build
         expect(comment).to include "<td rowspan='7'"
       end
@@ -386,7 +386,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <p><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' />📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
           <table>
           <tr>
-            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='7' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337' width='250' height='250' /></td>
             <td><b>App Name</b></td><td><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' /> The Best App</td>
           </tr>
           <tr><td><b>Configuration</b></td><td>Debug</td></tr>
@@ -411,7 +411,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <p><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' />📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
           <table>
           <tr>
-            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='7' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337' width='250' height='250' /></td>
             <td><b>App Name</b></td><td><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' /> The Best App</td>
           </tr>
           <tr><td><b>Build Number</b></td><td>1287003</td></tr>
@@ -442,7 +442,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <details><summary><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' />📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</summary>
           <table>
           <tr>
-            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='7' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Finstall.appcenter.ms%2Forgs%2FBestOrg%2Fapps%2FMy-App-Alpha%2Freleases%2F1337' width='250' height='250' /></td>
             <td><b>App Name</b></td><td><img alt='The Best App' align='top' src='https://assets.appcenter.ms/My-App-Alpha/1337/icon.png' width='20px' /> The Best App</td>
           </tr>
           <tr><td><b>Google Login</b></td><td>Disabled</td></tr>
@@ -474,7 +474,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           app_display_name: 'My App',
           download_url: 'https://foo.cloudfront.net/someuuid/myapp-prototype-build-pr1337-a1b2c3f.apk'
         )
-        expect(comment).to include 'https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Ffoo.cloudfront.net%2Fsomeuuid%2Fmyapp-prototype-build-pr1337-a1b2c3f.apk&choe=UTF-8'
+        expect(comment).to include 'https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Ffoo.cloudfront.net%2Fsomeuuid%2Fmyapp-prototype-build-pr1337-a1b2c3f.apk'
       end
 
       it 'includes the direct link as metadata' do
@@ -522,7 +522,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <p>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</p>
           <table>
           <tr>
-            <td rowspan='6' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Fbestfront.cloudfront.net%2Ffeed42%2Fbestapp-pr1357-a1b2c3f.apk&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='6' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Fbestfront.cloudfront.net%2Ffeed42%2Fbestapp-pr1357-a1b2c3f.apk' width='250' height='250' /></td>
             <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version Name</b></td><td>28.2</td></tr>
@@ -555,7 +555,7 @@ describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do
           <details><summary>📲 You can test the changes from this Pull Request in <b>The Best App</b> by scanning the QR code below to install the corresponding build.</summary>
           <table>
           <tr>
-            <td rowspan='7' width='260px'><img src='https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=https%3A%2F%2Fbestfront.cloudfront.net%2Ffeed42%2Fbestapp-pr1357-a1b2c3f.apk&choe=UTF-8' width='250' height='250' /></td>
+            <td rowspan='7' width='260px'><img src='https://api.qrserver.com/v1/create-qr-code/?size=500x500&qzone=4&data=https%3A%2F%2Fbestfront.cloudfront.net%2Ffeed42%2Fbestapp-pr1357-a1b2c3f.apk' width='250' height='250' /></td>
             <td><b>App Name</b></td><td> The Best App</td>
           </tr>
           <tr><td><b>Version Name</b></td><td>28.2</td></tr>


### PR DESCRIPTION
## What does this solve?

We've observed in recent days that the QR Codes for Prototype Builds, generated `chart.googleapis.com`, stop showing up. The request seems to lead to a 502. (See [Slack thread](https://a8c.slack.com/archives/CC7L49W13/p1704904163110209?thread_ts=1704811713.047909&cid=CC7L49W13))

Multiple places on the web [mention that this API has been shut down](https://github.com/google/google-visualization-issues/issues/2721) (though those messages date from years ago… but I guess it's not surprising to see Google close yet another service anyway…)

## How?

This PR replaces the use of the Google API with the https://goqr.me/api/ service instead.

## Testing

CI being green should be all there is, but if you want to also test the URLs for QR Code:

 - Open one of the new URLs in the specs (for example [this one](https://github.com/wordpress-mobile/release-toolkit/pull/537/files#diff-53b8c7a848584fe7f266346de49b5b972b4474b44ca1c9bb12552b8345adc3c1R119) in a browser tab
 - Validate that it shows a QR code that you can scan and that leads you to App Center

Alternatively, you could cut a branch in one of our app repos, make its `Gemfile` point `release-toolkit` to this branch, create a PR, and validate that the Prototype Build comment has the QR Code show up as expected.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~