### PR TITLE
Create Release Backmerge PR Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Added the action `create_release_backmerge_pull_request` to facilitate the creation of Pull Requests merging a release branch back to the main branch or currently ongoing releases [#570]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -83,7 +83,11 @@ module Fastlane
       # @param milestone [String] the milestone to associate with the pull request.
       # @param reviewers [Array<String>] the individual reviewers for the pull request.
       # @param team_reviewers [Array<String>] the team reviewers for the pull request.
-      # @return [void]
+      # @param intermediate_branch_created_callback [Proc] A callback to call after having created the intermediate branch
+      #        to allow the caller to e.g. add new commits on it before the PR is created. The callback takes two parameters: the base branch and the intermediate branch
+      #
+      # @return [String] The URL of the created Pull Request, or `nil` if no PR was created.
+      #
       def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:, intermediate_branch_created_callback:)
         intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -25,6 +25,10 @@ module Fastlane
         target_milestone = milestone_title.nil? ? nil : github_helper.get_milestone(repository, milestone_title)
 
         final_target_branches = if target_branches.empty?
+                                  unless source_branch.start_with?('release/')
+                                    UI.user_error!('`source_branch` must start with `release/`')
+                                  end
+
                                   determine_target_branches(release_version: source_branch.delete('release/'), default_branch: default_branch)
                                 else
                                   target_branches

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -48,7 +48,7 @@ module Fastlane
       end
 
       def self.determine_target_branches(release_version, default_branch)
-        release_branches = Actions.sh('git branch -r -l "origin/release/*"').chomp
+        release_branches = Actions.sh('git', 'branch', '-r', '-l', 'origin/release/*').chomp
 
         all_release_branches_versions = release_branches
                                         .split("\n")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -103,9 +103,7 @@ module Fastlane
         # if there's a callback, make sure it didn't switch branches
         other_action.ensure_git_branch(branch: "^#{intermediate_branch}/") unless intermediate_branch_created_callback.nil?
 
-        has_commits_between_head_and_base = Fastlane::Helper::GitHelper.has_commits_between?(base_ref: base_branch, head_ref: head_branch)
-
-        unless has_commits_between_head_and_base
+        if Fastlane::Helper::GitHelper.point_to_same_commit?(base_branch, head_branch)
           UI.error("No differences between #{head_branch} and #{base_branch}. Skipping PR creation.")
           return nil
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -134,7 +134,7 @@ module Fastlane
                                        default_value: DEFAULT_BRANCH,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :target_branches,
-                                       description: 'Array of target branches for the backmerge. If empty, the action will determine target branches by finding all `release/x.y.z` branches with a version greater than `release_version`. If none are found, it will target `default_branch`',
+                                       description: 'Array of target branches for the backmerge. If empty, the action will determine target branches by finding all `release/x.y.z` branches with a `x.y.z` version greater than the version in source branch's name. If none are found, it will target `default_branch`',
                                        optional: true,
                                        default_value: [],
                                        type: Array),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -43,8 +43,10 @@ module Fastlane
             title: "Merge #{release_branch} into #{target_branch}",
             head_branch: release_branch,
             base_branch: target_branch,
+            labels: labels,
             milestone: target_milestone&.number,
-            labels: labels
+            reviewers: reviewers,
+            team_reviewers: team_reviewers
           )
         end
       end
@@ -63,7 +65,7 @@ module Fastlane
         target_branches
       end
 
-      def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, milestone:, labels:)
+      def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:)
         intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
         Fastlane::Helper::GitHelper.create_branch(intermediate_branch)
 
@@ -90,7 +92,9 @@ module Fastlane
           head: intermediate_branch,
           base: base_branch,
           labels: labels,
-          milestone: milestone
+          milestone: milestone,
+          reviewers: reviewers,
+          team_reviewers: team_reviewers
         )
       end
 
@@ -107,7 +111,7 @@ module Fastlane
       end
 
       def self.return_value
-        'The list of backmerge PRs created'
+        'The list of the created backmerge Pull Request URLs'
       end
 
       def self.details
@@ -148,6 +152,14 @@ module Fastlane
                                        description: 'The title of the milestone to assign to the created PRs',
                                        optional: true,
                                        type: String),
+          FastlaneCore::ConfigItem.new(key: :reviewers,
+                                       description: 'An array of GitHub users that will be assigned to the pull request',
+                                       optional: true,
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :team_reviewers,
+                                       description: 'An array of GitHub team slugs that will be assigned to the pull request',
+                                       optional: true,
+                                       type: Array),
           Fastlane::Helper::GithubHelper.github_token_config_item,
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -83,15 +83,9 @@ module Fastlane
       # @param team_reviewers [Array<String>] the team reviewers for the pull request.
       # @return [void]
       def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:)
-        # Check for differences between head_branch and base_branch, using the three-dot diff ('base_branch...head_branch') instead
-        # of the two-dot diff ('base_branch..head_branch').
-        # This ensures that we are checking for differences as if a merge was to happen, providing a more accurate representation of what changes
-        # would be introduced by merging head_branch into base_branch.
-        #
-        # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
-        diff_output = Actions.sh('git', 'diff', "#{base_branch}...#{head_branch}").strip
+        commits_between_head_and_base = Fastlane::Helper::GitHelper.count_commits_between(base_ref: base_branch, head_ref: head_branch)
 
