### PR TITLE
Fix `android_download_translations` issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix `android_download_translation` issues reported in #569 [#571]
+   - add post-processing of `plurals` nodes too.
+   - detect and fix `\@string/` references escaped in GlotPress exports.
+   - replicate all XML attributes (and xmlns) present in `values/string.xml` on the corresponding nodes in the translated XML.
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -354,18 +354,18 @@ module Fastlane
           end
           # 3. Process copies for `string` nodes
           translated_xml.xpath('//string[@name]').each do |string_node|
-            apply_substitutions(string_node)
+            apply_substitutions!(string_node)
             quick_lint(string_node, locale_code)
           end
           # 4. Process copies for `string-array/item` nodes
           translated_xml.xpath('//string-array[@name]/item').each do |item_node|
-            apply_substitutions(item_node)
+            apply_substitutions!(item_node)
             quick_lint(item_node, locale_code)
           end
           # 5. Replicate attributes + Process copies for `plurals/item` nodes
           translated_xml.xpath('//plurals[@name]/item[@quantity]').each do |item_node|
             copy_orig_attributes.call(item_node, "//*[@name = '#{item_node.parent['name']}']/item[@quantity = '#{item_node['quantity']}']")
-            apply_substitutions(item_node)
+            apply_substitutions!(item_node)
             quick_lint(item_node, locale_code)
           end
         end
@@ -375,7 +375,7 @@ module Fastlane
         #
         # @param [Nokogiri::XML::Node] tag The XML tag/node to apply substitutions to
         #
-        def self.apply_substitutions(tag)
+        def self.apply_substitutions!(tag)
           tag.content = tag.content.gsub('...', '…')
 
           # Typography en-dash
@@ -387,7 +387,7 @@ module Fastlane
             is_negative_number ? str : "#{match[1]}\u{2013}#{match[2]}"
           end
         end
-        private_class_method :apply_substitutions
+        private_class_method :apply_substitutions!
 
         # Perform some quick basic checks about an individual `<string>` tag and print warnings accordingly:
         #  - detect the use of `%%` in the string even if `formatted=false` is set

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -405,7 +405,7 @@ module Fastlane
           # rubocop:disable Style/GuardClause
           if node.content.include?('\\@string/')
             UI.important "Warning: [#{lang}] exported translation for '#{named_node['name']}' contains `\\@string/`. This is a sign that this entry was not marked as `translatable=false` " \
-              + "in the original `values/strings.xml`, and was thus sent to GlotPress, which added the backslash when exporting it back."
+              + 'in the original `values/strings.xml`, and was thus sent to GlotPress, which added the backslash when exporting it back.'
             node.content = node.content.gsub('\\@string/', '@string/')
           end
           # rubocop:enable Style/GuardClause

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -152,6 +152,13 @@ module Fastlane
           (added_count + updated_count) != 0
         end
 
+        ########
+        # @!group Verify diff of library vs main strings matches
+        #
+        # @note This set of methods is used by `an_validate_lib_strings_action`
+        #       (which doesn't seem to be used by any of our Android projects nowadays?)
+        ########
+
         def self.verify_diff(diff_string, main_strings, lib_strings, library)
           return unless diff_string.start_with?('name=')
 
@@ -197,6 +204,8 @@ module Fastlane
             end
           end
         end
+
+        # @!endgroup
 
         ########
         # @!group Downloading translations from GlotPress
@@ -266,8 +275,10 @@ module Fastlane
           end
         end
 
+        # @!endgroup
+
         #####################
-        # Private Helpers
+        # @!group Private Helpers
         #####################
 
         # Downloads the export from GlotPress for a given locale and given filters
@@ -296,6 +307,9 @@ module Fastlane
         private_class_method :download_glotpress_export_file
 
         # Merge multiple Nokogiri::XML `strings.xml` documents together
+        #
+        # Used especially when we provided multiple GlotPress filters to `download_from_glotpress`,
+        # as in this case we'd trigger one export per filter, then merge the result in a single XML
         #
         # @param [Array<Nokogiri::XML::Document>] all_xmls Array of the Nokogiri XML documents to merge together
         # @return [Nokogiri::XML::Document] The merged document.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -364,7 +364,7 @@ module Fastlane
           end
           # 5. Replicate attributes + Process copies for `plurals/item` nodes
           translated_xml.xpath('//plurals[@name]/item[@quantity]').each do |item_node|
-            copy_orig_attributes.call(item_node, "//*[@name = '#{item_node.parent['name']}']/item[@quantity = '#{item_node['quantity']}']")
+            copy_orig_attributes.call(item_node, "//plurals[@name = '#{item_node.parent['name']}']/item[@quantity = '#{item_node['quantity']}']")
             apply_substitutions!(item_node)
             quick_lint(item_node, locale_code)
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -232,7 +232,7 @@ module Fastlane
         #
         # @param [String] res_dir The relative path to the `…/src/main/res` directory.
         # @param [String] glotpress_project_url The base URL to the glotpress project to download the strings from.
-        # @param [Hash{String=>String}, Array] glotpress_filters
+        # @param [Hash{Symbol=>String}, Array] glotpress_filters
         #        The filters to apply when exporting strings from GlotPress.
         #        Typical examples include `{ status: 'current' }` or `{ status: 'review' }`.
         #        If an array of Hashes is provided instead of a single Hash, this method will perform as many
@@ -279,7 +279,7 @@ module Fastlane
         # @param [String] locale The GlotPress locale code to download strings for.
         # @param [Hash{Symbol=>String}] filters The hash of filters to apply when exporting from GlotPress.
         #                               Typical examples include `{ status: 'current' }` or `{ status: 'review' }`.
