### PR TITLE
Ensure `comment_on_pr` formats comments as Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fixed `comment_on_pr` to allow first paragraph of the comment to still be interpreted as Markdown. [#544]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -237,7 +237,7 @@ module Fastlane
           comment.user.id == client.user.id and comment.body.include?(reuse_marker)
         end
 
-        comment_body = reuse_marker + body
+        comment_body = "#{reuse_marker}\n\n#{body}"
 
         if existing_comment.nil?
           client.add_comment(project_slug, pr_number, comment_body)

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -129,7 +129,7 @@ describe Fastlane::Helper::GithubHelper do
       )
     end
 
-    def mock_comment(body: '<!-- REUSE_ID: test-id --> Test', user_id: 1234)
+    def mock_comment(body: '<!-- REUSE_ID: test-id -->\n\nTest', user_id: 1234)
       instance_double('Comment', id: 1234, body: body, user: instance_double('User', id: user_id))
     end
   end

--- a/spec/update_pull_requests_milestone_spec.rb
+++ b/spec/update_pull_requests_milestone_spec.rb
@@ -87,16 +87,16 @@ describe Fastlane::Actions::UpdatePullRequestsMilestoneAction do
     end
 
     it 'adds a PR comment if one is provided' do
-      comment = 'Updated milestone from 12.2 to 12.3'
+      comment = 'Updated milestone from `12.2` to `12.3`'
       allow(client).to receive(:search_issues)
         .with(%(repo:#{test_repo} type:pr milestone:"#{mock_milestone(12.2)[:title]}" is:open))
         .and_return({ items: [101, 103].map { |n| mock_pr(n) } })
       allow(client).to receive(:issue_comments).and_return([])
 
       expect(client).to receive(:update_issue).with(test_repo, 101, { milestone: 123 })
-      expect(client).to receive(:add_comment).with(test_repo, 101, /<!-- REUSE_ID: .* -->#{comment}/)
+      expect(client).to receive(:add_comment).with(test_repo, 101, /<!-- REUSE_ID: .* -->\n\n#{Regexp.escape(comment)}/)
       expect(client).to receive(:update_issue).with(test_repo, 103, { milestone: 123 })
-      expect(client).to receive(:add_comment).with(test_repo, 103, /<!-- REUSE_ID: .* -->#{comment}/)
+      expect(client).to receive(:add_comment).with(test_repo, 103, /<!-- REUSE_ID: .* -->\n\n#{Regexp.escape(comment)}/)
 
       result = run_described_fastlane_action(
         github_token: test_token,


### PR DESCRIPTION
## Why?

The `comment_on_pr` action inserts a `<!-- REUSE_ID: … -->` hidden HTML comment in the comment body as a marker to identify comments and be able to update them (instead of creating new one) when appropriate.

But so far we didn't add any newlines after that marker comment. As a result, GitHub considered that, since the paragraph started with some HTML (that marker comment), the rest of the paragraph should also be interpreted as HTML, not Markdown.

This results in comments like [this one](https://github.tumblr.net/Tumblr/ios/pull/25462#issuecomment-649212) not being interpreted and formatted as Markdown.

## How?

The fix is simple: add newlines after the marker comment, so that it is considered as its own separate paragraph, thus allowing it to be interpreted as Markdown even if the first paragraph is a HTML comment. See [GitHub Flavored Markdown's spec on HTML blocks' end conditions](https://github.github.com/gfm/#html-blocks).