-        if diff_output.empty?
+        if commits_between_head_and_base.zero?
           UI.message("No differences between #{head_branch} and #{base_branch}. Skipping PR creation.")
           return nil
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -1,0 +1,163 @@
+require 'fastlane/action'
+require_relative '../../helper/github_helper'
+
+module Fastlane
+  module Actions
+    class CreateReleaseBackmergePullRequestAction < Action
+      DEFAULT_BRANCH = 'trunk'.freeze
+
+      def self.run(params)
+        token = params[:github_token]
+        repository = params[:repository]
+        release_branch = params[:release_branch]
+        default_branch = params[:default_branch]
+        target_branches_param = params[:target_branches]
+        labels = params[:labels]
+        milestone_title = params[:milestone_title]
+
+        unless release_branch.start_with?('release/')
+          UI.user_error!('`release_branch` must start with `release/`')
+        end
+
+        if target_branches_param.include?(release_branch)
+          UI.user_error!('`target_branches` must not contain `release_branch`')
+        end
+
+        github_helper = Fastlane::Helper::GithubHelper.new(github_token: params[:github_token])
+        target_milestone = milestone_title.nil? ? nil : github_helper.get_milestone(repository, milestone_title)
+
+        target_branches = if target_branches_param.empty?
+                            determine_target_branches(release_branch.delete('release/'), default_branch)
+                          else
+                            target_branches_param
+                          end
+
+        pr_urls = []
+
+        target_branches.each do |target_branch|
+          Fastlane::Helper::GitHelper.checkout_and_pull(release_branch)
+
+          pr_urls << create_backmerge_pr(
+            token: token,
+            repository: params[:repository],
+            title: "Merge #{release_branch} into #{target_branch}",
+            head_branch: release_branch,
+            base_branch: target_branch,
+            milestone: target_milestone&.number,
+            labels: labels
+          )
+        end
+
+        pr_urls
+      end
+
+      def self.determine_target_branches(release_version, default_branch)
+        release_branches = Actions.sh('git branch -r -l "origin/release/*"').chomp
+
+        all_release_branches_versions = release_branches
+                                        .split("\n")
+                                        .map { |branch| branch.match(%r{origin/release/([0-9.]*)})&.captures&.first }
+                                        .compact
+
+        target_branches = all_release_branches_versions.select { |branch| Gem::Version.new(branch) > Gem::Version.new(release_version) }
+                                                       .map { |v| "release/#{v}" }
+        target_branches = [default_branch] if target_branches.empty?
+
+        target_branches
+      end
+
+      def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, milestone:, labels:)
+        intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
+        Fastlane::Helper::GitHelper.create_branch(intermediate_branch)
+
+        other_action.push_to_git_remote(tags: false)
+
+        pr_body = <<~BODY
+          Merging `#{head_branch}` into `#{base_branch}`.
+
+          Via intermediate branch `#{intermediate_branch}`, to help fix conflicts if any:
+          ```
+          #{head_branch.rjust(40)}  ----o-- - - -
+          #{' ' * 40}       \\
+          #{intermediate_branch.rjust(40)}        `---.
+          #{' ' * 40}             \\
+          #{base_branch.rjust(40)}  ------------x- - -
+          ```
+        BODY
+
+        other_action.create_pull_request(
+          api_token: token,
+          repo: repository,
+          title: title,
+          body: pr_body,
+          head: intermediate_branch,
+          base: base_branch,
+          labels: labels,
+          milestone: milestone
+        )
+      end
+
+      def self.description
+        'Creates backmerge PRs for a release branch into target branches'
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.return_type
+        :array_of_strings
+      end
+
+      def self.return_value
+        'The list of backmerge PRs created'
+      end
+
+      def self.details
+        <<~DETAILS
+          This action creates backmerge Pull Requests from a release branch into one or more target branches.
+
+          It can be used to ensure that changes from a release branch are merged back into other branches, such as newer release branches or the main development branch (e.g., `trunk`).
+        DETAILS
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :repository,
+                                       env_name: 'GHHELPER_REPOSITORY',
+                                       description: 'The remote path of the GH repository on which we work',
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :release_branch,
+                                       description: 'The release branch, in the format `release/x.y.z`',
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :default_branch,
+                                       description: 'The default branch to target if no newer release branches exist',
+                                       optional: true,
+                                       default_value: DEFAULT_BRANCH,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :target_branches,
+                                       description: 'Array of target branches for the backmerge. If empty, the action will determine target branches by finding all `release/x.y.z` branches with a version greater than `release_version`. If none are found, it will target `default_branch`',
+                                       optional: true,
+                                       default_value: [],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :labels,
+                                       description: 'The labels that should be assigned to the backmerge PRs',
+                                       optional: true,
+                                       default_value: [],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :milestone_title,
+                                       description: 'The title of the milestone to assign to the created PRs',
+                                       optional: true,
+                                       type: String),
+          Fastlane::Helper::GithubHelper.github_token_config_item,
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -32,14 +32,12 @@ module Fastlane
                             target_branches_param
                           end
 
-        pr_urls = []
-
-        target_branches.each do |target_branch|
+        target_branches.map do |target_branch|
           Fastlane::Helper::GitHelper.checkout_and_pull(release_branch)
 
-          pr_urls << create_backmerge_pr(
+          create_backmerge_pr(
             token: token,
-            repository: params[:repository],
+            repository: repository,
             title: "Merge #{release_branch} into #{target_branch}",
             head_branch: release_branch,
             base_branch: target_branch,
@@ -47,8 +45,6 @@ module Fastlane
             labels: labels
           )
         end
-
-        pr_urls
       end
 
       def self.determine_target_branches(release_version, default_branch)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -83,8 +83,13 @@ module Fastlane
       # @param team_reviewers [Array<String>] the team reviewers for the pull request.
       # @return [void]
       def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:)
-        # Check for differences between head_branch and base_branch
-        diff_output = Actions.sh('git', 'diff', "#{base_branch}..#{head_branch}").strip
+        # Check for differences between head_branch and base_branch, using the three-dot diff ('base_branch...head_branch') instead
+        # of the two-dot diff ('base_branch..head_branch').
+        # This ensures that we are checking for differences as if a merge was to happen, providing a more accurate representation of what changes
+        # would be introduced by merging head_branch into base_branch.
+        #
+        # See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
+        diff_output = Actions.sh('git', 'diff', "#{base_branch}...#{head_branch}").strip
 
         if diff_output.empty?
           UI.message("No differences between #{head_branch} and #{base_branch}. Skipping PR creation.")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -95,7 +95,7 @@ module Fastlane
         intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
         Fastlane::Helper::GitHelper.create_branch(intermediate_branch)
 
-        intermediate_branch_created_callback&.call
+        intermediate_branch_created_callback&.call(base_branch, intermediate_branch)
 
         # if there's a callback, make sure it didn't switch branches
         other_action.ensure_git_branch(branch: "^#{intermediate_branch}/") unless intermediate_branch_created_callback.nil?
@@ -192,7 +192,7 @@ module Fastlane
                                        optional: true,
                                        type: Array),
           FastlaneCore::ConfigItem.new(key: :intermediate_branch_created_callback,
-                                       description: 'Callback to allow for the caller to perform operations on the intermediate branch before pushing',
+                                       description: 'Callback to allow for the caller to perform operations on the intermediate branch before pushing. The call back receives two parameters: the base (target) branch for the PR and the intermediate branch name',
                                        optional: true,
                                        type: Proc),
           Fastlane::Helper::GithubHelper.github_token_config_item,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -179,18 +179,18 @@ module Fastlane
         Action.sh('git', 'fetch', '--tags')
       end
 
-      # Counts the number of commits between two references in the Git repository.
+      # Calculates if there are new commits between two references in the Git repository.
       #
       # @param base_ref [String] The base reference (branch name, tag, or commit hash).
       # @param head_ref [String] The head reference (branch name, tag, or commit hash).
       # @param first_parent [Boolean] Counts only the first parent commit upon seeing a merge commit
       #
-      # @return [Integer] The number of commits between base_ref and head_ref.
+      # @return [Boolean] Whether there are new commits between base_ref and head_ref.
       #
-      def self.count_commits_between(base_ref:, head_ref:, first_parent: true)
+      def self.has_commits_between?(base_ref:, head_ref:, first_parent: true)
         git_repo = Git.open(Dir.pwd)
 
-        return git_repo.log.between(base_ref, head_ref).count unless first_parent
+        return git_repo.log.between(base_ref, head_ref).count.positive? unless first_parent
 
         base_commit = git_repo.gcommit(base_ref)
         head_commit = git_repo.gcommit(head_ref)
@@ -204,7 +204,7 @@ module Fastlane
           current_commit = current_commit.parents.first
         end
 
-        count
+        count.positive?
       end
 
       # Returns the current git branch, or "HEAD" if it's not checked out to any branch
@@ -232,6 +232,17 @@ module Fastlane
       #
       def self.branch_exists?(branch_name)
         !Action.sh('git', 'branch', '--list', branch_name).empty?
+      end
+
+      # Checks if a branch exists on the repository's remote.
+      #
+      # @param branch_name [String] the name of the branch to check.
+      # @param remote_name [String] the name of the remote repository (default is 'origin').
+      #
+      # @return [Boolean] true if the branch exists on remote, false otherwise.
+      #
+      def self.branch_exists_on_remote?(branch_name:, remote_name: 'origin')
+        !Action.sh('git', 'ls-remote', '--heads', remote_name, branch_name).empty?
       end
 
       # Ensure that we are on the expected branch, and abort if not.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -179,6 +179,21 @@ module Fastlane
         Action.sh('git', 'fetch', '--tags')
       end
 
+      # Counts the number of commits between two references in the Git repository.
+      #
+      # @param base_ref [String] The base reference (branch name, tag, or commit hash).
+      # @param head_ref [String] The head reference (branch name, tag, or commit hash).
+      #
+      # @return [Integer] The number of commits between base_ref and head_ref.
+      #
+      def self.count_commits_between(base_ref:, head_ref:)
+        git_repo = Git.open(Dir.pwd)
+
+        new_commits = git_repo.log.between(base_ref, head_ref)
+
+        new_commits.count
+      end
+
       # Returns the current git branch, or "HEAD" if it's not checked out to any branch
       # Can NOT be replaced using the environment variables such as `GIT_BRANCH` or `BUILDKITE_BRANCH`
       #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -179,32 +179,19 @@ module Fastlane
         Action.sh('git', 'fetch', '--tags')
       end
 
-      # Calculates if there are new commits between two references in the Git repository.
+      # Checks if two git references point to the same commit.
       #
-      # @param base_ref [String] The base reference (branch name, tag, or commit hash).
-      # @param head_ref [String] The head reference (branch name, tag, or commit hash).
-      # @param first_parent [Boolean] Counts only the first parent commit upon seeing a merge commit
+      # @param ref1 [String] the first git reference to check.
+      # @param ref2 [String] the second git reference to check.
       #
-      # @return [Boolean] Whether there are new commits between base_ref and head_ref.
+      # @return [Boolean] true if the two references point to the same commit, false otherwise.
       #
-      def self.has_commits_between?(base_ref:, head_ref:, first_parent: true)
+      def self.point_to_same_commit?(ref1, ref2)
         git_repo = Git.open(Dir.pwd)
+        ref1_commit = git_repo.gcommit(ref1)
+        ref2_commit = git_repo.gcommit(ref2)
 
-        return git_repo.log.between(base_ref, head_ref).count.positive? unless first_parent
-
-        base_commit = git_repo.gcommit(base_ref)
-        head_commit = git_repo.gcommit(head_ref)
-
-        count = 0
-        current_commit = head_commit
-        while current_commit
-          break if current_commit.sha == base_commit.sha
-
-          count += 1
-          current_commit = current_commit.parents.first
-        end
-
-        count.positive?
+        ref1_commit.sha == ref2_commit.sha
       end
 
       # Returns the current git branch, or "HEAD" if it's not checked out to any branch

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -31,13 +31,13 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
       .and_return("\n" + branches.map { |release| "origin/#{release}" }.join("\n") + "\n")
   end
 
-  def stub_expected_pull_requests(expected_backmerge_branches:, source_branch:, labels: [], milestone_number: nil, reviewers: nil, team_reviewers: nil, commits_between_head_and_base: 42)
+  def stub_expected_pull_requests(expected_backmerge_branches:, source_branch:, labels: [], milestone_number: nil, reviewers: nil, team_reviewers: nil, nb_new_commits: 42)
     expected_backmerge_branches.each do |target_branch|
       expected_intermediate_branch = "merge/#{source_branch.gsub('/', '-')}-into-#{target_branch.gsub('/', '-')}"
 
-      allow(Fastlane::Helper::GitHelper).to receive(:count_commits_between).with(base_ref: target_branch, head_ref: source_branch).and_return(commits_between_head_and_base)
+      allow(Fastlane::Helper::GitHelper).to receive(:count_commits_between).with(base_ref: target_branch, head_ref: source_branch).and_return(nb_new_commits)
 
-      next if commits_between_head_and_base.zero?
+      next if nb_new_commits.zero?
 
       expect(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(source_branch)
       expect(Fastlane::Helper::GitHelper).to receive(:create_branch).with(expected_intermediate_branch)
@@ -282,7 +282,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
       stub_expected_pull_requests(
         expected_backmerge_branches: expected_backmerge_branches,
         source_branch: source_branch,
-        commits_between_head_and_base: 0
+        nb_new_commits: 0
       )
 
       result = run_described_fastlane_action(

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -27,7 +27,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
 
   def stub_git_release_branches(branches)
     allow(Fastlane::Actions).to receive(:sh)
-      .with('git branch -r -l "origin/release/*"')
+      .with('git', 'branch', '-r', '-l', 'origin/release/*')
       .and_return("\n" + branches.map { |release| "origin/#{release}" }.join("\n") + "\n")
   end
 

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -31,17 +31,17 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
       .and_return("\n" + branches.map { |release| "origin/#{release}" }.join("\n") + "\n")
   end
 
-  def stub_expected_pull_requests(expected_backmerge_branches:, release_branch:, labels: [], milestone_number: nil, reviewers: nil, team_reviewers: nil)
+  def stub_expected_pull_requests(expected_backmerge_branches:, source_branch:, labels: [], milestone_number: nil, reviewers: nil, team_reviewers: nil)
     expected_backmerge_branches.each do |target_branch|
-      expected_intermediate_branch = "merge/#{release_branch.gsub('/', '-')}-into-#{target_branch.gsub('/', '-')}"
+      expected_intermediate_branch = "merge/#{source_branch.gsub('/', '-')}-into-#{target_branch.gsub('/', '-')}"
 
-      expect(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(release_branch)
+      expect(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(source_branch)
       expect(Fastlane::Helper::GitHelper).to receive(:create_branch).with(expected_intermediate_branch)
       expect(other_action_mock).to receive(:push_to_git_remote).with(tags: false)
       allow(other_action_mock).to receive(:create_pull_request).with(
         api_token: test_token,
         repo: test_repo,
-        title: "Merge #{release_branch} into #{target_branch}",
+        title: "Merge #{source_branch} into #{target_branch}",
         body: anything,
         head: expected_intermediate_branch,
         base: target_branch,
@@ -65,18 +65,18 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
       # all release branches should be ignored as we're providing `target_branches`
       stub_git_release_branches(%w[release/30.5 release/30.6 release/30.7 release/30.8])
 
-      release_branch = 'release/30.7'
+      source_branch = 'release/30.7'
 
       expected_backmerge_branches = %w[trunk release/30.6]
       stub_expected_pull_requests(
         expected_backmerge_branches: expected_backmerge_branches,
-        release_branch: release_branch
+        source_branch: source_branch
       )
 
       result = run_described_fastlane_action(
         github_token: test_token,
         repository: test_repo,
-        release_branch: release_branch,
+        source_branch: source_branch,
         target_branches: expected_backmerge_branches
       )
 
@@ -86,21 +86,21 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
 
   context 'when `target_branches` is not provided' do
     it 'determines target branches and creates backmerge PRs' do
-      # only release branches with version > `release_branch` should have a backmerge created
+      # only release branches with version > `source_branch` should have a backmerge created
       stub_git_release_branches(%w[release/30.6 release/30.5.1 release/30.5 release/30.4])
 
-      release_branch = 'release/30.5'
+      source_branch = 'release/30.5'
 
       expected_backmerge_branches = %w[release/30.6 release/30.5.1]
       stub_expected_pull_requests(
         expected_backmerge_branches: expected_backmerge_branches,
-        release_branch: release_branch
+        source_branch: source_branch
       )
 
       result = run_described_fastlane_action(
         github_token: test_token,
         repository: test_repo,
-        release_branch: release_branch
+        source_branch: source_branch
       )
 
       expect(result).to eq(expected_backmerge_branches.map { |target_branch| mock_pr_url(target_branch) })
@@ -109,17 +109,17 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
     it 'defaults to the `default_branch` if no newer release branches are found' do
       stub_git_release_branches(%w[release/30.6 release/30.5])
 
-      release_branch = 'release/30.6'
+      source_branch = 'release/30.6'
 
       stub_expected_pull_requests(
         expected_backmerge_branches: [default_branch],
-        release_branch: release_branch
+        source_branch: source_branch
       )
 
       result = run_described_fastlane_action(
         github_token: test_token,
         repository: test_repo,
-        release_branch: release_branch,
+        source_branch: source_branch,
         default_branch: default_branch
       )
 
@@ -128,35 +128,20 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
   end
 
   context 'when providing invalid input' do
-    it 'throws an error when the `release_branch` is invalid' do
+    it 'uses the `source_branch` in one of the `target_branches`' do
       stub_git_release_branches([])
 
-      release_branch = '30.6'
+      source_branch = 'release/30.6'
 
       expect do
         run_described_fastlane_action(
           github_token: test_token,
           repository: test_repo,
-          release_branch: release_branch,
-          default_branch: default_branch
-        )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, '`release_branch` must start with `release/`')
-    end
-
-    it 'uses the `release_branch` in one of the `target_branches`' do
-      stub_git_release_branches([])
-
-      release_branch = 'release/30.6'
-
-      expect do
-        run_described_fastlane_action(
-          github_token: test_token,
-          repository: test_repo,
-          release_branch: release_branch,
+          source_branch: source_branch,
           default_branch: default_branch,
           target_branches: ['release/30.6.1', 'release/30.6', 'release/30.7']
         )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, '`target_branches` must not contain `release_branch`')
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, '`target_branches` must not contain `source_branch`')
     end
   end
 
@@ -164,19 +149,19 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
     it 'creates a backmerge PR setting a milestone' do
       stub_git_release_branches([])
 
-      release_branch = 'release/30.6'
-      milestone = mock_milestone(release_branch)
+      source_branch = 'release/30.6'
+      milestone = mock_milestone(source_branch)
 
       stub_expected_pull_requests(
         expected_backmerge_branches: [default_branch],
-        release_branch: release_branch,
+        source_branch: source_branch,
         milestone_number: milestone[:number]
       )
 
       result = run_described_fastlane_action(
         github_token: test_token,
         repository: test_repo,
-        release_branch: release_branch,
+        source_branch: source_branch,
         default_branch: default_branch,
         milestone_title: milestone[:title]
       )
@@ -187,18 +172,18 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
     it 'no milestone is set if an unknown milestone is used' do
       stub_git_release_branches([])
 
-      release_branch = 'release/30.7'
+      source_branch = 'release/30.7'
 
       stub_expected_pull_requests(
         expected_backmerge_branches: [default_branch],
-        release_branch: release_branch,
+        source_branch: source_branch,
         milestone_number: nil
       )
 
       result = run_described_fastlane_action(
         github_token: test_token,
         repository: test_repo,
-        release_branch: release_branch,
+        source_branch: source_branch,
         default_branch: default_branch,
         milestone_title: 'nonexistentmilestone'
       )
@@ -215,18 +200,18 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
       it "creates a backmerge PR setting the labels: #{labels}" do
         stub_git_release_branches([])
 
-        release_branch = 'release/30.6'
+        source_branch = 'release/30.6'
 
         stub_expected_pull_requests(
           expected_backmerge_branches: [default_branch],
-          release_branch: release_branch,
+          source_branch: source_branch,
           labels: labels
         )
 
         result = run_described_fastlane_action(
           github_token: test_token,
           repository: test_repo,
-          release_branch: release_branch,
+          source_branch: source_branch,
           default_branch: default_branch,
           labels: labels
         )
@@ -244,11 +229,11 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
       it "creates a backmerge PR setting the team_reviewers `#{reviewers[:team_reviewers]}` and reviewers `#{reviewers[:reviewers]}`" do
         stub_git_release_branches([])
 
