### PR TITLE
Add a missing space in the word "codefreeze" in user text

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -35,8 +35,8 @@ module Fastlane
         unless params[:skip_confirm]
           confirm_message = "Building a new release branch starting from #{default_branch}.\nCurrent version is #{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += current_alpha_version.nil? ? no_alpha_version_message : "Current Alpha version is #{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{current_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
-          confirm_message += "After codefreeze the new version will be: #{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
-          confirm_message += current_alpha_version.nil? ? '' : "After codefreeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
+          confirm_message += "After code freeze the new version will be: #{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
+          confirm_message += current_alpha_version.nil? ? '' : "After code freeze the new Alpha will be: #{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_NAME]} (#{next_alpha_version[Fastlane::Helper::Android::VersionHelper::VERSION_CODE]}).\n"
           confirm_message += 'Do you want to continue?'
           UI.user_error!('Aborted by user request') unless UI.confirm(confirm_message)
         end
@@ -68,7 +68,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :skip_confirm,
                                        env_name: 'FL_ANDROID_CODEFREEZE_PRECHECKS_SKIPCONFIRM',
-                                       description: 'Skips confirmation before codefreeze',
+                                       description: 'Skips confirmation before code freeze',
                                        type: Boolean,
                                        default_value: false), # the default value if the user didn't provide one
           FastlaneCore::ConfigItem.new(key: :default_branch,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -18,7 +18,7 @@ module Fastlane
         next_version = Fastlane::Helper::Ios::VersionHelper.calc_next_release_version(current_version)
 
         # Ask user confirmation
-        unless params[:skip_confirm] || UI.confirm("Building a new release branch starting from #{default_branch}.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter codefreeze the new version will be: #{next_version}.\nDo you want to continue?")
+        unless params[:skip_confirm] || UI.confirm("Building a new release branch starting from #{default_branch}.\nCurrent version is #{current_version} (#{current_build_version}).\nAfter code freeze the new version will be: #{next_version}.\nDo you want to continue?")
           UI.user_error!('Aborted by user request')
         end
 
@@ -46,7 +46,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :skip_confirm,
                                        env_name: 'FL_IOS_CODEFREEZE_PRECHECKS_SKIPCONFIRM',
-                                       description: 'Skips confirmation before codefreeze',
+                                       description: 'Skips confirmation before code freeze',
                                        type: Boolean,
                                        default_value: false), # the default value if the user didn't provide one
           FastlaneCore::ConfigItem.new(key: :default_branch,


### PR DESCRIPTION
## What does it do?

Just a typo fix I noticed while working on the Simplenote Android 2.32 code freeze.

I don't think it grants a CHANGELOG entry.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
