### PR TITLE
Return web build URL from successful `buildkite_trigger_build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- `buildkite_trigger_build` now returns the web URL of the Buildkite build it scheduled [#564]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -27,11 +27,15 @@ module Fastlane
           options
         )
 
+        build_url = response.web_url
+
         if response.state == 'scheduled'
-          UI.success("Successfully scheduled new build. You can see it at '#{response.web_url}'")
+          UI.success("Successfully scheduled new build. You can see it at '#{build_url}'")
         else
           UI.crash!("Failed to start build.\nError: [#{response}]")
         end
+
+        build_url
       end
 
       #####################################################
@@ -98,6 +102,10 @@ module Fastlane
 
       def self.authors
         ['Automattic']
+      end
+
+      def self.return_value
+        'The web URL of the build the action started.'
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -14,9 +14,9 @@ module Fastlane
           commit: params[:commit],
           env: params[:environment].merge(pipeline_name),
           message: params[:message],
-          # Buildkite will not trigger a build if the GitHub activity for that branch is turned off
-          # We want API triggers to work regardless of the GitHub activity settings, so this option is necessary
-          # https://forum.buildkite.community/t/request-build-error-branches-have-been-disabled-for-this-pipeline/1463/2
+          # Buildkite will not trigger a build if the GitHub activity for that branch is turned off.
+          # We want API triggers to work regardless of the GitHub activity settings, so this option is necessary.
+          # See https://forum.buildkite.community/t/request-build-error-branches-have-been-disabled-for-this-pipeline/1463/2
           ignore_pipeline_branch_filters: true
         }.compact # remove entries with `nil` values from the Hash, if any
 
@@ -30,7 +30,7 @@ module Fastlane
         if response.state == 'scheduled'
           UI.success("Successfully scheduled new build. You can see it at '#{response.web_url}'")
         else
-          UI.crash!("Failed to start job\nError: [#{response}]")
+          UI.crash!("Failed to start build.\nError: [#{response}]")
         end
       end
 
@@ -39,7 +39,8 @@ module Fastlane
       #####################################################
 
       def self.description
-        'Triggers a job on Buildkite'
+        # https://buildkite.com/docs/pipelines/glossary#build
+        'Triggers a build on Buildkite'
       end
 
       def self.available_options

--- a/spec/buildkite_trigger_build_action_spec.rb
+++ b/spec/buildkite_trigger_build_action_spec.rb
@@ -21,6 +21,7 @@ describe Fastlane::Actions::BuildkiteTriggerBuildAction do
       # rubocop:enable RSpec/VerifiedDoubles
 
       url = run_described_fastlane_action(
+        buildkite_token: 'fake-token',
         branch: 'branch',
         commit: '1a2b3c',
         pipeline_file: 'pipeline.yml',
@@ -43,6 +44,7 @@ describe Fastlane::Actions::BuildkiteTriggerBuildAction do
       expect(FastlaneCore::UI).to receive(:crash!)
 
       run_described_fastlane_action(
+        buildkite_token: 'fake-token',
         branch: 'branch',
         commit: '1a2b3c',
         pipeline_file: 'pipeline.yml',

--- a/spec/buildkite_trigger_build_action_spec.rb
+++ b/spec/buildkite_trigger_build_action_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 require 'buildkit'
 
-FakeResponse = Struct.new(:state, :web_url)
-
 describe Fastlane::Actions::BuildkiteTriggerBuildAction do
   let(:buildkit) { Buildkit.new(token: 'test') }
 
@@ -13,8 +11,14 @@ describe Fastlane::Actions::BuildkiteTriggerBuildAction do
   context 'when the API responds with state scheduled' do
     it 'returns the new build web URL' do
       expected_url = 'https://fake.url'
+      # RuboCop recommends using instance_double, but doing so requires digging into Sawyer::Resource.
+      # That object uses metaprogramming to generate accessors for the keys in the JSON response that created it.
+      # For the sake of keeping the test simple, let's use a non-verifying double.
+      #
+      # rubocop:disable RSpec/VerifiedDoubles
       allow(buildkit).to receive(:create_build)
-        .and_return(FakeResponse.new('scheduled', expected_url))
+        .and_return(double(state: 'scheduled', web_url: expected_url))
+      # rubocop:enable RSpec/VerifiedDoubles
 
       url = run_described_fastlane_action(
         branch: 'branch',
@@ -30,8 +34,10 @@ describe Fastlane::Actions::BuildkiteTriggerBuildAction do
 
   context 'when the API responds with a state other than scheduled' do
     it 'raises an error' do
+      # rubocop:disable RSpec/VerifiedDoubles
       allow(buildkit).to receive(:create_build)
-        .and_return(FakeResponse.new('fail', 'this-is-ignored'))
+        .and_return(double(state: 'fail', web_url: 'this-is-ignored'))
+      # rubocop:enable RSpec/VerifiedDoubles
 
       # Don't care about the error message
       expect(FastlaneCore::UI).to receive(:crash!)

--- a/spec/buildkite_trigger_build_action_spec.rb
+++ b/spec/buildkite_trigger_build_action_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'buildkit'
+
+FakeResponse = Struct.new(:state, :web_url)
+
+describe Fastlane::Actions::BuildkiteTriggerBuildAction do
+  let(:buildkit) { Buildkit.new(token: 'test') }
+
+  before do
+    allow(Buildkit).to receive(:new).and_return(buildkit)
+  end
+
+  context 'when the API responds with state scheduled' do
+    it 'returns the new build web URL' do
+      expected_url = 'https://fake.url'
+      allow(buildkit).to receive(:create_build)
+        .and_return(FakeResponse.new('scheduled', expected_url))
+
+      url = run_described_fastlane_action(
+        branch: 'branch',
+        commit: '1a2b3c',
+        pipeline_file: 'pipeline.yml',
+        buildkite_organization: 'org',
+        buildkite_pipeline: 'project'
+      )
+
+      expect(url).to eq expected_url
+    end
+  end
+
+  context 'when the API responds with a state other than scheduled' do
+    it 'raises an error' do
+      allow(buildkit).to receive(:create_build)
+        .and_return(FakeResponse.new('fail', 'this-is-ignored'))
+
+      # Don't care about the error message
+      expect(FastlaneCore::UI).to receive(:crash!)
+
+      run_described_fastlane_action(
+        branch: 'branch',
+        commit: '1a2b3c',
+        pipeline_file: 'pipeline.yml',
+        buildkite_organization: 'org',
+        buildkite_pipeline: 'project'
+      )
+    end
+  end
+end


### PR DESCRIPTION
The idea came while working on automating the release for one of our apps. Having the URL of the web build the action scheduled available as the return value will enable fun things like annotating the trigger build with it.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider. – N.A.