-        release_branch = 'release/30.6'
+        source_branch = 'release/30.6'
 
         stub_expected_pull_requests(
           expected_backmerge_branches: [default_branch],
-          release_branch: release_branch,
+          source_branch: source_branch,
           reviewers: reviewers[:reviewers],
           team_reviewers: reviewers[:team_reviewers]
         )
@@ -256,7 +241,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
         result = run_described_fastlane_action(
           github_token: test_token,
           repository: test_repo,
-          release_branch: release_branch,
+          source_branch: source_branch,
           default_branch: default_branch,
           reviewers: reviewers[:reviewers],
           team_reviewers: reviewers[:team_reviewers]

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -307,9 +307,10 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
         source_branch: source_branch
       )
 
-      expect(other_action_mock).to receive(:ensure_git_branch).with(branch: "^merge/release-30.6-into-#{default_branch}/")
+      intermediate_branch = "merge/release-30.6-into-#{default_branch}"
+      expect(other_action_mock).to receive(:ensure_git_branch).with(branch: "^#{intermediate_branch}/")
       allow(Fastlane::UI).to receive(:message).with(anything)
-      expect(Fastlane::UI).to receive(:message).with('branch created callback was called!')
+      expect(Fastlane::UI).to receive(:message).with("branch created callback was called! #{default_branch} #{intermediate_branch}")
 
       # Due to the Proc parameter, we cannot use run_described_fastlane_action as it converts everything to strings
       lane = <<~LANE
