### PR TITLE
Introduce `update_pull_requests_milestone` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Added `update_pull_requests_milestone` action, to move all still-opened PRs of a given milestone to another milestone. [#539]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
@@ -1,0 +1,91 @@
+require 'fastlane/action'
+require_relative '../../helper/github_helper'
+
+module Fastlane
+  module Actions
+    class UpdatePullRequestsMilestoneAction < Action
+      def self.run(params)
+        repository = params[:repository]
+
+        github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
+
+        pr_number = params[:pr_number]
+        from_milestone = params[:from_milestone]
+        to_milestone = params[:to_milestone]
+        target_milestone = nil
+        unless to_milestone.nil?
+          target_milestone = github_helper.get_milestone(repository, to_milestone)
+          UI.user_error!("Unable to find target milestone matching version #{to_milestone}") if target_milestone.nil?
+        end
+
+        prs_nums = if pr_number
+                     [pr_number]
+                   elsif from_milestone
+                     # get the milestone object based on title starting text
+                     m = github_helper.get_milestone(repository, from_milestone)
+                     UI.user_error!("Unable to find source milestone matching version #{from_milestone}") if m.nil?
+
+                     # get all open PRs in that milestone
+                     github_helper.get_prs_for_milestone(repository: repository, milestone: m).map(&:number)
+                   else
+                     UI.user_error!('One of `pr_number` or `from_milestone` must be provided, to indicate which PR(s) to update')
+                   end
+
+        UI.message("Updating milestone of #{prs_nums.count} PRs to `#{target_milestone&.title}`")
+
+        prs_nums.each do |pr_num|
+          github_helper.set_pr_milestone(
+            repository: repository,
+            pr_number: pr_num,
+            milestone: target_milestone
+          )
+        end
+      end
+
+      def self.description
+        'Updates the milestone field of PRs'
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.return_value
+        'The PR numbers of all the PRs that were updated with the new milestone'
+      end
+
+      def self.details
+        'Updates the milestone field of a PR, of or all still-opened PRs in a milestone'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :repository,
+                                       env_name: 'GHHELPER_REPOSITORY',
+                                       description: 'The remote path of the GH repository on which we work',
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :pr_number,
+                                       description: 'The PR number to update the milestone of, if we only want to update a single PR',
+                                       optional: true,
+                                       type: Integer,
+                                       conflicting_options: [:from_milestone]),
+          FastlaneCore::ConfigItem.new(key: :from_milestone,
+                                       description: 'The version (milestone title\'s start) for which we want to update all open PRs of to a new milestone',
+                                       optional: true,
+                                       type: String,
+                                       conflicting_options: [:pr_number]),
+          FastlaneCore::ConfigItem.new(key: :to_milestone,
+                                       description: 'The version (milestone title\'s start) for the new milestone to assign to the targeted PRs. Pass nil to unset the milestone',
+                                       optional: true,
+                                       type: String),
+          Fastlane::Helper::GithubHelper.github_token_config_item,
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
@@ -9,7 +9,7 @@ module Fastlane
 
         github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
 
-        pr_number = params[:pr_number]
+        pr_numbers = params[:pr_numbers]
         from_milestone = params[:from_milestone]
         to_milestone = params[:to_milestone]
         pr_comment = params[:pr_comment]
@@ -20,8 +20,8 @@ module Fastlane
           UI.user_error!("Unable to find target milestone matching version #{to_milestone}") if target_milestone.nil?
         end
 
-        prs_nums = if pr_number
-                     [pr_number]
+        prs_nums = if pr_numbers
+                     pr_numbers
                    elsif from_milestone
                      # get the milestone object based on title starting text
                      m = github_helper.get_milestone(repository, from_milestone)
@@ -30,7 +30,7 @@ module Fastlane
                      # get all open PRs in that milestone
                      github_helper.get_prs_for_milestone(repository: repository, milestone: m).map(&:number)
                    else