-        # @return [Nokogiri::XML] the download XML document, parsed as a Nokogiri::XML object
+        # @return [Nokogiri::XML::Document] the download XML document, parsed as a Nokogiri::XML object
         #
         def self.download_glotpress_export_file(project_url:, locale:, filters:)
           query_params = filters.transform_keys { |k| "filters[#{k}]" }.merge(format: 'android')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -404,8 +404,9 @@ module Fastlane
           end
           # rubocop:disable Style/GuardClause
           if node.content.include?('\\@string/')
-            UI.important "Warning: [#{lang}] translation for '#{named_node['name']}' contains `\\@string/`. This is a sign that this entry was not marked as `translatable=false` in the original `values/strings.xml`, " \
-              + "as it should have when you're referencing another string (and as a result was sent to GlotPress, which added the backslash when exporting it back."
+            UI.important "Warning: [#{lang}] exported translation for '#{named_node['name']}' contains `\\@string/`. This is a sign that this entry was not marked as `translatable=false` " \
+              + "in the original `values/strings.xml`, and was thus sent to GlotPress, which added the backslash when exporting it back."
+            node.content = node.content.gsub('\\@string/', '@string/')
           end
           # rubocop:enable Style/GuardClause
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -407,6 +407,7 @@ module Fastlane
             UI.important "Warning: [#{lang}] translation for '#{named_node['name']}' contains `\\@string/`. This is a sign that this entry was not marked as `translatable=false` in the original `values/strings.xml`, " \
               + "as it should have when you're referencing another string (and as a result was sent to GlotPress, which added the backslash when exporting it back."
           end
+          # rubocop:enable Style/GuardClause
         end
         private_class_method :quick_lint
 

--- a/spec/android_localize_helper_spec.rb
+++ b/spec/android_localize_helper_spec.rb
@@ -182,18 +182,43 @@ describe Fastlane::Helper::Android::LocalizeHelper do
           include_examples 'en-dash substitutions', 'ordered lists', "/resources/string-array[@name='checklist_array']/item[1]", '- 1.', "\u{2013} 1.", '- 1.'
           include_examples 'en-dash substitutions', 'unordered lists', "/resources/string-array[@name='checklist_array']/item[2]", '- o', "\u{2013} o", '- o'
         end
+
+        context 'with //plurals/item tags' do
+          include_examples 'ellipsis substitutions', "/resources/plurals[@name='confirm_entry_trash']/item[@quantity='other']"
+        end
       end
 
