### PR TITLE
Add `other_action` to `git_submodule_update` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fixed the `android_download_translations` action by correctly calling Fastlane's `git_submodule_update` action [#561]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
@@ -22,7 +22,7 @@ module Fastlane
 
         # Update submodules then lint translations
         unless params[:lint_task].nil? || params[:lint_task].empty?
-          git_submodule_update(
+          other_action.git_submodule_update(
             recursive: true,
             init: true
           )


### PR DESCRIPTION
## What does it do?

This PR adds `other.action.` to the `git_submodule_update` call in the `android_download_translations` action. This was a bug reported by @ashiagr in p1712924182271989-slack-CC7L49W13:

![screenshot_2024-04-12_at_5 44 13_pm](https://github.com/wordpress-mobile/release-toolkit/assets/17955542/e82766d4-7ceb-4d0a-b033-edacef74fdfc)


## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.