-                     UI.user_error!('One of `pr_number` or `from_milestone` must be provided, to indicate which PR(s) to update')
+                     UI.user_error!('One of `pr_numbers` or `from_milestone` must be provided to indicate which PR(s) to update')
                    end
 
         UI.message("Updating milestone of #{prs_nums.count} PRs to `#{target_milestone&.title}`")
@@ -74,16 +74,16 @@ module Fastlane
                                        description: 'The remote path of the GH repository on which we work',
                                        optional: false,
                                        type: String),
-          FastlaneCore::ConfigItem.new(key: :pr_number,
-                                       description: 'The PR number to update the milestone of, if we only want to update a single PR',
+          FastlaneCore::ConfigItem.new(key: :pr_numbers,
+                                       description: 'The PR numbers to update the milestone of, if we only want to update a single PR',
                                        optional: true,
-                                       type: Integer,
+                                       type: Array,
                                        conflicting_options: [:from_milestone]),
           FastlaneCore::ConfigItem.new(key: :from_milestone,
                                        description: 'The version (milestone title\'s start) for which we want to update all open PRs of to a new milestone',
                                        optional: true,
                                        type: String,
-                                       conflicting_options: [:pr_number]),
+                                       conflicting_options: [:pr_numbers]),
           FastlaneCore::ConfigItem.new(key: :to_milestone,
                                        description: 'The version (milestone title\'s start) for the new milestone to assign to the targeted PRs. Pass nil to unset the milestone',
                                        optional: true,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
@@ -75,7 +75,7 @@ module Fastlane
                                        optional: false,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :pr_numbers,
-                                       description: 'The PR numbers to update the milestone of, if we only want to update a single PR',
+                                       description: 'The PR numbers to update the milestone of',
                                        optional: true,
                                        type: Array,
                                        conflicting_options: [:from_milestone]),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_pull_requests_milestone_action.rb
@@ -12,6 +12,8 @@ module Fastlane
         pr_number = params[:pr_number]
         from_milestone = params[:from_milestone]
         to_milestone = params[:to_milestone]
+        pr_comment = params[:pr_comment]
+
         target_milestone = nil
         unless to_milestone.nil?
           target_milestone = github_helper.get_milestone(repository, to_milestone)
@@ -38,6 +40,13 @@ module Fastlane
             repository: repository,
             pr_number: pr_num,
             milestone: target_milestone
+          )
+          next if pr_comment.nil? || pr_comment.empty?
+
+          github_helper.comment_on_pr(
+            project_slug: repository,
+            pr_number: pr_num,
+            body: pr_comment
           )
         end
       end
@@ -77,6 +86,10 @@ module Fastlane
                                        conflicting_options: [:pr_number]),
           FastlaneCore::ConfigItem.new(key: :to_milestone,
                                        description: 'The version (milestone title\'s start) for the new milestone to assign to the targeted PRs. Pass nil to unset the milestone',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :pr_comment,
+                                       description: 'If non-nil, the custom comment to leave on each PR whose milestone has been updated',
                                        optional: true,
                                        type: String),
           Fastlane::Helper::GithubHelper.github_token_config_item,

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'webmock/rspec'
 
 describe Fastlane::Helper::GithubHelper do
-  describe 'download_file_from_tag' do
+  describe '#download_file_from_tag' do
     let(:test_repo) { 'repo-test/project-test' }
     let(:test_tag) { '1.0' }
     let(:test_file) { 'test-folder/test-file.xml' }
@@ -44,7 +44,7 @@ describe Fastlane::Helper::GithubHelper do
     end
   end
 
-  describe 'get_last_milestone' do
+  describe '#get_last_milestone' do
     let(:test_repo) { 'repo-test/project-test' }
     let(:last_stone) { mock_milestone('10.0') }
     let(:client) do
@@ -76,7 +76,7 @@ describe Fastlane::Helper::GithubHelper do
     end
   end
 
