### PR TITLE
[Tooling] Improve release script a bit

### DIFF
--- a/rakelib/git_helpers.rake
+++ b/rakelib/git_helpers.rake
@@ -28,6 +28,6 @@ module GitHelper
   def self.commit_files(message, files, push: true)
     Rake.sh('git', 'add', *files)
     Rake.sh('git', 'commit', '-m', message)
-    Rake.sh('git', 'push', '-q', 'origin', current_branch) if push
+    Rake.sh('git', 'push', '-q', '-u', 'origin', current_branch) if push
   end
 end


### PR DESCRIPTION
- Make the local `release/` branch track remote one—so that once the PR is merged and remote branch deleted, we can see it marked as `gone` locally and prune it more easily.
- Improve PR and instructions body, also providing a copy/paste-able version of the changelog to use as the GitHub Release's description.