@@ -319,7 +320,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
             repository: '#{test_repo}',
             source_branch: '#{source_branch}',
             default_branch: '#{default_branch}',
-            intermediate_branch_created_callback: proc { UI.message('branch created callback was called!') }
+            intermediate_branch_created_callback: proc { |target, intermediate_branch| UI.message('branch created callback was called! ' + target + ' ' + intermediate_branch) }
           )
         end
       LANE

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -128,7 +128,22 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
   end
 
   context 'when providing invalid input' do
-    it 'uses the `source_branch` in one of the `target_branches`' do
+    it 'throws an error when the `source_branch` is invalid' do
+      stub_git_release_branches([])
+
+      source_branch = '30.6'
+
+      expect do
+        run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          source_branch: source_branch,
+          default_branch: default_branch
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, '`source_branch` must start with `release/`')
+    end
+
+    it 'throws an error when the `source_branch` in one of the `target_branches`' do
       stub_git_release_branches([])
 
       source_branch = 'release/30.6'

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -1,0 +1,236 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
+  let(:test_token) { 'ghp_fake_token' }
+  let(:test_repo) { 'repo-test/project-test' }
+  let(:default_branch) { 'main' }
+  let(:other_action_mock) { double }
+  let(:client) do
+    instance_double(
+      Octokit::Client,
+      user: instance_double('User', name: 'test'),
+      list_milestones: %w[30.7 30.6 30.5 30.5.1 30.4].map { |version| mock_milestone(version) },
+      'auto_paginate=': nil
+    )
+  end
+
+  def mock_milestone(release_branch)
+    release_version = release_branch.delete('release/')
+    number = release_version.gsub('.', '').to_i
+    sawyer_resource_stub(title: release_version, number: number)
+  end
+
+  def mock_pr_url(release_branch)
+    number = release_branch.delete('release/').gsub('.', '').to_i
+    "https://github.com/#{test_repo}/pull/#{number}"
+  end
+
+  def stub_git_release_branches(branches)
+    allow(Fastlane::Actions).to receive(:sh)
+      .with('git branch -r -l "origin/release/*"')
+      .and_return("\n" + branches.map { |release| "origin/#{release}" }.join("\n") + "\n")
+  end
+
+  def stub_expected_pull_requests(expected_backmerge_branches:, release_branch:, labels: [], milestone_number: nil)
+    expected_backmerge_branches.each do |target_branch|
+      expected_intermediate_branch = "merge/#{release_branch.gsub('/', '-')}-into-#{target_branch.gsub('/', '-')}"
+
+      expect(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull).with(release_branch)
+      expect(Fastlane::Helper::GitHelper).to receive(:create_branch).with(expected_intermediate_branch)
+      expect(other_action_mock).to receive(:push_to_git_remote).with(tags: false)
+      allow(other_action_mock).to receive(:create_pull_request).with(
+        api_token: test_token,
+        repo: test_repo,
+        title: "Merge #{release_branch} into #{target_branch}",
+        body: anything,
+        head: expected_intermediate_branch,
+        base: target_branch,
+        labels: labels,
+        milestone: milestone_number
+      ).and_return(mock_pr_url(target_branch))
+    end
+  end
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(client)
+    allow(Fastlane::Helper::GitHelper).to receive(:checkout_and_pull)
+    allow(Fastlane::Helper::GitHelper).to receive(:create_branch)
+    allow(Fastlane::Action).to receive(:other_action).and_return(other_action_mock)
+  end
+
+  context 'when `target_branches` is provided' do
+    it 'creates a backmerge PR for each target branch' do
+      # all release branches should be ignored as we're providing `target_branches`
+      stub_git_release_branches(%w[release/30.5 release/30.6 release/30.7 release/30.8])
+
+      release_branch = 'release/30.7'
+
+      expected_backmerge_branches = %w[trunk release/30.6]
+      stub_expected_pull_requests(
+        expected_backmerge_branches: expected_backmerge_branches,
+        release_branch: release_branch
+      )
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        release_branch: release_branch,
+        target_branches: expected_backmerge_branches
+      )
+
+      expect(result).to eq(expected_backmerge_branches.map { |target_branch| mock_pr_url(target_branch) })
+    end
+  end
+
+  context 'when `target_branches` is not provided' do
+    it 'determines target branches and creates backmerge PRs' do
+      # only release branches with version > `release_branch` should have a backmerge created
+      stub_git_release_branches(%w[release/30.6 release/30.5.1 release/30.5 release/30.4])
+
+      release_branch = 'release/30.5'
+
+      expected_backmerge_branches = %w[release/30.6 release/30.5.1]
+      stub_expected_pull_requests(
+        expected_backmerge_branches: expected_backmerge_branches,
+        release_branch: release_branch
+      )
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        release_branch: release_branch
+      )
+
+      expect(result).to eq(expected_backmerge_branches.map { |target_branch| mock_pr_url(target_branch) })
+    end
+
+    it 'defaults to the `default_branch` if no newer release branches are found' do
+      stub_git_release_branches(%w[release/30.6 release/30.5])
+
+      release_branch = 'release/30.6'
+
+      stub_expected_pull_requests(
+        expected_backmerge_branches: [default_branch],
+        release_branch: release_branch
+      )
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        release_branch: release_branch,
+        default_branch: default_branch
+      )
+
+      expect(result).to eq([mock_pr_url(default_branch)])
+    end
+  end
+
+  context 'when providing invalid input' do
+    it 'throws an error when the `release_branch` is invalid' do
+      stub_git_release_branches([])
+
+      release_branch = '30.6'
+
+      expect do
+        run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          release_branch: release_branch,
+          default_branch: default_branch
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, '`release_branch` must start with `release/`')
+    end
+
+    it 'uses the `release_branch` in one of the `target_branches`' do
+      stub_git_release_branches([])
+
+      release_branch = 'release/30.6'
+
+      expect do
+        run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          release_branch: release_branch,
+          default_branch: default_branch,
+          target_branches: ['release/30.6.1', 'release/30.6', 'release/30.7']
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, '`target_branches` must not contain `release_branch`')
+    end
+  end
+
+  context 'when providing a milestone' do
+    it 'creates a backmerge PR setting a milestone' do
+      stub_git_release_branches([])
+
+      release_branch = 'release/30.6'
+      milestone = mock_milestone(release_branch)
+
+      stub_expected_pull_requests(
+        expected_backmerge_branches: [default_branch],
+        release_branch: release_branch,
+        milestone_number: milestone[:number]
+      )
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        release_branch: release_branch,
+        default_branch: default_branch,
+        milestone_title: milestone[:title]
+      )
+
+      expect(result).to eq([mock_pr_url(default_branch)])
+    end
+
+    it 'no milestone is set if an unknown milestone is used' do
+      stub_git_release_branches([])
+
+      release_branch = 'release/30.7'
+
+      stub_expected_pull_requests(
+        expected_backmerge_branches: [default_branch],
+        release_branch: release_branch,
+        milestone_number: nil
+      )
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        release_branch: release_branch,
+        default_branch: default_branch,
+        milestone_title: 'nonexistentmilestone'
+      )
+
+      expect(result).to eq([mock_pr_url(default_branch)])
+    end
+  end
+
+  context 'when providing labels' do
+    [
+      %w[java ruby perl],
+      [],
+    ].each do |labels|
+      it "creates a backmerge PR setting the labels: #{labels}" do
+        stub_git_release_branches([])
+
+        release_branch = 'release/30.6'
+
+        stub_expected_pull_requests(
+          expected_backmerge_branches: [default_branch],
+          release_branch: release_branch,
+          labels: labels
+        )
+
+        result = run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          release_branch: release_branch,
+          default_branch: default_branch,
+          labels: labels
+        )
+
+        expect(result).to eq([mock_pr_url(default_branch)])
+      end
+    end
+  end
+end

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -33,7 +33,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
 
   def stub_git_branches_diff(base_branch:, head_branch:, diff:)
     allow(Fastlane::Actions).to receive(:sh)