-  describe 'comment_on_pr' do
+  describe '#comment_on_pr' do
     let(:client) do
       instance_double(
         Octokit::Client,
@@ -150,7 +150,7 @@ describe Fastlane::Helper::GithubHelper do
     end
   end
 
-  describe 'get_milestone' do
+  describe '#get_milestone' do
     let(:test_repo) { 'repo-test/project-test' }
     let(:test_milestones) { [{ title: '9.8' }, { title: '10.1' }, { title: '10.1.3 ❄️' }] }
     let(:client) do
@@ -200,7 +200,114 @@ describe Fastlane::Helper::GithubHelper do
     end
   end
 
-  describe 'create_milestone' do
+  describe '#get_prs_for_milestone' do
+    let(:test_repo) { 'repo-test/project-test' }
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+    let(:helper) do
+      described_class.new(github_token: 'Fake-GitHubToken-123')
+    end
+
+    before do
+      allow(Octokit::Client).to receive(:new).and_return(client)
+    end
+
+    it 'returns only opened PRs for a given milestone by default' do
+      search_results = [101, 103].map { |num| sawyer_resource_stub(number: num) }
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} type:pr milestone:"12.3 New Version" is:open))
+        .and_return({ items: search_results })
+
+      result = helper.get_prs_for_milestone(repository: test_repo, milestone: '12.3 New Version')
+      expect(result).to eq(search_results)
+    end
+
+    it 'returns only opened PRs for a given milestone if include_closed is false' do
+      search_results = [101, 103].map { |num| sawyer_resource_stub(number: num) }
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} type:pr milestone:"12.3 New Version" is:open))
+        .and_return({ items: search_results })
+
+      result = helper.get_prs_for_milestone(repository: test_repo, milestone: '12.3 New Version', include_closed: false)
+      expect(result).to eq(search_results)
+    end
+
+    it 'returns both opened and closed PRs of a milestone if include_closed is true' do
+      search_results = [101, 102, 103, 104].map { |num| sawyer_resource_stub(number: num) }
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} type:pr milestone:"12.3 New Version"))
+        .and_return({ items: search_results })
+
+      result = helper.get_prs_for_milestone(repository: test_repo, milestone: '12.3 New Version', include_closed: true)
+      expect(result).to eq(search_results)
+    end
+  end
+
+  describe '#set_pr_milestone' do
+    let(:test_repo) { 'repo-test/project-test' }
+    let(:client) do
+      instance_double(
+        Octokit::Client,
+        user: instance_double('User', name: 'test'),
+        'auto_paginate=': nil
+      )
+    end
+    let(:helper) do
+      described_class.new(github_token: 'Fake-GitHubToken-123')
+    end
+
+    before do
+      allow(Octokit::Client).to receive(:new).and_return(client)
+    end
+
+    it 'updates the milestone as expected when everything is OK' do
+      allow(client).to receive(:update_issue)
+        .with(test_repo, 1337, { milestone: 42 })
+        .and_return(sawyer_resource_stub(number: 1337))
+
+      result = helper.set_pr_milestone(
+        repository: test_repo,
+        pr_number: 1337,
+        milestone: 42
+      )
+      expect(result&.number).to eq(1337)
+    end
+
+    it 'raises a user_error! if PR number does not exist' do
+      allow(client).to receive(:update_issue)
+        .with(test_repo, 1337, { milestone: 42 })
+        .and_raise(Octokit::NotFound)
+
+      expect do
+        helper.set_pr_milestone(
+          repository: test_repo,
+          pr_number: 1337,
+          milestone: 42
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Could not find PR #1337 in #{test_repo}")
+    end
+
+    it 'raises a user_error! if the source milestone could not be found' do
+      allow(client).to receive(:update_issue)
+        .with(test_repo, 1337, { milestone: 42 })
+        .and_raise(Octokit::UnprocessableEntity)
+
+      expect do
+        helper.set_pr_milestone(
+          repository: test_repo,
+          pr_number: 1337,
+          milestone: 42
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Invalid milestone 42')
+    end
+  end
+
+  describe '#create_milestone' do
     let(:test_repo) { 'repo-test/project-test' }
     let(:test_milestone_number) { '10.0' }
     let(:test_milestone_duedate) { '2022-10-22T23:39:01Z' }
@@ -377,7 +484,7 @@ describe Fastlane::Helper::GithubHelper do
     end
   end
 
-  describe 'create_release' do
+  describe '#create_release' do
     let(:test_repo) { 'repo-test/project-test' }
     let(:test_tag) { '1.0' }
     let(:test_target) { 'dummysha123456' }
@@ -442,7 +549,7 @@ describe Fastlane::Helper::GithubHelper do
     end
   end
 
-  describe 'github_token_config_item' do
+  describe '#github_token_config_item' do
     it 'has the correct key' do
       expect(described_class.github_token_config_item.key).to eq(:github_token)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,6 +77,22 @@ def run_described_fastlane_action(parameters)
   Fastlane::FastFile.new.parse(lane).runner.execute(:test)
 end
 
+# Create a stubbed `Sawyer::Resource` instance. Useful to stub tests expected to return values from the GitHub API.
+#
+# @param [Hash] fields The data / list of fields and values for this API response stub
+# @return [Sawyer::Response] a response object representing the provided hash
+#
+# @note Based on how Sawyer gem itself does testing in their own test suite
+# @see https://github.com/lostisland/sawyer/blob/f5f080d5c5260e094069139ffc7c13d0acba4ab5/test/resource_test.rb#L6-L12
+def sawyer_resource_stub(**fields)
+  stubs = Faraday::Adapter::Test::Stubs.new
+  agent = Sawyer::Agent.new 'http://release-toolkit.com/specs' do |conn|
+    conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
+    conn.adapter :test, stubs
+  end
+  Sawyer::Resource.new(agent, fields)
+end
+
 # Executes the given block within an ad hoc temporary directory.
 def in_tmp_dir
   Dir.mktmpdir('a8c-release-toolkit-tests-') do |tmpdir|

--- a/spec/update_pull_requests_milestone_spec.rb
+++ b/spec/update_pull_requests_milestone_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
+  let(:test_token) { 'ghp_fake_token' }
+  let(:test_repo) { 'repo-test/project-test' }
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      user: instance_double('User', name: 'test'),
+      list_milestones: %w[12.2 12.3 12.4].map { |version| mock_milestone(version) },
+      'auto_paginate=': nil
+    )
+  end
+
+  def mock_milestone(version)
+    number = version.to_s.gsub('.', '').to_i
+    sawyer_resource_stub(title: "#{version} Fake milestone (##{number})", number: number)
+  end
+
+  def mock_pr(number)
+    sawyer_resource_stub(number: number)
+  end
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+  end
+
+  context 'when providing a single PR number' do
+    it 'updates the milestone of a single PR' do
+      expect(client).to receive(:update_issue).with(test_repo, 1337, { milestone: 123 })
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        pr_number: 1337,
+        to_milestone: '12.3'
+      )
+
+      expect(result).to eq([1337])
+    end
+
+    it 'removes the milestone if to_milestone is nil' do
+      expect(client).to receive(:update_issue).with(test_repo, 1337, { milestone: nil })
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        pr_number: 1337,
+        to_milestone: nil
+      )
+
+      expect(result).to eq([1337])
+    end
+  end
+
+  context 'when providing a source milestone' do
+    it 'updates the milestone of all matching and still-opened PRs' do
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} type:pr milestone:"#{mock_milestone(12.2)[:title]}" is:open))
+        .and_return({ items: [101, 103].map { |n| mock_pr(n) } })
+
+      expect(client).to receive(:update_issue).with(test_repo, 101, { milestone: 123 })
+      expect(client).to receive(:update_issue).with(test_repo, 103, { milestone: 123 })
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        from_milestone: '12.2',
+        to_milestone: '12.3'
+      )
+
+      expect(result).to eq([101, 103])
+    end
+  end
+
+  describe 'error handling' do
+    it 'raises a user_error! if the destination milestone could not be found' do
+      expect do
+        run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          from_milestone: '12.2',
+          to_milestone: '99.9'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Unable to find target milestone matching version 99.9')
+    end
+
+    it 'raises if both a source milestone and a pr_number were provided' do
+      expect do
+        run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          from_milestone: '12.2',
+          pr_number: 1337,
+          to_milestone: '12.3'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, %(Unresolved conflict between options: 'from_milestone' and 'pr_number'))
+    end
+
+    it 'raises if neither a source milestone nor a pr_number was provided' do
+      expect do
+        run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          to_milestone: '12.3'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'One of `pr_number` or `from_milestone` must be provided, to indicate which PR(s) to update')
+    end
+  end
+end

