### PR TITLE
Release 11.0.3 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,20 @@ _None_
 
 ### Bug Fixes
 
-- Fix `android_download_translation` issues reported in #569 [#571]
-   - add post-processing of `plurals` nodes too.
-   - detect and fix `\@string/` references escaped in GlotPress exports.
-   - replicate all XML attributes (and xmlns) present in `values/string.xml` on the corresponding nodes in the translated XML.
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 11.0.3
+
+### Bug Fixes
+
+- Fix `android_download_translation` issues reported in #569 [#571]
+   - add post-processing of `plurals` nodes too.
+   - detect and fix `\@string/` references escaped in GlotPress exports.
+   - replicate all XML attributes (and xmlns) present in `values/string.xml` on the corresponding nodes in the translated XML.
 
 ## 11.0.2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (11.0.2)
+    fastlane-plugin-wpmreleasetoolkit (11.0.3)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ task :new_release do
     PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
     copy/pasting the following text as the GitHub Release's description:
     ```
-    #{changelog}
+    #{changelog.join}
     ```
   BODY
   GitHelper.prepare_github_pr("release/#{new_version}", 'trunk', "Release #{new_version} into trunk", pr_body)
@@ -87,7 +87,7 @@ task :new_release do
     with the following text as description:
 
     ```
-    #{changelog}
+    #{changelog.join}
     ```
 
     The publication of the new GitHub release will create a git tag, which in turn will trigger

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '11.0.2'
+    VERSION = '11.0.3'
   end
 end

--- a/rakelib/git_helpers.rake
+++ b/rakelib/git_helpers.rake
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module GitHelper
   def self.current_branch
     `git --no-pager branch --show-current`.chomp
@@ -19,8 +21,8 @@ module GitHelper
 
   def self.prepare_github_pr(head, base, title, body)
     require 'open-uri'
-    qtitle = title.gsub(' ', '%20')
-    qbody = body.gsub(' ', '%20')
+    qtitle = CGI.escape(title)
+    qbody = CGI.escape(body)
     uri = "https://github.com/wordpress-mobile/release-toolkit/compare/#{base}...#{head}?expand=1&title=#{qtitle}&body=#{qbody}"
     Rake.sh('open', uri)
   end


### PR DESCRIPTION
Releasing new version 11.0.3.

Also fixing the `rake new_release` script while at it, closing https://github.com/wordpress-mobile/release-toolkit/issues/559

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Fix `android_download_translation` issues reported in #569 [#571]
   - add post-processing of `plurals` nodes too.
   - detect and fix `\@string/` references escaped in GlotPress exports.
   - replicate all XML attributes (and xmlns) present in `values/string.xml` on the corresponding nodes in the translated XML.
```
