### PR TITLE
WIP – Fix `build.gradle` for Android checks and version bump

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -54,6 +54,7 @@ module Fastlane
         Fastlane::Helper::Android::VersionHelper.update_versions(
           new_version_beta,
           new_version_alpha,
+          build_gradle_path: build_gradle_path,
           version_properties_path: version_properties_path
         )
         Fastlane::Helper::Android::GitHelper.commit_version_bump(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -11,6 +11,10 @@ module Fastlane
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
 
+        # build_gradle_path and version_properties_path are marked as conflicting options: either you give one or the other.
+        # Fastlane requires conflicting options to be optional, but that leaves the door open for neither being given.
+        UI.user_error!('Either a build_gradle_path or version_properties_path must be specified.') if build_gradle_path.nil? && version_properties_path.nil?
+
         default_branch = params[:default_branch]
         other_action.ensure_git_branch(branch: default_branch)
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -14,6 +14,10 @@ module Fastlane
         build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
 
+        # build_gradle_path and version_properties_path are marked as conflicting options: either you give one or the other.
+        # Fastlane requires conflicting options to be optional, but that leaves the door open for neither being given.
+        UI.user_error!('Either a build_gradle_path or version_properties_path must be specified.') if build_gradle_path.nil? && version_properties_path.nil?
+
         # Checkout default branch and update
         default_branch = params[:default_branch]
         Fastlane::Helper::GitHelper.checkout_and_pull(default_branch)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -10,16 +10,18 @@ module Fastlane
         # inside the project subfolder.
         #
         def self.commit_version_bump(build_gradle_path:, version_properties_path:)
-          if File.exist?(version_properties_path)
+          if version_properties_path.nil? == false && File.exist?(version_properties_path)
             git_commit(
               path: version_properties_path,
               message: 'Bump version number'
             )
-          else
+          elsif build_gradle_path.nil? == false && File.exist?(build_gradle_path)
             git_commit(
               path: build_gradle_path,
               message: 'Bump version number'
             )
+          else
+            UI.user_error!('Both version.properties and build.gradle paths where either nil or invalid.')
           end
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -80,7 +80,9 @@ module Fastlane
         # @return [Hash] A hash with 2 keys `"name"` and `"code"` containing the extracted version name and code, respectively
         #
         def self.get_alpha_version(build_gradle_path:, version_properties_path:)
-          return get_version_from_properties(version_properties_path: version_properties_path, is_alpha: true) if File.exist?(version_properties_path)
+          return get_version_from_properties(version_properties_path: version_properties_path, is_alpha: true) if version_properties_path.nil? == false && File.exist?(version_properties_path)
+
+          UI.user_error!('Both version.properties and build.gradle paths where either nil or invalid.') unless build_gradle_path.nil? == false && File.exist?(build_gradle_path)
 
           section = 'defaultConfig'
           name = get_version_name_from_gradle_file(build_gradle_path, section)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -46,7 +46,9 @@ module Fastlane
         # @return [Hash] A hash with 2 keys "name" and "code" containing the extracted version name and code, respectively
         #
         def self.get_release_version(build_gradle_path:, version_properties_path:)
-          return get_version_from_properties(version_properties_path: version_properties_path) if File.exist?(version_properties_path)
+          return get_version_from_properties(version_properties_path: version_properties_path) if version_properties_path.nil? == false && File.exist?(version_properties_path)
+
+          UI.user_error!('Both version.properties and build.gradle paths where either nil or invalid.') unless build_gradle_path.nil? == false && File.exist?(build_gradle_path)
 
           section = 'defaultConfig'
           name = get_version_name_from_gradle_file(build_gradle_path, section)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -295,8 +295,8 @@ module Fastlane
         # @param [Hash] new_version_beta The version hash for the beta, containing values for keys "name" and "code"
         # @param [Hash] new_version_alpha The version hash for the alpha , containing values for keys "name" and "code"
         #
-        def self.update_versions(new_version_beta, new_version_alpha, version_properties_path:)
-          if File.exist?(version_properties_path)
+        def self.update_versions(new_version_beta, new_version_alpha, build_gradle_path:, version_properties_path:)
+          if version_properties_path.nil? == false && File.exist?(version_properties_path)
             replacements = {
               versionName: (new_version_beta || {})[VERSION_NAME],
               versionCode: (new_version_beta || {})[VERSION_CODE],
@@ -310,9 +310,11 @@ module Fastlane
               value.nil? ? line : "#{key}=#{value}"
             end
             File.write(version_properties_path, content)
+          elsif build_gradle_path.nil? == false && File.exist?(build_gradle_path)
+            update_version(new_version_beta, 'defaultConfig', build_gradle_path: build_gradle_path)
+            update_version(new_version_alpha, 'defaultConfig', build_gradle_path: build_gradle_path) unless new_version_alpha.nil?
           else
-            update_version(new_version_beta, 'defaultConfig')
-            update_version(new_version_alpha, 'defaultConfig') unless new_version_alpha.nil?
+            UI.user_error!('Both version.properties and build.gradle paths where either nil or invalid.')
           end
         end
 

--- a/spec/android_bump_version_release_spec.rb
+++ b/spec/android_bump_version_release_spec.rb
@@ -1,0 +1,19 @@
+require_relative 'spec_helper'
+
+describe Fastlane::Actions::AndroidBumpVersionReleaseAction do
+  context 'when evaluating the build_gradle_path and version_properties_path values' do
+    it 'fails if neither is given' do
+      expect { run_described_fastlane_action({}) }
+        .to raise_error(FastlaneCore::Interface::FastlaneError, 'Either a build_gradle_path or version_properties_path must be specified.')
+    end
+
+    it 'show the conflicting options message if both are given' do
+      expect do
+        run_described_fastlane_action(
+          build_gradle_path: 'some',
+          version_properties_path: 'some other'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unresolved conflict between options: 'build_gradle_path' and 'version_properties_path'")
+    end
+  end
+end

--- a/spec/android_codefreeze_prechecks_spec.rb
+++ b/spec/android_codefreeze_prechecks_spec.rb
@@ -1,0 +1,19 @@
+require_relative 'spec_helper'
+
+describe Fastlane::Actions::AndroidCodefreezePrechecksAction do
+  context 'when evaluating the build_gradle_path and version_properties_path values' do
+    it 'fails if neither is given' do
+      expect { run_described_fastlane_action({}) }
+        .to raise_error(FastlaneCore::Interface::FastlaneError, 'Either a build_gradle_path or version_properties_path must be specified.')
+    end
+
+    it 'show the conflicting options message if both are given' do
+      expect do
+        run_described_fastlane_action(
+          build_gradle_path: 'some',
+          version_properties_path: 'some other'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Unresolved conflict between options: 'build_gradle_path' and 'version_properties_path'")
+    end
+  end
+end

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -68,6 +68,10 @@ describe Fastlane::Helper::Android::VersionHelper do
     include_examples 'robustly accepts version.properties and build.gradle paths', :get_release_version
   end
 
+  describe 'get_alpha_version' do
+    include_examples 'robustly accepts version.properties and build.gradle paths', :get_alpha_version
+  end
+
   describe 'get_version_from_properties' do
     it 'returns version name and code when present' do
       test_file_content = <<~CONTENT

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -149,7 +149,7 @@ describe Fastlane::Helper::Android::VersionHelper do
         allow(File).to receive(:exist?).with(VERSION_PROPERTIES_PATH).and_return(true)
         allow(File).to receive(:read).with(VERSION_PROPERTIES_PATH).and_return(original_content)
         expect(File).to receive(:write).with(VERSION_PROPERTIES_PATH, expected_content)
-        subject.update_versions(new_beta_version, nil, version_properties_path: VERSION_PROPERTIES_PATH)
+        subject.update_versions(new_beta_version, nil, build_gradle_path: nil, version_properties_path: VERSION_PROPERTIES_PATH)
       end
 
       it 'updates both the main and alpha versions if alpha provided' do
@@ -165,7 +165,7 @@ describe Fastlane::Helper::Android::VersionHelper do
         allow(File).to receive(:exist?).with(VERSION_PROPERTIES_PATH).and_return(true)
         allow(File).to receive(:read).with(VERSION_PROPERTIES_PATH).and_return(original_content)
         expect(File).to receive(:write).with(VERSION_PROPERTIES_PATH, expected_content)
-        subject.update_versions(new_beta_version, new_alpha_version, version_properties_path: VERSION_PROPERTIES_PATH)
+        subject.update_versions(new_beta_version, new_alpha_version, build_gradle_path: nil, version_properties_path: VERSION_PROPERTIES_PATH)
       end
     end
   end


### PR DESCRIPTION
## What does it do?

I run into this when working on the Simplenote Android 2.32 code freeze. 

I run the 2.31 code freeze using 9.1.0 (see https://github.com/Automattic/simplenote-android/pull/1631) and it worked fine. Since then, the project upgraded to 9.4.0 via https://github.com/Automattic/simplenote-android/pull/1636 and the lane gives errors related the code implicitly expecting a `version.properties` parameter.

I started addressing them, by ensuring the code uses `build.gradle` when `version.properties` is not given. But the more I progressed the more I questioned the value of the work I was doing. _Wouldn't it be better to support only the `version.properties` only, so that code and tests can be clearer?

I then run into this error, which looks to me like a mix of the setup expecting an alpha that is not there without a way to opt-out and dead code still lingering in `release-toolkit`:

![image](https://github.com/wordpress-mobile/release-toolkit/assets/1218433/175cd53d-6989-42fd-b060-787b8888592b)
![image](https://github.com/wordpress-mobile/release-toolkit/assets/1218433/175cd53d-6989-42fd-b060-787b8888592b)

I decided to push this PR as draft for reference and to raise the approach question with the team.


## Checklist before requesting a review

- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