-      it 'replicates formatted="false" attribute to generated files' do
-        orig_xml = File.open(generated_file(nil)) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
-        pt_xml = File.open(generated_file('pt-rBR')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+      describe 'replicates attributes to generated files' do
+        shared_examples 'replicates attributes' do |xpath, attribute|
+          it "replicates the `#{attribute}` attribute to generated files" do
+            orig_xml = File.open(generated_file(nil)) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+            pt_xml = File.open(generated_file('pt-rBR')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
 
-        orig_node = orig_xml.xpath("/resources/string[@formatted='false']").first
-        expect(orig_node).not_to be_nil
+            orig_node = orig_xml.xpath(xpath).first
+            expect(orig_node).not_to be_nil
 
-        pt_node = pt_xml.xpath("/resources/string[@name='#{orig_node['name']}']").first
-        expect(pt_node).not_to be_nil
-        expect(pt_node['formatted']).to eq(orig_node['formatted'])
+            pt_node = pt_xml.xpath(xpath).first
+            expect(pt_node).not_to be_nil
+            expect(pt_node[attribute]).to eq(orig_node[attribute])
+          end
+        end
+
+        context 'with /resource tags' do
+          include_examples 'replicates attributes', '/resources', 'xmlns:tools'
+        end
+
+        context 'with //string tags' do
+          include_examples 'replicates attributes', "/resources/string[@name='shipping_label_woo_discount_bottomsheet_message']", 'formatted'
+          include_examples 'replicates attributes', "/resources/string[@name='app_name']", 'content_override'
+        end
+
+        context 'with //string-array tags' do
+          include_examples 'replicates attributes', "/resources/string-array[@name='weeks_full']", 'translatable'
+        end
+
+        context 'with //plurals tags' do
+          include_examples 'replicates attributes', "/resources/plurals[@name='confirm_entry_trash']", 'formatted'
+        end
       end
 
       it 'warns about %% usage on tags with formatted="false"' do

--- a/spec/android_localize_helper_spec.rb
+++ b/spec/android_localize_helper_spec.rb
@@ -221,18 +221,57 @@ describe Fastlane::Helper::Android::LocalizeHelper do
         end
       end
 
-      it 'warns about %% usage on tags with formatted="false"' do
-        fr_xml = File.open(generated_file('fr')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
-        string_nodes = fr_xml.xpath("/resources/string[@formatted='false'][contains(text(),'%%')]")
-        expect(string_nodes).not_to be_empty
-        item_nodes = fr_xml.xpath("/resources/*[@formatted='false']/item[contains(text(),'%%')]")
-        expect(item_nodes).not_to be_empty
+      describe 'quick_lint' do
+        it 'warns about %% usage on tags with formatted="false"' do
+          fr_xml = File.open(generated_file('fr')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+          string_nodes = fr_xml.xpath("/resources/string[@formatted='false'][contains(text(),'%%')]")
+          expect(string_nodes).not_to be_empty
+          item_nodes = fr_xml.xpath("/resources/*[@formatted='false']/item[contains(text(),'%%')]")
+          expect(item_nodes).not_to be_empty
 
-        [*string_nodes, *item_nodes].each do |node|
-          expect(node.content).to include('%%')
-          rsrc_name = node['name'] || node.parent['name']
-          expect(rsrc_name).not_to be_nil
-          expect(warning_messages).to include(%(Warning: [fr] translation for '#{rsrc_name}' has attribute formatted=false, but still contains escaped '%%' in translation.))
+          [*string_nodes, *item_nodes].each do |node|
+            expect(node.content).to include('%%')
+            rsrc_name = node['name'] || node.parent['name']
+            expect(rsrc_name).not_to be_nil
+            expect(warning_messages).to include(%(Warning: [fr] translation for '#{rsrc_name}' has attribute formatted=false, but still contains escaped '%%' in translation.))
+          end
+        end
+
+        it 'warns about @string/ references not containing translatable="false"' do
+          fr_exported_xml = File.open(stub_file('fr')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+          exported_node = fr_exported_xml.xpath("/resources/string[@name='stringref']")&.first
+          expect(exported_node).not_to be_nil
+          expect(exported_node.content).to include('\\@string/')
+
+          fr_processed_xml = File.open(generated_file('fr')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+          processed_node = fr_processed_xml.xpath("/resources/string[@name='stringref']")&.first
+          expect(processed_node).not_to be_nil
+          expect(processed_node.content).to include('@string/')
+          expect(processed_node.content).not_to include('\\@string/')
+
+          expect(warning_messages).to include("Warning: [fr] exported translation for 'stringref' contains `\\@string/`. This is a sign that this entry was not marked as `translatable=false` " \
+                + "in the original `values/strings.xml`, and was thus sent to GlotPress, which added the backslash when exporting it back.")
+        end
+
+        it 'auto-fixes `\\@string/` escaped references in string, string-array/item and plurals/' do
+          fr_exported_xml = File.open(stub_file('fr')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+          fr_processed_xml = File.open(generated_file('fr')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+
+          xpaths = %w[
+            /resources/string[@name='stringref']
+            /resources/string-array[@name='weeks_full']
+            /resources/plurals[@name='confirm_entry_trash']/item[@quantity='one']
+          ]
+          xpaths.each do |xpath|
+            exported_node = fr_exported_xml.xpath(xpath)&.first
+            expect(exported_node).not_to be_nil
+            expect(exported_node.content).to include('\\@string/')
+
+            processed_node = fr_processed_xml.xpath(xpath)&.first
+            expect(processed_node).not_to be_nil
+            expect(processed_node.content).to include('@string/')
+            expect(processed_node.content).not_to include('\\@string/')
+          end
         end
       end
     end

--- a/spec/android_localize_helper_spec.rb
+++ b/spec/android_localize_helper_spec.rb
@@ -196,15 +196,21 @@ describe Fastlane::Helper::Android::LocalizeHelper do
 
             orig_node = orig_xml.xpath(xpath).first
             expect(orig_node).not_to be_nil
+            expect(orig_node[attribute]).not_to be_nil
 
             pt_node = pt_xml.xpath(xpath).first
             expect(pt_node).not_to be_nil
+            expect(pt_node[attribute]).not_to be_nil
             expect(pt_node[attribute]).to eq(orig_node[attribute])
           end
         end
 
-        context 'with /resource tags' do
-          include_examples 'replicates attributes', '/resources', 'xmlns:tools'
+        it 'replicates the xmlns namespaces on generated files' do
+          orig_xml = File.open(generated_file(nil)) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+          pt_xml = File.open(generated_file('pt-rBR')) { |f| Nokogiri::XML(f, nil, Encoding::UTF_8.to_s) }
+
+          expect(orig_xml.namespaces).not_to be_empty
+          expect(pt_xml.namespaces).to eq(orig_xml.namespaces)
         end
 
         context 'with //string tags' do

--- a/spec/android_localize_helper_spec.rb
+++ b/spec/android_localize_helper_spec.rb
@@ -250,7 +250,7 @@ describe Fastlane::Helper::Android::LocalizeHelper do
           expect(processed_node.content).not_to include('\\@string/')
 
           expect(warning_messages).to include("Warning: [fr] exported translation for 'stringref' contains `\\@string/`. This is a sign that this entry was not marked as `translatable=false` " \
-                + "in the original `values/strings.xml`, and was thus sent to GlotPress, which added the backslash when exporting it back.")
+                + 'in the original `values/strings.xml`, and was thus sent to GlotPress, which added the backslash when exporting it back.')
         end
 
         it 'auto-fixes `\\@string/` escaped references in string, string-array/item and plurals/' do

--- a/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
@@ -72,8 +72,15 @@ Language: fr
         <item>@string/saturday</item>
         <item>None</item>
     </string-array>
+    <string-array name="progress" formatted="false">
+        <item>0%%</item>
+        <item>25%</item>
+        <item>50%%</item>
+        <item>75%</item>
+        <item>100%</item>
+    </string-array>
     <string name="confirm_single_entry_trash">Êtes-vous sûr de vouloir déplacer cette entrée vers la corbeille ?</string>
-    <plurals name="confirm_entry_trash" formatted="false">
+    <plurals name="confirm_entry_trash" formatted="true">
         <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
         <item quantity="other">Etes-vous sûr… de vouloir déplacer %d entrées vers la corbeille ?</item>
     </plurals>

--- a/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
@@ -71,7 +71,7 @@ Language: fr
         <item>@string/thursday</item>
         <item>@string/friday</item>
         <item>@string/saturday</item>
-        <item>None</item>
+        <item>Aucun</item>
     </string-array>
     <string-array name="progress" formatted="false">
         <item>0%%</item>

--- a/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
@@ -31,6 +31,7 @@ Language: fr
         <item>En cours…</item>
         <item>Toutes les commandes…</item>
     </string-array>
+    <string name="stringref">@string/shipping_label_woo_discount_bottomsheet_title</string>
     <string name="threat_fix_description">Les prix vont de 70–120 $ par heure</string>
     <string-array name="settings_jetpackdescription">
         <item>Vous pouvez marquer une adresse IP (ou une série d’adresses IP) comme « Toujours autorisé »</item>

--- a/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-fr/strings.xml
@@ -5,7 +5,8 @@ Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/2.4.0-alpha
 Language: fr
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string name="app_name" content_override="true">WooCommerce</string>
     <string name="product_attributes_error_saving">Erreur lors de l’enregistrement de vos attributs</string>
     <string name="shipping_label_payments_cant_edit_warning">Seul le propriétaire du site peut gérer les moyens de paiement des étiquettes d’expédition. Veuillez contacter le propriétaire de la boutique %1$s (%2$s) pour gérer les moyens de paiement.</string>
     <string name="shipping_label_shipping_method_free_shipping">Livraison gratuite</string>
@@ -54,4 +55,26 @@ Language: fr
         <item> - o Deux: deuxième point</item>
     </string-array>
     <string name="multi_range_statement">La première plage est 2–100 et la seconde est 123–456.</string>
+    <string name="sunday">Dimanche</string>
+    <string name="monday">Lundi</string>
+    <string name="tuesday">Mardi</string>
+    <string name="wednesday">Mercredi</string>
+    <string name="thursday">Jeudi</string>
+    <string name="friday">Vendredi</string>
+    <string name="saturday">Samedi</string>
+    <string-array name="weeks_full" translatable="false">
+        <item>@string/sunday</item>
+        <item>@string/monday</item>
+        <item>@string/tuesday</item>
+        <item>@string/wednesday</item>
+        <item>@string/thursday</item>
+        <item>@string/friday</item>
+        <item>@string/saturday</item>
+        <item>None</item>
+    </string-array>
+    <string name="confirm_single_entry_trash">Êtes-vous sûr de vouloir déplacer cette entrée vers la corbeille ?</string>
+    <plurals name="confirm_entry_trash" formatted="false">
+        <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
+        <item quantity="other">Etes-vous sûr… de vouloir déplacer %d entrées vers la corbeille ?</item>
+    </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/expected/values-pt-rBR/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-pt-rBR/strings.xml
@@ -63,8 +63,15 @@ Language: pt_BR
         <item>@string/saturday</item>
         <item>Nenhum</item>
     </string-array>
+    <string-array name="progress" formatted="false">
+        <item>0%</item>
+        <item>25%</item>
+        <item>50%</item>
+        <item>75%</item>
+        <item>100%</item>
+    </string-array>
     <string name="confirm_single_entry_trash">Tem certeza de que deseja mover esta entrada para a lixeira?</string>
-    <plurals name="confirm_entry_trash" formatted="false">
+    <plurals name="confirm_entry_trash" formatted="true">
         <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
         <item quantity="other">Tem certeza… deseja mover %d entradas para a lixeira?</item>
     </plurals>

--- a/spec/test-data/translations/glotpress-download/expected/values-pt-rBR/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-pt-rBR/strings.xml
@@ -5,7 +5,8 @@ Plural-Forms: nplurals=2; plural=(n > 1);
 Generator: GlotPress/2.4.0-alpha
 Language: pt_BR
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string name="app_name" content_override="true">WooCommerce</string>
     <string name="shipping_label_payments_saving_error">Ocorreu um erro ao salvar suas configurações</string>
     <string name="shipping_label_payments_saving_dialog_message">Aguarde…</string>
     <string name="shipping_label_payments_saving_dialog_title">Salvando suas configurações</string>
@@ -45,4 +46,26 @@ Language: pt_BR
         <item> - o Dois: segundo ponto</item>
     </string-array>
     <string name="multi_range_statement">O primeiro intervalo é 2–100 e o segundo é 123–456.</string>
+    <string name="sunday">Domingo</string>
+    <string name="monday">Segunda-feira</string>
+    <string name="tuesday">Terça-feira</string>
+    <string name="wednesday">Quarta-feira</string>
+    <string name="thursday">Quinta-feira</string>
+    <string name="friday">Sexta-feira</string>
+    <string name="saturday">Sábado</string>
+    <string-array name="weeks_full" translatable="false">
+        <item>@string/sunday</item>
+        <item>@string/monday</item>
+        <item>@string/tuesday</item>
+        <item>@string/wednesday</item>
+        <item>@string/thursday</item>
+        <item>@string/friday</item>
+        <item>@string/saturday</item>
+        <item>Nenhum</item>
+    </string-array>
+    <string name="confirm_single_entry_trash">Tem certeza de que deseja mover esta entrada para a lixeira?</string>
+    <plurals name="confirm_entry_trash" formatted="false">
+        <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
+        <item quantity="other">Tem certeza… deseja mover %d entradas para a lixeira?</item>
+    </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/expected/values-zh-rCN/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-zh-rCN/strings.xml
@@ -73,8 +73,15 @@ Language: zh_CN
         <item>@string/saturday</item>
         <item>没有任何</item>
     </string-array>
+    <string-array name="progress" formatted="false">
+        <item>0%</item>
+        <item>25%</item>
+        <item>50%</item>
+        <item>75%</item>
+        <item>100%</item>
+    </string-array>
     <string name="confirm_single_entry_trash">您确定要将该条目移至垃圾箱吗？</string>
-    <plurals name="confirm_entry_trash" formatted="false">
+    <plurals name="confirm_entry_trash" formatted="true">
         <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
         <item quantity="other">您确定…要将 %d 个条目移至垃圾箱吗？</item>
     </plurals>

--- a/spec/test-data/translations/glotpress-download/expected/values-zh-rCN/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values-zh-rCN/strings.xml
@@ -5,7 +5,8 @@ Plural-Forms: nplurals=1; plural=0;
 Generator: GlotPress/2.4.0-alpha
 Language: zh_CN
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <string name="app_name" content_override="true">WooCommerce</string>
     <string name="shipping_label_payments_cant_edit_warning">只有站点所有者可以管理配送标签付款方式。 请联系商店所有者 %1$s (%2$s) 以管理付款方式。</string>
     <string name="product_term_name_already_exists">已存在具有此名称的选项</string>
     <string name="product_attribute_name_already_exists">已存在具有此名称的属性</string>
@@ -55,4 +56,26 @@ Language: zh_CN
         <item> - o 二：第二点</item>
     </string-array>
     <string name="multi_range_statement">第一范围是2–100，第二范围是123–456</string>
+    <string name="sunday">星期日</string>
+    <string name="monday">星期一</string>
+    <string name="tuesday">星期二</string>
+    <string name="wednesday">星期三</string>
+    <string name="thursday">星期四</string>
+    <string name="friday">星期五</string>
+    <string name="saturday">星期六</string>
+    <string-array name="weeks_full" translatable="false">
+        <item>@string/sunday</item>
+        <item>@string/monday</item>
+        <item>@string/tuesday</item>
+        <item>@string/wednesday</item>
+        <item>@string/thursday</item>
+        <item>@string/friday</item>
+        <item>@string/saturday</item>
+        <item>没有任何</item>
+    </string-array>
+    <string name="confirm_single_entry_trash">您确定要将该条目移至垃圾箱吗？</string>
+    <plurals name="confirm_entry_trash" formatted="false">
+        <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
+        <item quantity="other">您确定…要将 %d 个条目移至垃圾箱吗？</item>
+    </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/expected/values/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values/strings.xml
@@ -44,6 +44,8 @@
         <item>All Orders</item>
     </string-array>
 
+    <!-- strings referencing other strings via @string/ should be marked translatable=false -->
+    <string name="stringref">@string/shipping_label_woo_discount_bottomsheet_title</string>
 
     <string name="shipping_label_payments_cant_edit_warning">Only the site owner can manage the shipping label payment methods. Please contact Store Owner %1$s (%2$s) to manage payment methods.</string>
     <string name="threat_fix_description">Pricing ranges from $70–120/hour</string>

--- a/spec/test-data/translations/glotpress-download/expected/values/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<resources>
-    <string name="app_name">WooCommerce</string>
-
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Android O notification channels, these show in the Android app settings -->
     <string name="notification_channel_general_title">General</string>
     <string name="notification_channel_general_id" translatable="false" content_override="true">wooandroid_notification_channel_general_id</string>
@@ -16,9 +14,10 @@
     <!--
         General Strings
     -->
+    <string name="app_name" content_override="true">WooCommerce</string>
     <string name="all">All</string>
 
-    <string name="shipping_label_woo_discount_bottomsheet_title">What is WooCommerce  Services discount?</string>
+    <string name="shipping_label_woo_discount_bottomsheet_title">What is WooCommerce Services discount?</string>
     <string name="shipping_label_woo_discount_bottomsheet_message" formatted="false">When purchasing shipping labels with WooCommerce, you get 5% to 40% off compared to post office rates.</string>
 
     <string name="shipping_label_payments_selected_payment_method">Payment method selected</string>
@@ -71,4 +70,36 @@
         <item> - o Two. Second point</item>
     </string-array>
     <string name="multi_range_statement">First range is 2–100 and second is 123–456.</string>
+
+    <!--
+    string-array with references, translatable attributes
+    -->
+    <string name="sunday">Sunday</string>
+    <string name="monday">Monday</string>
+    <string name="tuesday">Tuesday</string>
+    <string name="wednesday">Wednesday</string>
+    <string name="thursday">Thursday</string>
+    <string name="friday">Friday</string>
+    <string name="saturday">Saturday</string>
+
+    <string-array name="weeks_full" translatable="false">
+      <item>@string/sunday</item>
+      <item>@string/monday</item>
+      <item>@string/tuesday</item>
+      <item>@string/wednesday</item>
+      <item>@string/thursday</item>
+      <item>@string/friday</item>
+      <item>@string/saturday</item>
+      <item>None</item>
+    </string-array>
+
+    <!--
+    plurals with references, tools:ignore attribute
+    -->
+
+    <string name="confirm_single_entry_trash">Are you sure you want to move this entry to the trash can?</string>
+    <plurals name="confirm_entry_trash" formatted="false">
+      <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
+      <item quantity="other">Are you sure… you want to move %d entries to the trash can?</item>
+    </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/expected/values/strings.xml
+++ b/spec/test-data/translations/glotpress-download/expected/values/strings.xml
@@ -72,7 +72,7 @@
     <string name="multi_range_statement">First range is 2–100 and second is 123–456.</string>
 
     <!--
-    string-array with references, translatable attributes
+    string-array with references, translatable & formatted attributes
     -->
     <string name="sunday">Sunday</string>
     <string name="monday">Monday</string>
@@ -93,12 +93,20 @@
       <item>None</item>
     </string-array>
 
+    <string-array name="progress" formatted="false">
+      <item>0%</item>
+      <item>25%</item>
+      <item>50%</item>
+      <item>75%</item>
+      <item>100%</item>
+    </string-array>
+
     <!--
     plurals with references, tools:ignore attribute
     -->
 
     <string name="confirm_single_entry_trash">Are you sure you want to move this entry to the trash can?</string>
-    <plurals name="confirm_entry_trash" formatted="false">
+    <plurals name="confirm_entry_trash" formatted="true">
       <item quantity="one" tools:ignore="ImpliedQuantity">@string/confirm_single_entry_trash</item>
       <item quantity="other">Are you sure… you want to move %d entries to the trash can?</item>
     </plurals>

--- a/spec/test-data/translations/glotpress-download/filters/merged.xml
+++ b/spec/test-data/translations/glotpress-download/filters/merged.xml
@@ -5,7 +5,7 @@ Plural-Forms: nplurals=2; plural=n > 1;
 Generator: GlotPress/2.4.0-alpha
 Language: fr
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="gp_locale">fr</string>
     <string name="only_in_current">This is only in "current" export</string>
     <string name="in_multiple_exports">fuzzy</string>

--- a/spec/test-data/translations/glotpress-download/stubs/fr.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/fr.xml
@@ -71,7 +71,7 @@ Language: fr
         <item>\@string/thursday</item>
         <item>\@string/friday</item>
         <item>\@string/saturday</item>
-        <item>None</item>
+        <item>Aucun</item>
     </string-array>
     <string-array name="progress" formatted="false">
         <item>0%%</item>

--- a/spec/test-data/translations/glotpress-download/stubs/fr.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/fr.xml
@@ -31,6 +31,7 @@ Language: fr
 		<item>En cours…</item>
 		<item>Toutes les commandes...</item>
 	</string-array>
+	<string name="stringref">\@string/shipping_label_woo_discount_bottomsheet_title</string>
 	<string name="threat_fix_description">Les prix vont de 70-120 $ par heure</string>
     <string-array name="settings_jetpackdescription">
         <item>Vous pouvez marquer une adresse IP (ou une série d’adresses IP) comme « Toujours autorisé »</item>
@@ -63,13 +64,13 @@ Language: fr
     <string name="friday">Vendredi</string>
     <string name="saturday">Samedi</string>
     <string-array name="weeks_full">
-        <item>@string/sunday</item>
-        <item>@string/monday</item>
-        <item>@string/tuesday</item>
-        <item>@string/wednesday</item>
-        <item>@string/thursday</item>
-        <item>@string/friday</item>
-        <item>@string/saturday</item>
+        <item>\@string/sunday</item>
+        <item>\@string/monday</item>
+        <item>\@string/tuesday</item>
+        <item>\@string/wednesday</item>
+        <item>\@string/thursday</item>
+        <item>\@string/friday</item>
+        <item>\@string/saturday</item>
         <item>None</item>
     </string-array>
     <string-array name="progress" formatted="false">
@@ -81,7 +82,7 @@ Language: fr
     </string-array>
     <string name="confirm_single_entry_trash">Êtes-vous sûr de vouloir déplacer cette entrée vers la corbeille ?</string>
     <plurals name="confirm_entry_trash">
-        <item quantity="one">@string/confirm_single_entry_trash</item>
+        <item quantity="one">\@string/confirm_single_entry_trash</item>
         <item quantity="other">Etes-vous sûr... de vouloir déplacer %d entrées vers la corbeille ?</item>
     </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/stubs/fr.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/fr.xml
@@ -6,6 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: fr
 -->
 <resources>
+  <string name="app_name">WooCommerce</string>
 	<string name="product_attributes_error_saving">Erreur lors de l’enregistrement de vos attributs</string>
 	<string name="shipping_label_payments_cant_edit_warning">Seul le propriétaire du site peut gérer les moyens de paiement des étiquettes d’expédition. Veuillez contacter le propriétaire de la boutique %1$s (%2$s) pour gérer les moyens de paiement.</string>
 	<string name="shipping_label_shipping_method_free_shipping">Livraison gratuite</string>
@@ -54,4 +55,26 @@ Language: fr
         <item> - o Deux: deuxième point</item>
     </string-array>
     <string name="multi_range_statement">La première plage est 2-100 et la seconde est 123-456.</string>
+    <string name="sunday">Dimanche</string>
+    <string name="monday">Lundi</string>
+    <string name="tuesday">Mardi</string>
+    <string name="wednesday">Mercredi</string>
+    <string name="thursday">Jeudi</string>
+    <string name="friday">Vendredi</string>
+    <string name="saturday">Samedi</string>
+    <string-array name="weeks_full">
+        <item>@string/sunday</item>
+        <item>@string/monday</item>
+        <item>@string/tuesday</item>
+        <item>@string/wednesday</item>
+        <item>@string/thursday</item>
+        <item>@string/friday</item>
+        <item>@string/saturday</item>
+        <item>None</item>
+    </string-array>
+    <string name="confirm_single_entry_trash">Êtes-vous sûr de vouloir déplacer cette entrée vers la corbeille ?</string>
+    <plurals name="confirm_entry_trash">
+        <item quantity="one">@string/confirm_single_entry_trash</item>
+        <item quantity="other">Etes-vous sûr... de vouloir déplacer %d entrées vers la corbeille ?</item>
+    </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/stubs/fr.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/fr.xml
@@ -72,6 +72,13 @@ Language: fr
         <item>@string/saturday</item>
         <item>None</item>
     </string-array>
+    <string-array name="progress" formatted="false">
+        <item>0%%</item>
+        <item>25%</item>
+        <item>50%%</item>
+        <item>75%</item>
+        <item>100%</item>
+    </string-array>
     <string name="confirm_single_entry_trash">Êtes-vous sûr de vouloir déplacer cette entrée vers la corbeille ?</string>
     <plurals name="confirm_entry_trash">
         <item quantity="one">@string/confirm_single_entry_trash</item>

--- a/spec/test-data/translations/glotpress-download/stubs/pt-br.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/pt-br.xml
@@ -6,6 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: pt_BR
 -->
 <resources>
+  <string name="app_name">WooCommerce</string>
 	<string name="shipping_label_payments_saving_error">Ocorreu um erro ao salvar suas configurações</string>
 	<string name="shipping_label_payments_saving_dialog_message">Aguarde...</string>
 	<string name="shipping_label_payments_saving_dialog_title">Salvando suas configurações</string>
@@ -45,4 +46,26 @@ Language: pt_BR
         <item> - o Dois: segundo ponto</item>
     </string-array>
     <string name="multi_range_statement">O primeiro intervalo é 2-100 e o segundo é 123-456.</string>
+    <string name="sunday">Domingo</string>
+    <string name="monday">Segunda-feira</string>
+    <string name="tuesday">Terça-feira</string>
+    <string name="wednesday">Quarta-feira</string>
+    <string name="thursday">Quinta-feira</string>
+    <string name="friday">Sexta-feira</string>
+    <string name="saturday">Sábado</string>
+    <string-array name="weeks_full">
+        <item>@string/sunday</item>
+        <item>@string/monday</item>
+        <item>@string/tuesday</item>
+        <item>@string/wednesday</item>
+        <item>@string/thursday</item>
+        <item>@string/friday</item>
+        <item>@string/saturday</item>
+        <item>Nenhum</item>
+    </string-array>
+    <string name="confirm_single_entry_trash">Tem certeza de que deseja mover esta entrada para a lixeira?</string>
+    <plurals name="confirm_entry_trash">
+        <item quantity="one">@string/confirm_single_entry_trash</item>
+        <item quantity="other">Tem certeza... deseja mover %d entradas para a lixeira?</item>
+    </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/stubs/pt-br.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/pt-br.xml
@@ -63,6 +63,13 @@ Language: pt_BR
         <item>@string/saturday</item>
         <item>Nenhum</item>
     </string-array>
+    <string-array name="progress" formatted="false">
+        <item>0%</item>
+        <item>25%</item>
+        <item>50%</item>
+        <item>75%</item>
+        <item>100%</item>
+    </string-array>
     <string name="confirm_single_entry_trash">Tem certeza de que deseja mover esta entrada para a lixeira?</string>
     <plurals name="confirm_entry_trash">
         <item quantity="one">@string/confirm_single_entry_trash</item>

--- a/spec/test-data/translations/glotpress-download/stubs/pt-br.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/pt-br.xml
@@ -54,13 +54,13 @@ Language: pt_BR
     <string name="friday">Sexta-feira</string>
     <string name="saturday">Sábado</string>
     <string-array name="weeks_full">
-        <item>@string/sunday</item>
-        <item>@string/monday</item>
-        <item>@string/tuesday</item>
-        <item>@string/wednesday</item>
-        <item>@string/thursday</item>
-        <item>@string/friday</item>
-        <item>@string/saturday</item>
+        <item>\@string/sunday</item>
+        <item>\@string/monday</item>
+        <item>\@string/tuesday</item>
+        <item>\@string/wednesday</item>
+        <item>\@string/thursday</item>
+        <item>\@string/friday</item>
+        <item>\@string/saturday</item>
         <item>Nenhum</item>
     </string-array>
     <string-array name="progress" formatted="false">
@@ -72,7 +72,7 @@ Language: pt_BR
     </string-array>
     <string name="confirm_single_entry_trash">Tem certeza de que deseja mover esta entrada para a lixeira?</string>
     <plurals name="confirm_entry_trash">
-        <item quantity="one">@string/confirm_single_entry_trash</item>
+        <item quantity="one">\@string/confirm_single_entry_trash</item>
         <item quantity="other">Tem certeza... deseja mover %d entradas para a lixeira?</item>
     </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/stubs/zh-cn.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/zh-cn.xml
@@ -6,6 +6,7 @@ Generator: GlotPress/2.4.0-alpha
 Language: zh_CN
 -->
 <resources>
+  <string name="app_name">WooCommerce</string>
 	<string name="shipping_label_payments_cant_edit_warning">只有站点所有者可以管理配送标签付款方式。 请联系商店所有者 %1$s (%2$s) 以管理付款方式。</string>
 	<string name="product_term_name_already_exists">已存在具有此名称的选项</string>
 	<string name="product_attribute_name_already_exists">已存在具有此名称的属性</string>
@@ -55,4 +56,26 @@ Language: zh_CN
         <item> - o 二：第二点</item>
     </string-array>
     <string name="multi_range_statement">第一范围是2-100，第二范围是123-456</string>
+    <string name="sunday">星期日</string>
+    <string name="monday">星期一</string>
+    <string name="tuesday">星期二</string>
+    <string name="wednesday">星期三</string>
+    <string name="thursday">星期四</string>
+    <string name="friday">星期五</string>
+    <string name="saturday">星期六</string>
+    <string-array name="weeks_full">
+        <item>@string/sunday</item>
+        <item>@string/monday</item>
+        <item>@string/tuesday</item>
+        <item>@string/wednesday</item>
+        <item>@string/thursday</item>
+        <item>@string/friday</item>
+        <item>@string/saturday</item>
+        <item>没有任何</item>
+    </string-array>
+    <string name="confirm_single_entry_trash">您确定要将该条目移至垃圾箱吗？</string>
+    <plurals name="confirm_entry_trash">
+        <item quantity="one">@string/confirm_single_entry_trash</item>
+        <item quantity="other">您确定...要将 %d 个条目移至垃圾箱吗？</item>
+    </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/stubs/zh-cn.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/zh-cn.xml
@@ -64,13 +64,13 @@ Language: zh_CN
     <string name="friday">星期五</string>
     <string name="saturday">星期六</string>
     <string-array name="weeks_full">
-        <item>@string/sunday</item>
-        <item>@string/monday</item>
-        <item>@string/tuesday</item>
-        <item>@string/wednesday</item>
-        <item>@string/thursday</item>
-        <item>@string/friday</item>
-        <item>@string/saturday</item>
+        <item>\@string/sunday</item>
+        <item>\@string/monday</item>
+        <item>\@string/tuesday</item>
+        <item>\@string/wednesday</item>
+        <item>\@string/thursday</item>
+        <item>\@string/friday</item>
+        <item>\@string/saturday</item>
         <item>没有任何</item>
     </string-array>
     <string-array name="progress" formatted="false">
@@ -82,7 +82,7 @@ Language: zh_CN
     </string-array>
     <string name="confirm_single_entry_trash">您确定要将该条目移至垃圾箱吗？</string>
     <plurals name="confirm_entry_trash">
-        <item quantity="one">@string/confirm_single_entry_trash</item>
+        <item quantity="one">\@string/confirm_single_entry_trash</item>
         <item quantity="other">您确定...要将 %d 个条目移至垃圾箱吗？</item>
     </plurals>
 </resources>

--- a/spec/test-data/translations/glotpress-download/stubs/zh-cn.xml
+++ b/spec/test-data/translations/glotpress-download/stubs/zh-cn.xml
@@ -73,6 +73,13 @@ Language: zh_CN
         <item>@string/saturday</item>
         <item>没有任何</item>
     </string-array>
+    <string-array name="progress" formatted="false">
+        <item>0%</item>
+        <item>25%</item>
+        <item>50%</item>
+        <item>75%</item>
+        <item>100%</item>
+    </string-array>
     <string name="confirm_single_entry_trash">您确定要将该条目移至垃圾箱吗？</string>
     <plurals name="confirm_entry_trash">
         <item quantity="one">@string/confirm_single_entry_trash</item>


### PR DESCRIPTION
Fixes #569 — i.e. the issues that DayOne Android encountered in their last `2024.14` release (See p1720472497193469-slack-CC7L49W13)

## What does it do?

- Replicate all XML attributes (e.g. `tools:ignore="ImpliedQuantity"`) from original `values/strings.xml` on all nodes of translated XMLs exported from GlotPress
- Apply text substitutions (`...`=>`…`, `-`=>`–`, etc) on `plurals/item` nodes too (before it was only on `string` and `string-array` nodes)
- Improve our `quick_lint` check on each copies to (1) be run on _all_ nodes containing a string (including `plurals/item` and `string-array/item` not just `string`) and (2) warn about + auto-fix `\@string/…` in exports (suggesting to add `translatable="false"` on the offending key(s) to fix the issue at its root in the future)

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~

## How to Test

 - Run `bundle exec rspec` and validate all unit tests pass
 - In [the DayOne Android repo](https://github.com/bloom/DayOne-Android):
    - Create a test branch
    - Run `bundle exec fastlane download_translations`, then commit the changes if any (this will serve as the "before" baseline for the rest of the test)
    - Update the `Gemfile` to point release-toolkit to `gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'fix/android_download_translations'`
    - Run `bundle install`
    - Run `bundle exec fastlane download_translations` again, and check the diff. Especially validate that any `\@string/` escaped references previously present in translations were properly fixed, and that attributes present in the `values/strings.xml` were now all properly replicated on all the translated XMLs
    - Run `./gradlew lint` and validate it passes
    - Edit the `app/src/main/res/values/strings.xml`:
        - Pick a plural that has been translated in other locales (ideally we'd pick `confirm_entry_trash_multiple` since that's the one that caused the problem in `2024.14` release, but at the time of writing this PR this key is not present in GlotPress anymore), like `daily_prompt_card_menu_view_entries` for example
        - Add the `tools:ignore="ImpliedQuantity"` attribute on one of its `item` child nodes, e.g. `<item quantity="one" tools:ignore="ImpliedQuantity">View one Entry</item>`
        - Don't forget to also add the `tools` XML namespace at the top of the XML: `<resources xmlns:tools="http://schemas.android.com/tools">`
    - Re-run `bundle exec fastlane download_translations`, and verify that this new `tools:ignore="ImpliedQuantity"` attribute has been replicated on the `daily_prompt_card_menu_view_entries` item node of all translated XMLs
    - Run `./gradlew lint` and validate it passes
 - Replicate a similar test on WPAndroid and WCAndroid, to validate we wouldn't break those (I'm starting to wonder why we only copied a specific list of attributes before this PR instead of copying them all… maybe there was a reason that I forgot about?)

cc @danilo04 @AmandaRiu 

## What's Next

 - Do a new release of `release-toolkit`
 - Point DayOne Android to the new version
 - Inform DOAndroid team that they can revert [their workaround](https://github.com/bloom/DayOne-Android/pull/4579) and go back to use `tools:ignore="ImpliedQuantity"` on their `plurals/item` nodes.
     - Any attribute present in `values/strings.xml` will be replicated in the downloaded-and-post-processed `values-{locale}/strings.xml` for each corresponding node now.
     - Removing their workaround which tests `if (entries.size > 1)` and go back to `ImpliedQuantity` will allow to let the OS cover even cases of locales which are using `quantity=one` not just for `1` but for other values (e.g. Bielorussian uses this plural form also for `11`, `21`, `31`, …)
 - Inform DOAndroid that, while testing the change on their codebase, it now rightfully informed of a warning about `daily_prompt_settings_notifications` being a string reference but not having `translatable=false`. As a side effect, while other translators have left it untouched in GlotPress, [the Italian translator did translate `@string/notifications` to `\@stringa/notifiche`](https://translate.wordpress.com/projects/day-one/android/it/default/?filters%5Bterm%5D=daily_prompt_settings_notifications&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc) (and because the prefix is now `\@stringa/` not `\@string/`, this wasn't auto-fixed by the action like it now is for the others).