--- a/spec/update_pull_requests_milestone_spec.rb
+++ b/spec/update_pull_requests_milestone_spec.rb
@@ -25,7 +25,7 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
     allow(Octokit::Client).to receive(:new).and_return(client)
   end
 
-  context 'when providing a single PR number' do
+  context 'when providing explicit PR numbers' do
     it 'updates the milestone of a single PR' do
       expect(client).to receive(:update_issue).with(test_repo, 1337, { milestone: 123 })
 
@@ -142,7 +142,7 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
       end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Unable to find target milestone matching version 99.9')
     end
 
-    it 'raises if both a source milestone and a pr_number were provided' do
+    it 'raises if both from_milestone and pr_numbers were provided' do
       expect do
         run_described_fastlane_action(
           github_token: test_token,
@@ -154,7 +154,7 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
       end.to raise_error(FastlaneCore::Interface::FastlaneError, %(Unresolved conflict between options: 'from_milestone' and 'pr_numbers'))
     end
 
-    it 'raises if neither a source milestone nor a pr_number was provided' do
+    it 'raises if neither from_milestone nor pr_numbers were provided' do
       expect do
         run_described_fastlane_action(
           github_token: test_token,

--- a/spec/update_pull_requests_milestone_spec.rb
+++ b/spec/update_pull_requests_milestone_spec.rb
@@ -32,11 +32,25 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
       result = run_described_fastlane_action(
         github_token: test_token,
         repository: test_repo,
-        pr_number: 1337,
+        pr_numbers: [1337],
         to_milestone: '12.3'
       )
 
       expect(result).to eq([1337])
+    end
+
+    it 'updates the milestone of provided PRs' do
+      expect(client).to receive(:update_issue).with(test_repo, 42, { milestone: 123 })
+      expect(client).to receive(:update_issue).with(test_repo, 1337, { milestone: 123 })
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        pr_numbers: [42, 1337],
+        to_milestone: '12.3'
+      )
+
+      expect(result).to eq([42, 1337])
     end
 
     it 'removes the milestone if to_milestone is nil' do
@@ -45,7 +59,7 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
       result = run_described_fastlane_action(
         github_token: test_token,
         repository: test_repo,
-        pr_number: 1337,
+        pr_numbers: [1337],
         to_milestone: nil
       )
 
@@ -134,10 +148,10 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
           github_token: test_token,
           repository: test_repo,
           from_milestone: '12.2',
-          pr_number: 1337,
+          pr_numbers: [1337],
           to_milestone: '12.3'
         )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, %(Unresolved conflict between options: 'from_milestone' and 'pr_number'))
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, %(Unresolved conflict between options: 'from_milestone' and 'pr_numbers'))
     end
 
     it 'raises if neither a source milestone nor a pr_number was provided' do
@@ -147,7 +161,7 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
           repository: test_repo,
           to_milestone: '12.3'
         )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'One of `pr_number` or `from_milestone` must be provided, to indicate which PR(s) to update')
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'One of `pr_numbers` or `from_milestone` must be provided to indicate which PR(s) to update')
     end
   end
 end


### PR DESCRIPTION
## What does it do?

Adds `update_pull_requests_milestone` action, whose role is to move the milestone of all open PRs in milestone A to milestone B.
   - This will be useful to replace the legacy MilestoneMover script/repo that we've been using in Tumblr iOS and Android
   - And also be useful for any other app repos that would be interested to also adopt this new action as part of their `finalize_release` and/or `code_freeze` to move all still-opened PRs to the next milestone/version

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~
