### PR TITLE
Deprecate all iOS and Android precheck actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,19 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Deprecated the following actions: [#577]
+    - `android_betabuild_prechecks`
+    - `android_build_prechecks`
+    - `android_codefreeze_prechecks`
+    - `android_completecodefreeze_prechecks`
+    - `android_finalize_prechecks`
+    - `android_hotfix_prechecks`
+    - `ios_betabuild_prechecks`
+    - `ios_build_prechecks`
+    - `ios_codefreeze_prechecks`
+    - `ios_completecodefreeze_prechecks`
+    - `ios_finalize_prechecks`
+    - `ios_hotfix_prechecks`
 
 ## 11.1.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -88,11 +88,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before preparing for a new test build'
+        'Runs some prechecks before preparing for a new test build'
       end
 
       def self.details
-        '(DEPRECATED) Updates the relevant release branch, checks the app version and ensure the branch is clean'
+        'Updates the relevant release branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -84,7 +84,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_betabuild_prechecks.rb
@@ -79,12 +79,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before preparing for a new test build'
+        '(DEPRECATED) Runs some prechecks before preparing for a new test build'
       end
 
       def self.details
-        'Updates the relevant release branch, checks the app version and ensure the branch is clean'
+        '(DEPRECATED) Updates the relevant release branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -52,7 +52,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -56,11 +56,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before the build'
+        'Runs some prechecks before the build'
       end
 
       def self.details
-        '(DEPRECATED) Runs some prechecks before the build'
+        'Runs some prechecks before the build'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_prechecks.rb
@@ -47,12 +47,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before the build'
+        '(DEPRECATED) Runs some prechecks before the build'
       end
 
       def self.details
-        'Runs some prechecks before the build'
+        '(DEPRECATED) Runs some prechecks before the build'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -60,7 +60,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -55,12 +55,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before code freeze'
+        '(DEPRECATED) Runs some prechecks before code freeze'
       end
 
       def self.details
-        'Updates the default branch, checks the app version and ensure the branch is clean'
+        '(DEPRECATED) Updates the default branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_codefreeze_prechecks.rb
@@ -64,11 +64,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before code freeze'
+        'Runs some prechecks before code freeze'
       end
 
       def self.details
-        '(DEPRECATED) Updates the default branch, checks the app version and ensure the branch is clean'
+        'Updates the default branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -35,12 +35,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before finalizing a code freeze'
+        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
       end
 
       def self.details
-        'Runs some prechecks before finalizing a code freeze'
+        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -40,7 +40,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_completecodefreeze_prechecks.rb
@@ -44,11 +44,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
+        'Runs some prechecks before finalizing a code freeze'
       end
 
       def self.details
-        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
+        'Runs some prechecks before finalizing a code freeze'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -48,11 +48,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before finalizing a release'
+        'Runs some prechecks before finalizing a release'
       end
 
       def self.details
-        '(DEPRECATED) Runs some prechecks before finalizing a release'
+        'Runs some prechecks before finalizing a release'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -39,12 +39,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before finalizing a release'
+        '(DEPRECATED) Runs some prechecks before finalizing a release'
       end
 
       def self.details
-        'Runs some prechecks before finalizing a release'
+        '(DEPRECATED) Runs some prechecks before finalizing a release'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_finalize_prechecks.rb
@@ -44,7 +44,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
@@ -38,12 +38,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before preparing for a new hotfix'
+        '(DEPRECATED) Runs some prechecks before preparing for a new hotfix'
       end
 
       def self.details
-        'Checks out a new branch from a tag and updates tags'
+        '(DEPRECATED) Checks out a new branch from a tag and updates tags'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
@@ -47,11 +47,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before preparing for a new hotfix'
+        'Runs some prechecks before preparing for a new hotfix'
       end
 
       def self.details
-        '(DEPRECATED) Checks out a new branch from a tag and updates tags'
+        'Checks out a new branch from a tag and updates tags'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_hotfix_prechecks.rb
@@ -43,7 +43,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -50,12 +50,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before preparing for a new test build'
+        '(DEPRECATED) Runs some prechecks before preparing for a new test build'
       end
 
       def self.details
-        'Updates the relevant release branch, checks the app version and ensure the branch is clean'
+        '(DEPRECATED) Updates the relevant release branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -55,7 +55,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_betabuild_prechecks.rb
@@ -59,11 +59,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before preparing for a new test build'
+        'Runs some prechecks before preparing for a new test build'
       end
 
       def self.details
-        '(DEPRECATED) Updates the relevant release branch, checks the app version and ensure the branch is clean'
+        'Updates the relevant release branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -23,12 +23,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before the build'
+        '(DEPRECATED) Runs some prechecks before the build'
       end
 
       def self.details
-        'Runs some prechecks before the build'
+        '(DEPRECATED) Runs some prechecks before the build'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -28,7 +28,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_prechecks.rb
@@ -32,11 +32,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before the build'
+        'Runs some prechecks before the build'
       end
 
       def self.details
-        '(DEPRECATED) Runs some prechecks before the build'
+        'Runs some prechecks before the build'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -33,12 +33,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before code freeze'
+        '(DEPRECATED) Runs some prechecks before code freeze'
       end
 
       def self.details
-        'Updates the default branch, checks the app version and ensure the branch is clean'
+        '(DEPRECATED) Updates the default branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -42,11 +42,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before code freeze'
+        'Runs some prechecks before code freeze'
       end
 
       def self.details
-        '(DEPRECATED) Updates the default branch, checks the app version and ensure the branch is clean'
+        'Updates the default branch, checks the app version and ensure the branch is clean'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_codefreeze_prechecks.rb
@@ -38,7 +38,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -29,12 +29,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before finalizing a code freeze'
+        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
       end
 
       def self.details
-        'Runs some prechecks before finalizing a code freeze'
+        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -34,7 +34,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_completecodefreeze_prechecks.rb
@@ -38,11 +38,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
+        'Runs some prechecks before finalizing a code freeze'
       end
 
       def self.details
-        '(DEPRECATED) Runs some prechecks before finalizing a code freeze'
+        'Runs some prechecks before finalizing a code freeze'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -29,12 +29,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before finalizing a release'
+        '(DEPRECATED) Runs some prechecks before finalizing a release'
       end
 
       def self.details
-        'Runs some prechecks before finalizing a release'
+        '(DEPRECATED) Runs some prechecks before finalizing a release'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -34,7 +34,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_finalize_prechecks.rb
@@ -38,11 +38,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before finalizing a release'
+        'Runs some prechecks before finalizing a release'
       end
 
       def self.details
-        '(DEPRECATED) Runs some prechecks before finalizing a release'
+        'Runs some prechecks before finalizing a release'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
@@ -38,12 +38,20 @@ module Fastlane
       # @!group Documentation
       #####################################################
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+      end
+
       def self.description
-        'Runs some prechecks before preparing for a new hotfix'
+        '(DEPRECATED) Runs some prechecks before preparing for a new hotfix'
       end
 
       def self.details
-        'Checks out a new branch from a tag and updates tags'
+        '(DEPRECATED) Checks out a new branch from a tag and updates tags'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
@@ -47,11 +47,11 @@ module Fastlane
       end
 
       def self.description
-        '(DEPRECATED) Runs some prechecks before preparing for a new hotfix'
+        'Runs some prechecks before preparing for a new hotfix'
       end
 
       def self.details
-        '(DEPRECATED) Checks out a new branch from a tag and updates tags'
+        'Checks out a new branch from a tag and updates tags'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_hotfix_prechecks.rb
@@ -43,7 +43,7 @@ module Fastlane
       end
 
       def self.deprecated_notes
-        'This action is deprecated and will be removed in an upcoming Release Toolkit version. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Any necessary steps that are included in this precheck action should be added directly in a repo\'s Fastfile. See https://github.com/wordpress-mobile/release-toolkit/issues/576'
       end
 
       def self.description


### PR DESCRIPTION
## What does it do?
Fixes #576 

This PR deprecates the following precheck actions: 
- `android_betabuild_prechecks`
- `android_build_prechecks`
- `android_codefreeze_prechecks`
- `android_completecodefreeze_prechecks`
- `android_finalize_prechecks`
- `android_hotfix_prechecks`
- `ios_betabuild_prechecks`
- `ios_build_prechecks`
- `ios_codefreeze_prechecks`
- `ios_completecodefreeze_prechecks`
- `ios_finalize_prechecks`
- `ios_hotfix_prechecks`

When the versioning changes were added in #512, it was decided that we would stop using these `-prechecks` actions and instead use any necessary steps from those actions directly in Fastfiles. The idea is that the precheck actions were opaque and made it harder to figure out where errors were occuring when running release management lanes. There are some other versioning and preflight actions that we'll want to deprecate as well (at least the versioning ones for sure), but I decided to limit this PR to only the precheck actions. 

Example: See these WooCommerce iOS and Android PRs that switched from using the precheck actions to directly adding the steps in the Woo lanes: 
- https://github.com/woocommerce/woocommerce-android/pull/9865
- https://github.com/woocommerce/woocommerce-ios/pull/10807

From what I can tell, the Simplenote Android, iOS, and Mac apps are the only apps still using these prechecks (they weren't updated with the versioning changes last year), so it won't be a lot of work for us once these actions are eventually removed. 

## Checklist before requesting a review

- [X] Run `bundle exec rubocop` to test for code style violations and recommendations
- [X] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [X] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