-      .with('git', 'diff', "#{base_branch}..#{head_branch}")
+      .with('git', 'diff', "#{base_branch}...#{head_branch}")
       .and_return(diff)
   end
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -26,12 +26,12 @@ describe Fastlane::Helper::GitHelper do
   end
 
   it 'can detect a valid git repository' do
-    `git init --initial-branch main || git init`
+    init_git_repo
     expect(described_class.is_git_repo?).to be true
   end
 
   it 'can detect a valid git repository from a child folder' do
-    `git init --initial-branch main || git init`
+    init_git_repo
     `mkdir -p a/b`
     Dir.chdir('./a/b')
     expect(described_class.is_git_repo?).to be true
@@ -54,13 +54,13 @@ describe Fastlane::Helper::GitHelper do
   end
 
   it 'can detect a repository with Git-lfs enabled' do
-    `git init --initial-branch main || git init`
+    init_git_repo
     `git lfs install`
     expect(described_class.has_git_lfs?).to be true
   end
 
   it 'can detect a repository without Git-lfs enabled' do
-    `git init --initial-branch main || git init`
+    init_git_repo
     `git lfs uninstall &>/dev/null`
     expect(described_class.is_git_repo?).to be true
     expect(described_class.has_git_lfs?).to be false
@@ -107,6 +107,74 @@ describe Fastlane::Helper::GitHelper do
     it 'adds all pending file changes before commit if :all is provided as `files`' do
       expect_shell_command('git', 'commit', '-a', '-m', @message)
       described_class.commit(message: @message, files: :all)
