### PR TITLE
Release 11.0.2 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ _None_
 
 - `buildkite_trigger_build` now returns the web URL of the Buildkite build it scheduled [#564]
 
+### Internal Changes
+
+- Bump `yard` from `0.9.34` to `0.9.36` [#554]
+- Bump `nokogiri` from `1.16.2` to `1.16.5` [#566]
+- Bump `rexml` from `3.2.6` to `3.2.8` [#566]
+
 ## 11.0.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- `buildkite_trigger_build` now returns the web URL of the Buildkite build it scheduled [#564]
+_None_
 
 ### Bug Fixes
 
@@ -19,6 +19,12 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 11.0.2
+
+### New Features
+
+- `buildkite_trigger_build` now returns the web URL of the Buildkite build it scheduled [#564]
 
 ## 11.0.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (11.0.1)
+    fastlane-plugin-wpmreleasetoolkit (11.0.2)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '11.0.1'
+    VERSION = '11.0.2'
   end
 end


### PR DESCRIPTION
Release 11.0.2

To address Dependabot security alerts in projects that use this tool.