### PR TITLE
Release 9.3.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Updated QRCode generated images (for Prototype Build) to use https://goqr.me/api as a replacement to the now-discontinued Google service. [#537]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 9.3.1
+
+### Bug Fixes
+
+- Updated QRCode generated images (for Prototype Build) to use https://goqr.me/api as a replacement to the now-discontinued Google service. [#537]
 
 ## 9.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (9.3.0)
+    fastlane-plugin-wpmreleasetoolkit (9.3.1)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
@@ -435,4 +435,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.4.21
+   2.4.14

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '9.3.0'
+    VERSION = '9.3.1'
   end
 end


### PR DESCRIPTION
New version 9.3.1, to fix the QR Codes on Prototype Builds.

PR Author: Be sure to create a GitHub Release and tag once this PR gets merged.