### PR TITLE
Release 10.0.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@
 
 ### Breaking Changes
 
+_None_
+
+### New Features
+
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 10.0.0
+
+### Breaking Changes
+
 - Upgraded the minimum required Ruby version to `3.2.2`. [#517]
 - Removed the old `setbranchprotection` and `removebranchprotection` backwards-compatiblity stubs for the now-renamed `set_branch_protection` and `remove_branch_protection` actions. [#549]
 - Renamed `setfrozentag` action to `set_milestone_frozen_marker`. [#548]
@@ -13,10 +31,6 @@
 - Removed the `has_alpha_version` option from several actions and helper methods. It has already been deprecated for many versions. [#550]
 - Removed the `project_name` and `project_root_folder` options from several actions. [#550]
 - Renamed `update_pull_requests_milestone` to `update_assigned_milestone` and make it handle GitHub issues as well as PRs. [#547]
-
-### New Features
-
-_None_
 
 ### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (9.4.0)
+    fastlane-plugin-wpmreleasetoolkit (10.0.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '9.4.0'
+    VERSION = '10.0.0'
   end
 end


### PR DESCRIPTION
New version 10.0.0. Be sure to create a GitHub Release and tag once this PR gets merged.