+    end
+  end
+
+  context('count_commits_between(base_ref:, head_ref:)') do
+    before do
+      # Spec branching setup:
+      #
+      #   (1.0)
+      # A---B---C         main
+      #        / \
+      #       |   D---E   feature-branch
+      #       F---G---H   another-branch / new-branch
+
+      init_git_repo
+
+      add_file_and_commit(file: 'file1.txt', message: 'commit A')
+      add_file_and_commit(file: 'file2.txt', message: 'commit B')
+
+      create_tag('1.0')
+
+      add_file_and_commit(file: 'file3.txt', message: 'commit C')
+
+      create_branch('feature-branch')
+      add_file_and_commit(file: 'file4.txt', message: 'commit D feature branch')
+      add_file_and_commit(file: 'file5.txt', message: 'commit E feature branch')
+
+      checkout_branch('main')
+
+      create_branch('another-branch')
+      add_file_and_commit(file: 'file6.txt', message: 'commit F another branch')
+      add_file_and_commit(file: 'file7.txt', message: 'commit G another branch')
+      add_file_and_commit(file: 'file8.txt', message: 'commit H another branch')
+
+      create_branch('new-branch')
+    end
+
+    it 'counts commits between different branches' do
+      count = described_class.count_commits_between(base_ref: 'main', head_ref: 'feature-branch')
+      expect(count).to eq(2)
+    end
+
+    it 'counts commits between a tag and a branch' do
+      count = described_class.count_commits_between(base_ref: '1.0', head_ref: 'feature-branch')
+      expect(count).to eq(3)
+    end
+
+    it 'counts commits between a commit hash and a branch' do
+      count = described_class.count_commits_between(base_ref: commit_hash(commit_message: 'commit B'), head_ref: 'another-branch')
+      expect(count).to eq(4)
+    end
+
+    it 'counts commits between different branches with the same parent' do
+      count = described_class.count_commits_between(base_ref: 'feature-branch', head_ref: 'another-branch')
+      expect(count).to eq(3)
+    end
+
+    it 'counts commits between the same branch' do
+      count = described_class.count_commits_between(base_ref: 'feature-branch', head_ref: 'feature-branch')
+      expect(count).to eq(0)
+    end
+
+    it 'counts commits between branches that have no difference' do
+      count = described_class.count_commits_between(base_ref: 'another-branch', head_ref: 'new-branch')
+      expect(count).to eq(0)
+    end
+
+    it 'raises error for a non-existent base_ref' do
+      expect { described_class.count_commits_between(base_ref: 'non-existent', head_ref: 'main') }.to raise_error(StandardError)
     end
   end
 
@@ -170,7 +238,7 @@ describe Fastlane::Helper::GitHelper do
 end
 
 def setup_git_repo(dummy_file_path: nil, add_file_to_gitignore: false, commit_gitignore: false)
-  `git init --initial-branch main || git init`
+  init_git_repo
   `touch .gitignore`
   `git add .gitignore && git commit -m 'Add .gitignore'`
 
@@ -185,4 +253,30 @@ def setup_git_repo(dummy_file_path: nil, add_file_to_gitignore: false, commit_gi
 
   `echo #{dummy_file_path} > .gitignore`
   `git add .gitignore && git commit -m 'Update .gitignore'` if commit_gitignore
+end
+
+def init_git_repo
+  `git init --initial-branch main || git init`
+end
+
+def add_file_and_commit(file:, message:)
+  `touch #{file}`
+  `git add .`
+  `git commit -m '#{message}'`
+end
+
+def checkout_branch(branch_name)
+  `git checkout #{branch_name}`
+end
+
+def create_branch(branch_name)
+  `git checkout -B #{branch_name}`
+end
+
+def create_tag(tag_name)
+  `git tag #{tag_name}`
+end
+
+def commit_hash(commit_message:)
+  `git log --pretty=format:'%H' -1 --grep='#{commit_message}'`.strip
 end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -110,7 +110,7 @@ describe Fastlane::Helper::GitHelper do
     end
   end
 
-  context('has_commits_between?(base_ref:, head_ref:, first_parent:)') do
+  context('point_to_same_commit?(ref1, ref2)') do
     before do
       # Spec branching setup:
       #
@@ -144,48 +144,38 @@ describe Fastlane::Helper::GitHelper do
       merge_branch(base: 'main', head: 'feature-branch')
     end
 
-    shared_examples 'counting commits between refs' do |first_parent|
-      it 'counts commits between a tag and a branch' do
-        diff_exists = described_class.has_commits_between?(base_ref: '1.0', head_ref: 'another-branch', first_parent: first_parent)
-        expect(diff_exists).to be true
-      end
-
-      it 'counts commits between a tag and a branch that had a merge' do
-        diff_exists = described_class.has_commits_between?(base_ref: '1.0', head_ref: 'main', first_parent: first_parent)
-        expect(diff_exists).to be true
-      end
-
-      it 'counts commits between a tag and a commit hash' do
-        diff_exists = described_class.has_commits_between?(base_ref: '1.0', head_ref: commit_hash(commit_message: 'commit D'))
-        expect(diff_exists).to be true
-      end
-
-      it 'counts commits between a commit hash and a branch' do
-        diff_exists = described_class.has_commits_between?(base_ref: commit_hash(commit_message: 'commit B'), head_ref: 'another-branch', first_parent: first_parent)
-        expect(diff_exists).to be true
-      end
-
-      it 'counts commits between the same branch' do
-        diff_exists = described_class.has_commits_between?(base_ref: 'feature-branch', head_ref: 'feature-branch', first_parent: first_parent)
-        expect(diff_exists).to be false
-      end
-
-      it 'counts commits between branches that have no difference' do
-        diff_exists = described_class.has_commits_between?(base_ref: 'another-branch', head_ref: 'new-branch', first_parent: first_parent)
-        expect(diff_exists).to be false
-      end
-
-      it 'raises error for a non-existent base_ref' do
-        expect { described_class.has_commits_between?(base_ref: 'non-existent', head_ref: 'main', first_parent: first_parent) }.to raise_error(StandardError)
-      end
+    it 'checks if a tag and a branch point to the same commit' do
+      same_commit = described_class.point_to_same_commit?('1.0', 'another-branch')
+      expect(same_commit).to be false
     end
 
-    context 'counting commits considering only the merge commit (first parent)' do
-      include_examples 'counting commits between refs', true
+    it 'checks if a tag and a branch that had a merge point to the same commit' do
+      same_commit = described_class.point_to_same_commit?('1.0', 'main')
+      expect(same_commit).to be false
     end
 
-    context 'counting commits considering all commits' do
-      include_examples 'counting commits between refs', false
+    it 'checks if a tag and a commit hash point to the same commit' do
+      same_commit = described_class.point_to_same_commit?('1.0', commit_hash(commit_message: 'commit D'))
+      expect(same_commit).to be false
+    end
+
+    it 'checks if a commit hash and a branch point to the same commit' do
+      same_commit = described_class.point_to_same_commit?(commit_hash(commit_message: 'commit B'), 'another-branch')
+      expect(same_commit).to be false
+    end
+
+    it 'checks if commits between the same branch point to the same commit' do
+      same_commit = described_class.point_to_same_commit?('feature-branch', 'feature-branch')
+      expect(same_commit).to be true
+    end
+
+    it 'checks if commits between branches that have no difference point to the same commit' do
+      same_commit = described_class.point_to_same_commit?('another-branch', 'new-branch')
+      expect(same_commit).to be true
+    end
+
+    it 'raises error for a non-existent base_ref' do
+      expect { described_class.point_to_same_commit?('non-existent', 'main') }.to raise_error(StandardError)
     end
   end
 


### PR DESCRIPTION
## What does it do?

This PR adds the `create_release_backmerge_pull_request` action.

Its goal is to facilitate the creation of Pull Requests from a release branch back to the main branch or, alternatively, to any currently ongoing version (e.g. in a case of a hotfix, there might be already new version(s) being released).

It standardize some common tasks such as creating the PR from an intermediate branch based on the release branch, assigning a milestone to the newly created PR, generating a illustrative PR body text and so on.

An example call looks like:
```ruby
create_release_backmerge_pull_request(
  repository: GITHUB_REPO,
  release_branch: 'release/30.6',
  default_branch: 'trunk',
  milestone_title: '30.6'
)
```

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
