### PR TITLE
Add `EnvManager` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- Add `EnvManager` class for loading `.env` files and accessing required environment variables with user-friendly error messages. [#578]
+- Add `Fastlane::Wpmreleasetoolkit::EnvManager` for loading `.env` files and accessing required environment variables with user-friendly error messages. Repos that maintain their own `EnvManager` can switch to this centralized implementation. [#578]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Add `EnvManager` class for loading `.env` files and accessing required environment variables with user-friendly error messages. [#578]
 
 ### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)
+      dotenv (~> 2.8)
       fastlane (~> 2.231)
       gettext (~> 3.5)
       git (~> 1.3)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'buildkit', '~> 1.5'
   spec.add_dependency 'chroma', '0.2.0'
   spec.add_dependency 'diffy', '~> 3.3'
+  spec.add_dependency 'dotenv', '~> 2.8'
   spec.add_dependency 'fastlane', '~> 2.231'
   spec.add_dependency 'gettext', '~> 3.5'
   spec.add_dependency 'git', '~> 1.3'

--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -4,7 +4,7 @@ require 'fastlane/plugin/wpmreleasetoolkit/version'
 
 module Fastlane
   module Wpmreleasetoolkit
-    # Return all .rb files inside the "actions", "helper" and "models" directories
+    # Return all .rb files inside the "actions", "env_manager", "helper", "models", and "versioning" directories
     def self.all_classes
       Dir[File.expand_path('**/{actions,env_manager,helper,models,versioning}/**/*.rb', File.dirname(__FILE__))]
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -6,7 +6,7 @@ module Fastlane
   module Wpmreleasetoolkit
     # Return all .rb files inside the "actions", "helper" and "models" directories
     def self.all_classes
-      Dir[File.expand_path('**/{actions,helper,models,versioning}/**/*.rb', File.dirname(__FILE__))]
+      Dir[File.expand_path('**/{actions,env_manager,helper,models,versioning}/**/*.rb', File.dirname(__FILE__))]
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'dotenv'
+# TODO: It would be nice to decouple this from Fastlane.
+# To give a good UX in the current use case, however, it's best to access the Fastlane UI methods directly.
+require 'fastlane'
+
+# Manages loading of environment variables from a .env and accessing them in a user-friendly way.
+class EnvManager
+  @env_path = nil
+  @env_example_path = nil
+  @print_error_lambda = nil
+
+  # Set up by loading the .env file with the given name.
+  #
+  # TODO: We could go one step and guess the name based on the repo URL.
+  def self.set_up(
+    env_file_name:,
+    env_file_folder: File.join(Dir.home, '.a8c-apps'),
+    example_env_file_path: 'fastlane/example.env',
+    print_error_lambda: ->(message) { FastlaneCore::UI.user_error!(message) }
+  )
+    @env_path = File.join(env_file_folder, env_file_name)
+    @env_example_path = example_env_file_path
+    @print_error_lambda = print_error_lambda
+
+    # We don't check for @env_path to exist here
+    Dotenv.load(@env_path)
+  end
+
+  # Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing or empty.
+  def self.get_required_env!(key)
+    unless ENV.key?(key)
+      message = "Environment variable '#{key}' is not set."
+
+      if running_on_ci?
+        @print_error_lambda.call(message)
+      elsif File.exist?(@env_path)
+        @print_error_lambda.call("#{message} Consider adding it to #{@env_path}.")
+      else
+        env_file_dir = File.dirname(@env_path)
+        env_file_name = File.basename(@env_path)
+
+        @print_error_lambda.call <<~MSG
+          #{env_file_name} not found in #{env_file_dir} while looking for env var #{key}.
+
+          Please copy #{@env_example_path} to #{@env_path} and fill in the value for #{key}.
+
+          mkdir -p #{env_file_dir} && cp #{@env_example_path} #{@env_path}
+        MSG
+      end
+    end
+
+    value = ENV.fetch(key)
+
+    UI.user_error!("Env var for key #{key} is set but empty. Please set a value for #{key}.") if value.to_s.empty?
+
+    value
+  end
+
+  # Use this to ensure all env vars a lane requires are set.
+  #
+  # The best place to call this is at the start of a lane, to fail early.
+  def self.require_env_vars!(*keys)
+    keys.each { |key| get_required_env!(key) }
+  end
+
+  def self.running_on_ci?
+    ENV['CI'] == 'true'
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -40,27 +40,35 @@ class EnvManager
     unless ENV.key?(key)
       message = "Environment variable '#{key}' is not set."
 
-      if running_on_ci?
-        @print_error_lambda.call(message)
-      elsif File.exist?(@env_path)
-        @print_error_lambda.call("#{message} Consider adding it to #{@env_path}.")
-      else
-        env_file_dir = File.dirname(@env_path)
-        env_file_name = File.basename(@env_path)
+      error_message =
+        if running_on_ci?
+          message
+        elsif File.exist?(@env_path)
+          "#{message} Consider adding it to #{@env_path}."
+        else
+          env_file_dir = File.dirname(@env_path)
+          env_file_name = File.basename(@env_path)
 
-        @print_error_lambda.call <<~MSG
-          #{env_file_name} not found in #{env_file_dir} while looking for env var #{key}.
+          <<~MSG
+            #{env_file_name} not found in #{env_file_dir} while looking for env var #{key}.
 
-          Please copy #{@env_example_path} to #{@env_path} and fill in the value for #{key}.
+            Please copy #{@env_example_path} to #{@env_path} and fill in the value for #{key}.
 
-          mkdir -p #{env_file_dir} && cp #{@env_example_path} #{@env_path}
-        MSG
-      end
+            mkdir -p #{env_file_dir} && cp #{@env_example_path} #{@env_path}
+          MSG
+        end
+
+      @print_error_lambda.call(error_message)
+      raise KeyError, error_message
     end
 
     value = ENV.fetch(key)
 
-    @print_error_lambda.call("Env var for key #{key} is set but empty. Please set a value for #{key}.") if value.to_s.empty?
+    if value.to_s.empty?
+      empty_message = "Env var for key #{key} is set but empty. Please set a value for #{key}."
+      @print_error_lambda.call(empty_message)
+      raise ArgumentError, empty_message
+    end
 
     value
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -8,7 +8,7 @@ require 'fastlane'
 
 # Manages loading of environment variables from a .env and accessing them in a user-friendly way.
 class EnvManager
-  attr_reader :env_path, :env_example_path
+  attr_reader :env_path, :env_example_path, :print_error_lambda
 
   class << self
     attr_writer :default_print_error_lambda
@@ -153,7 +153,7 @@ class EnvManager
   end
 
   def self.default_print_error_lambda
-    @default&.instance_variable_get(:@print_error_lambda) || @default_print_error_lambda || ->(message) { FastlaneCore::UI.user_error!(message) }
+    @default&.print_error_lambda || @default_print_error_lambda || ->(message) { FastlaneCore::UI.user_error!(message) }
   end
 
   private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -68,6 +68,32 @@ class EnvManager
     keys.each { |key| get_required_env!(key) }
   end
 
+  # CI environment helpers — read common metadata from the CI provider.
+
+  def build_number
+    ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')
+  end
+
+  def branch_name
+    ENV.fetch('BUILDKITE_BRANCH', nil)
+  end
+
+  def commit_hash
+    ENV.fetch('BUILDKITE_COMMIT', nil)
+  end
+
+  # Returns the PR number as an Integer, or nil if not running on a PR build.
+  # Buildkite sets BUILDKITE_PULL_REQUEST to 'false' (not nil) when not on a PR.
+  def pull_request_number
+    pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', 'false')
+    pr_num == 'false' ? nil : Integer(pr_num)
+  end
+
+  # Returns a human-readable label: "PR #123" for PR builds, or the branch name otherwise.
+  def pr_number_or_branch_name
+    pull_request_number&.then { |num| "PR ##{num}" } || branch_name
+  end
+
   # Class-level convenience methods that delegate to a default instance.
   # This preserves the existing API: `EnvManager.set_up(...)` then `EnvManager.get_required_env!(...)`.
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dotenv'
+require 'shellwords'
 # TODO: It would be nice to decouple this from Fastlane.
 # To give a good UX in the current use case, however, it's best to access the Fastlane UI methods directly.
 require 'fastlane'
@@ -54,7 +55,7 @@ class EnvManager
 
             Please copy #{@env_example_path} to #{@env_path} and fill in the value for #{key}.
 
-            mkdir -p #{env_file_dir} && cp #{@env_example_path} #{@env_path}
+            mkdir -p #{Shellwords.shellescape(env_file_dir)} && cp #{Shellwords.shellescape(@env_example_path)} #{Shellwords.shellescape(@env_path)}
           MSG
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -2,8 +2,6 @@
 
 require 'dotenv'
 require 'shellwords'
-# TODO: It would be nice to decouple this from Fastlane.
-# To give a good UX in the current use case, however, it's best to access the Fastlane UI methods directly.
 require 'fastlane'
 
 module Fastlane
@@ -17,8 +15,6 @@ module Fastlane
       end
 
       # Set up by loading the .env file with the given name.
-      #
-      # TODO: We could go one step and guess the name based on the repo URL.
       def initialize(
         env_file_name:,
         env_file_folder: File.join(Dir.home, '.a8c-apps'),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -69,7 +69,7 @@ class EnvManager
   #
   # The best place to call this is at the start of a lane, to fail early.
   def require_env_vars!(*keys)
-    keys.each { |key| get_required_env!(key) }
+    keys.flatten.each { |key| get_required_env!(key) }
   end
 
   # CI environment helpers — read common metadata from the CI provider.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -78,6 +78,16 @@ class EnvManager
     @default.require_env_vars!(*keys)
   end
 
+  # Clears the default instance, useful for test teardown.
+  def self.reset!
+    @default = nil
+  end
+
+  # Returns true if a default instance has been configured via `.set_up`.
+  def self.configured?
+    !@default.nil?
+  end
+
   private
 
   def running_on_ci?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -7,14 +7,12 @@ require 'fastlane'
 
 # Manages loading of environment variables from a .env and accessing them in a user-friendly way.
 class EnvManager
-  @env_path = nil
-  @env_example_path = nil
-  @print_error_lambda = nil
+  attr_reader :env_path, :env_example_path
 
   # Set up by loading the .env file with the given name.
   #
   # TODO: We could go one step and guess the name based on the repo URL.
-  def self.set_up(
+  def initialize(
     env_file_name:,
     env_file_folder: File.join(Dir.home, '.a8c-apps'),
     example_env_file_path: 'fastlane/example.env',
@@ -29,7 +27,7 @@ class EnvManager
   end
 
   # Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing or empty.
-  def self.get_required_env!(key)
+  def get_required_env!(key)
     unless ENV.key?(key)
       message = "Environment variable '#{key}' is not set."
 
@@ -53,7 +51,7 @@ class EnvManager
 
     value = ENV.fetch(key)
 
-    UI.user_error!("Env var for key #{key} is set but empty. Please set a value for #{key}.") if value.to_s.empty?
+    @print_error_lambda.call("Env var for key #{key} is set but empty. Please set a value for #{key}.") if value.to_s.empty?
 
     value
   end
@@ -61,12 +59,28 @@ class EnvManager
   # Use this to ensure all env vars a lane requires are set.
   #
   # The best place to call this is at the start of a lane, to fail early.
-  def self.require_env_vars!(*keys)
+  def require_env_vars!(*keys)
     keys.each { |key| get_required_env!(key) }
   end
 
-  def self.running_on_ci?
+  # Class-level convenience methods that delegate to a default instance.
+  # This preserves the existing API: `EnvManager.set_up(...)` then `EnvManager.get_required_env!(...)`.
+
+  def self.set_up(**args)
+    @default = new(**args)
+  end
+
+  def self.get_required_env!(key)
+    @default.get_required_env!(key)
+  end
+
+  def self.require_env_vars!(*keys)
+    @default.require_env_vars!(*keys)
+  end
+
+  private
+
+  def running_on_ci?
     ENV['CI'] == 'true'
   end
-  private_class_method :running_on_ci?
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -9,6 +9,10 @@ require 'fastlane'
 class EnvManager
   attr_reader :env_path, :env_example_path
 
+  class << self
+    attr_writer :default_print_error_lambda
+  end
+
   # Set up by loading the .env file with the given name.
   #
   # TODO: We could go one step and guess the name based on the repo URL.
@@ -98,7 +102,7 @@ class EnvManager
   # This preserves the existing API: `EnvManager.set_up(...)` then `EnvManager.get_required_env!(...)`.
 
   def self.set_up(**args)
-    FastlaneCore::UI.user_error!('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.') if configured?
+    default_print_error_lambda.call('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.') if configured?
 
     @default = new(**args)
   end
@@ -124,7 +128,11 @@ class EnvManager
   def self.default!
     return @default if configured?
 
-    FastlaneCore::UI.user_error!('EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
+    default_print_error_lambda.call('EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
+  end
+
+  def self.default_print_error_lambda
+    @default&.instance_variable_get(:@print_error_lambda) || @default_print_error_lambda || ->(message) { FastlaneCore::UI.user_error!(message) }
   end
 
   private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -158,7 +158,16 @@ class EnvManager
 
   private
 
+  # Consider any non-empty, non-falsy value of `CI` to mean we're running on CI.
+  # Most CI providers set `CI=true`, but some use `CI=1`.
+  #
+  # Note: the CI helpers above (`build_number`, etc.) remain Buildkite-specific —
+  # see the block comment on them. Detection via `CI` is a de facto standard and
+  # cheap to generalize; value-fetching is not.
   def running_on_ci?
-    ENV['CI'] == 'true'
+    value = ENV.fetch('CI', nil)
+    return false if value.nil? || value.empty?
+
+    !%w[false 0].include?(value.downcase)
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -85,7 +85,7 @@ class EnvManager
   #
   # Notice that given Buildkite is the only CI provider we use, they are Buildkite-dependent.
   #
-  # If this were to be adopted more broadly, we'd need a two-tier approch:
+  # If this were to be adopted more broadly, we'd need a two-tier approach:
   # 1. Detect which CI is in use
   # 2. Use its specific env vars
   # 3. Maybe fallback to best guess or outright error if no vendor detected

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -131,7 +131,9 @@ class EnvManager
   def self.default!
     return @default if configured?
 
-    default_print_error_lambda.call('EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
+    message = 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.'
+    default_print_error_lambda.call(message)
+    raise message
   end
 
   def self.default_print_error_lambda

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -22,7 +22,10 @@ class EnvManager
     @env_example_path = example_env_file_path
     @print_error_lambda = print_error_lambda
 
-    # We don't check for @env_path to exist here
+    unless File.exist?(@env_path) || running_on_ci?
+      FastlaneCore::UI.important("Warning: env file not found at #{@env_path}. Environment variables may not be loaded.")
+    end
+
     Dotenv.load(@env_path)
   end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -33,12 +33,15 @@ class EnvManager
       @print_warning_lambda.call("Warning: env file not found at #{@env_path}. Environment variables may not be loaded.")
     end
 
-    Dotenv.load(@env_path)
+    # Parse rather than load so we don't mutate the global ENV. Each instance
+    # gets its own view, and values from the process environment (e.g. set by
+    # CI) still take precedence — see `env_value`.
+    @loaded_env = File.exist?(@env_path) ? Dotenv.parse(@env_path) : {}
   end
 
   # Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing or empty.
   def get_required_env!(key)
-    unless ENV.key?(key)
+    unless env_var_set?(key)
       message = "Environment variable '#{key}' is not set."
 
       error_message =
@@ -63,7 +66,7 @@ class EnvManager
       raise KeyError, error_message
     end
 
-    value = ENV.fetch(key)
+    value = env_value(key)
 
     if value.to_s.empty?
       empty_message = "Env var for key #{key} is set but empty. Please set a value for #{key}."
@@ -157,6 +160,16 @@ class EnvManager
   end
 
   private
+
+  # Process ENV takes precedence over values loaded from the .env file, matching
+  # the original `Dotenv.load` (no-override) semantics.
+  def env_var_set?(key)
+    ENV.key?(key) || @loaded_env.key?(key)
+  end
+
+  def env_value(key)
+    ENV.key?(key) ? ENV.fetch(key) : @loaded_env[key]
+  end
 
   # Consider any non-empty, non-falsy value of `CI` to mean we're running on CI.
   # Most CI providers set `CI=true`, but some use `CI=1`.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -16,14 +16,16 @@ class EnvManager
     env_file_name:,
     env_file_folder: File.join(Dir.home, '.a8c-apps'),
     example_env_file_path: 'fastlane/example.env',
-    print_error_lambda: ->(message) { FastlaneCore::UI.user_error!(message) }
+    print_error_lambda: ->(message) { FastlaneCore::UI.user_error!(message) },
+    print_warning_lambda: ->(message) { FastlaneCore::UI.important(message) }
   )
     @env_path = File.join(env_file_folder, env_file_name)
     @env_example_path = example_env_file_path
     @print_error_lambda = print_error_lambda
+    @print_warning_lambda = print_warning_lambda
 
     unless File.exist?(@env_path) || running_on_ci?
-      FastlaneCore::UI.important("Warning: env file not found at #{@env_path}. Environment variables may not be loaded.")
+      @print_warning_lambda.call("Warning: env file not found at #{@env_path}. Environment variables may not be loaded.")
     end
 
     Dotenv.load(@env_path)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -102,7 +102,10 @@ class EnvManager
   # This preserves the existing API: `EnvManager.set_up(...)` then `EnvManager.get_required_env!(...)`.
 
   def self.set_up(**args)
-    default_print_error_lambda.call('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.') if configured?
+    if configured?
+      default_print_error_lambda.call('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.')
+      return @default
+    end
 
     @default = new(**args)
   end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -6,181 +6,185 @@ require 'shellwords'
 # To give a good UX in the current use case, however, it's best to access the Fastlane UI methods directly.
 require 'fastlane'
 
-# Manages loading of environment variables from a .env and accessing them in a user-friendly way.
-class EnvManager
-  attr_reader :env_path, :env_example_path, :print_error_lambda
+module Fastlane
+  module Wpmreleasetoolkit
+    # Manages loading of environment variables from a .env and accessing them in a user-friendly way.
+    class EnvManager
+      attr_reader :env_path, :env_example_path, :print_error_lambda
 
-  class << self
-    attr_writer :default_print_error_lambda
-  end
+      class << self
+        attr_writer :default_print_error_lambda
+      end
 
-  # Set up by loading the .env file with the given name.
-  #
-  # TODO: We could go one step and guess the name based on the repo URL.
-  def initialize(
-    env_file_name:,
-    env_file_folder: File.join(Dir.home, '.a8c-apps'),
-    example_env_file_path: 'fastlane/example.env',
-    print_error_lambda: ->(message) { FastlaneCore::UI.user_error!(message) },
-    print_warning_lambda: ->(message) { FastlaneCore::UI.important(message) }
-  )
-    @env_path = File.join(env_file_folder, env_file_name)
-    @env_example_path = example_env_file_path
-    @print_error_lambda = print_error_lambda
-    @print_warning_lambda = print_warning_lambda
+      # Set up by loading the .env file with the given name.
+      #
+      # TODO: We could go one step and guess the name based on the repo URL.
+      def initialize(
+        env_file_name:,
+        env_file_folder: File.join(Dir.home, '.a8c-apps'),
+        example_env_file_path: 'fastlane/example.env',
+        print_error_lambda: ->(message) { FastlaneCore::UI.user_error!(message) },
+        print_warning_lambda: ->(message) { FastlaneCore::UI.important(message) }
+      )
+        @env_path = File.join(env_file_folder, env_file_name)
+        @env_example_path = example_env_file_path
+        @print_error_lambda = print_error_lambda
+        @print_warning_lambda = print_warning_lambda
 
-    unless File.exist?(@env_path) || running_on_ci?
-      @print_warning_lambda.call("Warning: env file not found at #{@env_path}. Environment variables may not be loaded.")
-    end
-
-    # Parse rather than load so we don't mutate the global ENV. Each instance
-    # gets its own view, and values from the process environment (e.g. set by
-    # CI) still take precedence — see `env_value`.
-    @loaded_env = File.exist?(@env_path) ? Dotenv.parse(@env_path) : {}
-  end
-
-  # Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing or empty.
-  def get_required_env!(key)
-    unless env_var_set?(key)
-      message = "Environment variable '#{key}' is not set."
-
-      error_message =
-        if running_on_ci?
-          message
-        elsif File.exist?(@env_path)
-          "#{message} Consider adding it to #{@env_path}."
-        else
-          env_file_dir = File.dirname(@env_path)
-          env_file_name = File.basename(@env_path)
-
-          <<~MSG
-            #{env_file_name} not found in #{env_file_dir} while looking for env var #{key}.
-
-            Please copy #{@env_example_path} to #{@env_path} and fill in the value for #{key}.
-
-            mkdir -p #{Shellwords.shellescape(env_file_dir)} && cp #{Shellwords.shellescape(@env_example_path)} #{Shellwords.shellescape(@env_path)}
-          MSG
+        unless File.exist?(@env_path) || running_on_ci?
+          @print_warning_lambda.call("Warning: env file not found at #{@env_path}. Environment variables may not be loaded.")
         end
 
-      @print_error_lambda.call(error_message)
-      raise KeyError, error_message
+        # Parse rather than load so we don't mutate the global ENV. Each instance
+        # gets its own view, and values from the process environment (e.g. set by
+        # CI) still take precedence — see `env_value`.
+        @loaded_env = File.exist?(@env_path) ? Dotenv.parse(@env_path) : {}
+      end
+
+      # Use this instead of getting values from `ENV` directly. It will throw an error if the requested value is missing or empty.
+      def get_required_env!(key)
+        unless env_var_set?(key)
+          message = "Environment variable '#{key}' is not set."
+
+          error_message =
+            if running_on_ci?
+              message
+            elsif File.exist?(@env_path)
+              "#{message} Consider adding it to #{@env_path}."
+            else
+              env_file_dir = File.dirname(@env_path)
+              env_file_name = File.basename(@env_path)
+
+              <<~MSG
+                #{env_file_name} not found in #{env_file_dir} while looking for env var #{key}.
+
+                Please copy #{@env_example_path} to #{@env_path} and fill in the value for #{key}.
+
+                mkdir -p #{Shellwords.shellescape(env_file_dir)} && cp #{Shellwords.shellescape(@env_example_path)} #{Shellwords.shellescape(@env_path)}
+              MSG
+            end
+
+          @print_error_lambda.call(error_message)
+          raise KeyError, error_message
+        end
+
+        value = env_value(key)
+
+        if value.to_s.empty?
+          empty_message = "Env var for key #{key} is set but empty. Please set a value for #{key}."
+          @print_error_lambda.call(empty_message)
+          raise ArgumentError, empty_message
+        end
+
+        value
+      end
+
+      # Use this to ensure all env vars a lane requires are set.
+      #
+      # The best place to call this is at the start of a lane, to fail early.
+      def require_env_vars!(*keys)
+        keys.flatten.each { |key| get_required_env!(key) }
+      end
+
+      # CI environment helpers — read common metadata from the CI provider.
+      #
+      # Notice that given Buildkite is the only CI provider we use, they are Buildkite-dependent.
+      #
+      # If this were to be adopted more broadly, we'd need a two-tier approach:
+      # 1. Detect which CI is in use
+      # 2. Use its specific env vars
+      # 3. Maybe fallback to best guess or outright error if no vendor detected
+
+      def build_number
+        ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')
+      end
+
+      def branch_name
+        ENV.fetch('BUILDKITE_BRANCH', nil)
+      end
+
+      def commit_hash
+        ENV.fetch('BUILDKITE_COMMIT', nil)
+      end
+
+      # Returns the PR number as an Integer, or nil if not running on a PR build.
+      # Buildkite sets BUILDKITE_PULL_REQUEST to 'false' (not nil) when not on a PR.
+      def pull_request_number
+        pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', 'false')
+        pr_num == 'false' ? nil : Integer(pr_num)
+      end
+
+      # Returns a human-readable label: "PR #123" for PR builds, or the branch name otherwise.
+      def pr_number_or_branch_name
+        pull_request_number&.then { |num| "PR ##{num}" } || branch_name
+      end
+
+      # Class-level convenience methods that delegate to a default instance.
+      # This preserves the existing API: `EnvManager.set_up(...)` then `EnvManager.get_required_env!(...)`.
+
+      def self.set_up(**args)
+        if configured?
+          default_print_error_lambda.call('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.')
+          return @default
+        end
+
+        @default = new(**args)
+      end
+
+      def self.get_required_env!(key)
+        default!.get_required_env!(key)
+      end
+
+      def self.require_env_vars!(*keys)
+        default!.require_env_vars!(*keys)
+      end
+
+      # Clears the default instance, useful for test teardown.
+      def self.reset!
+        @default = nil
+      end
+
+      # Returns true if a default instance has been configured via `.set_up`.
+      def self.configured?
+        !@default.nil?
+      end
+
+      def self.default!
+        return @default if configured?
+
+        message = 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.'
+        default_print_error_lambda.call(message)
+        raise message
+      end
+
+      def self.default_print_error_lambda
+        @default&.print_error_lambda || @default_print_error_lambda || ->(message) { FastlaneCore::UI.user_error!(message) }
+      end
+
+      private
+
+      # Process ENV takes precedence over values loaded from the .env file, matching
+      # the original `Dotenv.load` (no-override) semantics.
+      def env_var_set?(key)
+        ENV.key?(key) || @loaded_env.key?(key)
+      end
+
+      def env_value(key)
+        ENV.key?(key) ? ENV.fetch(key) : @loaded_env[key]
+      end
+
+      # Consider any non-empty, non-falsy value of `CI` to mean we're running on CI.
+      # Most CI providers set `CI=true`, but some use `CI=1`.
+      #
+      # Note: the CI helpers above (`build_number`, etc.) remain Buildkite-specific —
+      # see the block comment on them. Detection via `CI` is a de facto standard and
+      # cheap to generalize; value-fetching is not.
+      def running_on_ci?
+        value = ENV.fetch('CI', nil)
+        return false if value.nil? || value.empty?
+
+        !%w[false 0].include?(value.downcase)
+      end
     end
-
-    value = env_value(key)
-
-    if value.to_s.empty?
-      empty_message = "Env var for key #{key} is set but empty. Please set a value for #{key}."
-      @print_error_lambda.call(empty_message)
-      raise ArgumentError, empty_message
-    end
-
-    value
-  end
-
-  # Use this to ensure all env vars a lane requires are set.
-  #
-  # The best place to call this is at the start of a lane, to fail early.
-  def require_env_vars!(*keys)
-    keys.flatten.each { |key| get_required_env!(key) }
-  end
-
-  # CI environment helpers — read common metadata from the CI provider.
-  #
-  # Notice that given Buildkite is the only CI provider we use, they are Buildkite-dependent.
-  #
-  # If this were to be adopted more broadly, we'd need a two-tier approach:
-  # 1. Detect which CI is in use
-  # 2. Use its specific env vars
-  # 3. Maybe fallback to best guess or outright error if no vendor detected
-
-  def build_number
-    ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')
-  end
-
-  def branch_name
-    ENV.fetch('BUILDKITE_BRANCH', nil)
-  end
-
-  def commit_hash
-    ENV.fetch('BUILDKITE_COMMIT', nil)
-  end
-
-  # Returns the PR number as an Integer, or nil if not running on a PR build.
-  # Buildkite sets BUILDKITE_PULL_REQUEST to 'false' (not nil) when not on a PR.
-  def pull_request_number
-    pr_num = ENV.fetch('BUILDKITE_PULL_REQUEST', 'false')
-    pr_num == 'false' ? nil : Integer(pr_num)
-  end
-
-  # Returns a human-readable label: "PR #123" for PR builds, or the branch name otherwise.
-  def pr_number_or_branch_name
-    pull_request_number&.then { |num| "PR ##{num}" } || branch_name
-  end
-
-  # Class-level convenience methods that delegate to a default instance.
-  # This preserves the existing API: `EnvManager.set_up(...)` then `EnvManager.get_required_env!(...)`.
-
-  def self.set_up(**args)
-    if configured?
-      default_print_error_lambda.call('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.')
-      return @default
-    end
-
-    @default = new(**args)
-  end
-
-  def self.get_required_env!(key)
-    default!.get_required_env!(key)
-  end
-
-  def self.require_env_vars!(*keys)
-    default!.require_env_vars!(*keys)
-  end
-
-  # Clears the default instance, useful for test teardown.
-  def self.reset!
-    @default = nil
-  end
-
-  # Returns true if a default instance has been configured via `.set_up`.
-  def self.configured?
-    !@default.nil?
-  end
-
-  def self.default!
-    return @default if configured?
-
-    message = 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.'
-    default_print_error_lambda.call(message)
-    raise message
-  end
-
-  def self.default_print_error_lambda
-    @default&.print_error_lambda || @default_print_error_lambda || ->(message) { FastlaneCore::UI.user_error!(message) }
-  end
-
-  private
-
-  # Process ENV takes precedence over values loaded from the .env file, matching
-  # the original `Dotenv.load` (no-override) semantics.
-  def env_var_set?(key)
-    ENV.key?(key) || @loaded_env.key?(key)
-  end
-
-  def env_value(key)
-    ENV.key?(key) ? ENV.fetch(key) : @loaded_env[key]
-  end
-
-  # Consider any non-empty, non-falsy value of `CI` to mean we're running on CI.
-  # Most CI providers set `CI=true`, but some use `CI=1`.
-  #
-  # Note: the CI helpers above (`build_number`, etc.) remain Buildkite-specific —
-  # see the block comment on them. Detection via `CI` is a de facto standard and
-  # cheap to generalize; value-fetching is not.
-  def running_on_ci?
-    value = ENV.fetch('CI', nil)
-    return false if value.nil? || value.empty?
-
-    !%w[false 0].include?(value.downcase)
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -98,6 +98,8 @@ class EnvManager
   # This preserves the existing API: `EnvManager.set_up(...)` then `EnvManager.get_required_env!(...)`.
 
   def self.set_up(**args)
+    FastlaneCore::UI.user_error!('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.') if configured?
+
     @default = new(**args)
   end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -68,4 +68,5 @@ class EnvManager
   def self.running_on_ci?
     ENV['CI'] == 'true'
   end
+  private_class_method :running_on_ci?
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -82,6 +82,13 @@ class EnvManager
   end
 
   # CI environment helpers — read common metadata from the CI provider.
+  #
+  # Notice that given Buildkite is the only CI provider we use, they are Buildkite-dependent.
+  #
+  # If this were to be adopted more broadly, we'd need a two-tier approch:
+  # 1. Detect which CI is in use
+  # 2. Use its specific env vars
+  # 3. Maybe fallback to best guess or outright error if no vendor detected
 
   def build_number
     ENV.fetch('BUILDKITE_BUILD_NUMBER', '0')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager.rb
@@ -102,11 +102,11 @@ class EnvManager
   end
 
   def self.get_required_env!(key)
-    @default.get_required_env!(key)
+    default!.get_required_env!(key)
   end
 
   def self.require_env_vars!(*keys)
-    @default.require_env_vars!(*keys)
+    default!.require_env_vars!(*keys)
   end
 
   # Clears the default instance, useful for test teardown.
@@ -117,6 +117,12 @@ class EnvManager
   # Returns true if a default instance has been configured via `.set_up`.
   def self.configured?
     !@default.nil?
+  end
+
+  def self.default!
+    return @default if configured?
+
+    FastlaneCore::UI.user_error!('EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
   end
 
   private

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe EnvManager do
+describe Fastlane::Wpmreleasetoolkit::EnvManager do
   let(:errors) { [] }
   let(:print_error_lambda) do
     lambda do |message|

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -205,6 +205,101 @@ describe EnvManager do
     end
   end
 
+  describe 'CI environment helpers' do
+    subject(:manager) do
+      described_class.new(
+        env_file_name: 'test.env',
+        env_file_folder: '/tmp',
+        print_error_lambda: print_error_lambda
+      )
+    end
+
+    describe '#build_number' do
+      it 'returns the Buildkite build number' do
+        ENV['BUILDKITE_BUILD_NUMBER'] = '42'
+
+        expect(manager.build_number).to eq('42')
+      end
+
+      it 'defaults to 0 when not set' do
+        ENV.delete('BUILDKITE_BUILD_NUMBER')
+
+        expect(manager.build_number).to eq('0')
+      end
+    end
+
+    describe '#branch_name' do
+      it 'returns the Buildkite branch' do
+        ENV['BUILDKITE_BRANCH'] = 'feature/cool'
+
+        expect(manager.branch_name).to eq('feature/cool')
+      end
+
+      it 'returns nil when not set' do
+        ENV.delete('BUILDKITE_BRANCH')
+
+        expect(manager.branch_name).to be_nil
+      end
+    end
+
+    describe '#commit_hash' do
+      it 'returns the Buildkite commit' do
+        ENV['BUILDKITE_COMMIT'] = 'abc123'
+
+        expect(manager.commit_hash).to eq('abc123')
+      end
+
+      it 'returns nil when not set' do
+        ENV.delete('BUILDKITE_COMMIT')
+
+        expect(manager.commit_hash).to be_nil
+      end
+    end
+
+    describe '#pull_request_number' do
+      it 'returns the PR number as an integer' do
+        ENV['BUILDKITE_PULL_REQUEST'] = '99'
+
+        expect(manager.pull_request_number).to eq(99)
+      end
+
+      it 'returns nil when set to false' do
+        ENV['BUILDKITE_PULL_REQUEST'] = 'false'
+
+        expect(manager.pull_request_number).to be_nil
+      end
+
+      it 'returns nil when not set' do
+        ENV.delete('BUILDKITE_PULL_REQUEST')
+
+        expect(manager.pull_request_number).to be_nil
+      end
+    end
+
+    describe '#pr_number_or_branch_name' do
+      it 'returns PR label when on a PR build' do
+        ENV['BUILDKITE_PULL_REQUEST'] = '42'
+        ENV['BUILDKITE_BRANCH'] = 'feature/x'
+
+        expect(manager.pr_number_or_branch_name).to eq('PR #42')
+      end
+
+      it 'falls back to branch name when not on a PR' do
+        ENV['BUILDKITE_PULL_REQUEST'] = 'false'
+        ENV['BUILDKITE_BRANCH'] = 'trunk'
+
+        expect(manager.pr_number_or_branch_name).to eq('trunk')
+      end
+
+      it 'returns nil when neither PR nor branch is set' do
+        ENV.delete('BUILDKITE_PULL_REQUEST')
+        ENV.delete('BUILDKITE_BRANCH')
+
+        expect(manager.pr_number_or_branch_name).to be_nil
+      end
+    end
+  end
+
   describe 'class-level convenience methods' do
     before do
       described_class.set_up(

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -301,6 +301,8 @@ describe EnvManager do
   end
 
   describe 'class-level convenience methods' do
+    before { described_class.reset! }
+
     before do
       described_class.set_up(
         env_file_name: 'test.env',
@@ -317,6 +319,13 @@ describe EnvManager do
 
         expect(described_class.get_required_env!('CLASS_KEY')).to eq('class_value')
       end
+
+      it 'raises a clear error when called before set_up' do
+        described_class.reset!
+
+        expect { described_class.get_required_env!('CLASS_KEY') }
+          .to raise_error(FastlaneCore::Interface::FastlaneError, 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
+      end
     end
 
     describe '.require_env_vars!' do
@@ -326,6 +335,13 @@ describe EnvManager do
 
         expect(described_class.get_required_env!('CK1')).to eq('v1')
         expect(described_class.get_required_env!('CK2')).to eq('v2')
+      end
+
+      it 'raises a clear error when called before set_up' do
+        described_class.reset!
+
+        expect { described_class.require_env_vars!('CK1', 'CK2') }
+          .to raise_error(FastlaneCore::Interface::FastlaneError, 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
       end
     end
 

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -197,6 +197,16 @@ describe EnvManager do
       expect(result_b).to eq('b')
     end
 
+    it 'accepts an array of keys' do
+      ENV['KEY_A'] = 'a'
+      ENV['KEY_B'] = 'b'
+
+      manager.require_env_vars!(%w[KEY_A KEY_B])
+
+      expect(manager.get_required_env!('KEY_A')).to eq('a')
+      expect(manager.get_required_env!('KEY_B')).to eq('b')
+    end
+
     it 'raises on the first missing key' do
       ENV['KEY_A'] = 'a'
       ENV.delete('KEY_B')

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -11,6 +11,9 @@ describe EnvManager do
     end
   end
 
+  let(:warnings) { [] }
+  let(:print_warning_lambda) { ->(message) { warnings << message } }
+
   # Capture and restore ENV state around each test
   around do |example|
     saved_env = ENV.to_h
@@ -73,37 +76,40 @@ describe EnvManager do
     it 'warns when the env file does not exist' do
       ENV.delete('CI')
 
-      expect(FastlaneCore::UI).to receive(:important).with(/env file not found/)
-
       described_class.new(
         env_file_name: 'nonexistent.env',
         env_file_folder: '/tmp/no-such-dir',
-        print_error_lambda: print_error_lambda
+        print_error_lambda: print_error_lambda,
+        print_warning_lambda: print_warning_lambda
       )
+
+      expect(warnings).to include(a_string_matching(/env file not found/))
     end
 
     it 'does not warn when the env file exists' do
       with_tmp_file(named: 'exists.env', content: '') do |path|
-        expect(FastlaneCore::UI).not_to receive(:important)
-
         described_class.new(
           env_file_name: File.basename(path),
           env_file_folder: File.dirname(path),
-          print_error_lambda: print_error_lambda
+          print_error_lambda: print_error_lambda,
+          print_warning_lambda: print_warning_lambda
         )
+
+        expect(warnings).to be_empty
       end
     end
 
     it 'does not warn on CI even if the env file is missing' do
       ENV['CI'] = 'true'
 
-      expect(FastlaneCore::UI).not_to receive(:important)
-
       described_class.new(
         env_file_name: 'nonexistent.env',
         env_file_folder: '/tmp/no-such-dir',
-        print_error_lambda: print_error_lambda
+        print_error_lambda: print_error_lambda,
+        print_warning_lambda: print_warning_lambda
       )
+
+      expect(warnings).to be_empty
     end
   end
 

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -373,6 +373,15 @@ describe EnvManager do
         expect { described_class.get_required_env!('CLASS_KEY') }
           .to raise_error('EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
       end
+
+      it 'raises even when the error lambda does not raise' do
+        described_class.reset!
+        described_class.default_print_error_lambda = ->(message) { errors << message }
+
+        expect { described_class.get_required_env!('CLASS_KEY') }
+          .to raise_error(RuntimeError, 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
+        expect(errors).to include(a_string_matching(/not configured/))
+      end
     end
 
     describe '.require_env_vars!' do

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -112,6 +112,38 @@ describe EnvManager do
 
       expect(warnings).to be_empty
     end
+
+    # Guard against the common pitfall of a strict `CI == 'true'` check —
+    # some providers set `CI=1` or similar truthy values.
+    %w[true TRUE 1 yes on].each do |ci_value|
+      it "treats CI=#{ci_value.inspect} as running on CI" do
+        ENV['CI'] = ci_value
+
+        described_class.new(
+          env_file_name: 'nonexistent.env',
+          env_file_folder: '/tmp/no-such-dir',
+          print_error_lambda: print_error_lambda,
+          print_warning_lambda: print_warning_lambda
+        )
+
+        expect(warnings).to be_empty
+      end
+    end
+
+    %w[false FALSE 0].each do |ci_value|
+      it "does not treat CI=#{ci_value.inspect} as running on CI" do
+        ENV['CI'] = ci_value
+
+        described_class.new(
+          env_file_name: 'nonexistent.env',
+          env_file_folder: '/tmp/no-such-dir',
+          print_error_lambda: print_error_lambda,
+          print_warning_lambda: print_warning_lambda
+        )
+
+        expect(warnings).not_to be_empty
+      end
+    end
   end
 
   describe '#get_required_env!' do

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -419,8 +419,7 @@ describe EnvManager do
         ENV['CK1'] = 'v1'
         ENV['CK2'] = 'v2'
 
-        expect(described_class.get_required_env!('CK1')).to eq('v1')
-        expect(described_class.get_required_env!('CK2')).to eq('v2')
+        expect { described_class.require_env_vars!('CK1', 'CK2') }.not_to raise_error
       end
 
       it 'raises a clear error when called before set_up' do

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require_relative '../lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager'
 
 describe EnvManager do
   let(:errors) { [] }

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -207,7 +207,7 @@ describe Fastlane::Wpmreleasetoolkit::EnvManager do
         ENV['CI'] = 'true'
 
         expect { manager.get_required_env!('MISSING_KEY') }
-          .to raise_error("Environment variable 'MISSING_KEY' is not set.")
+          .to raise_error(/Environment variable 'MISSING_KEY' is not set\./)
       end
 
       it 'suggests adding the var to the env file when the file exists' do
@@ -224,7 +224,7 @@ describe Fastlane::Wpmreleasetoolkit::EnvManager do
           )
 
           expect { local_manager.get_required_env!('MISSING_KEY') }
-            .to raise_error("Environment variable 'MISSING_KEY' is not set. Consider adding it to #{env_path}.")
+            .to raise_error(/Environment variable 'MISSING_KEY' is not set\. Consider adding it to #{Regexp.escape(env_path)}/)
         end
       end
 

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -166,6 +166,20 @@ describe EnvManager do
           .to raise_error(%r{test\.env not found in /tmp/nonexistent-env-folder})
       end
 
+      it 'escapes paths with spaces in the shell command' do
+        ENV.delete('CI')
+
+        spaced_manager = described_class.new(
+          env_file_name: 'test.env',
+          env_file_folder: '/tmp/path with spaces',
+          example_env_file_path: 'lane/example file.env',
+          print_error_lambda: print_error_lambda
+        )
+
+        expect { spaced_manager.get_required_env!('MISSING_KEY') }
+          .to raise_error(%r{mkdir -p /tmp/path\\ with\\ spaces && cp lane/example\\ file\.env /tmp/path\\ with\\ spaces/test\.env})
+      end
+
       it 'raises KeyError even when the error lambda does not raise' do
         ENV['CI'] = 'true'
         non_raising_errors = []

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -165,6 +165,21 @@ describe EnvManager do
         expect { manager.get_required_env!('MISSING_KEY') }
           .to raise_error(%r{test\.env not found in /tmp/nonexistent-env-folder})
       end
+
+      it 'raises KeyError even when the error lambda does not raise' do
+        ENV['CI'] = 'true'
+        non_raising_errors = []
+
+        non_raising_manager = described_class.new(
+          env_file_name: 'test.env',
+          env_file_folder: '/tmp',
+          print_error_lambda: ->(message) { non_raising_errors << message }
+        )
+
+        expect { non_raising_manager.get_required_env!('MISSING_KEY') }
+          .to raise_error(KeyError, /MISSING_KEY/)
+        expect(non_raising_errors).to include(a_string_matching(/not set/))
+      end
     end
 
     it 'prints an error when the env var is set but empty' do
@@ -172,6 +187,21 @@ describe EnvManager do
 
       expect { manager.get_required_env!('EMPTY_KEY') }
         .to raise_error(/is set but empty/)
+    end
+
+    it 'raises ArgumentError for empty values even when the error lambda does not raise' do
+      ENV['EMPTY_KEY'] = ''
+      non_raising_errors = []
+
+      non_raising_manager = described_class.new(
+        env_file_name: 'test.env',
+        env_file_folder: '/tmp',
+        print_error_lambda: ->(message) { non_raising_errors << message }
+      )
+
+      expect { non_raising_manager.get_required_env!('EMPTY_KEY') }
+        .to raise_error(ArgumentError, /is set but empty/)
+      expect(non_raising_errors).to include(a_string_matching(/is set but empty/))
     end
   end
 

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -62,15 +62,52 @@ describe EnvManager do
       expect(manager.env_example_path).to eq('fastlane/example.env')
     end
 
-    it 'loads the .env file via Dotenv' do
+    it 'loads values from the .env file without mutating ENV' do
+      ENV.delete('TEST_INIT_VAR')
+
       with_tmp_file(named: 'test.env', content: "TEST_INIT_VAR=loaded\n") do |path|
-        described_class.new(
+        manager = described_class.new(
           env_file_name: File.basename(path),
           env_file_folder: File.dirname(path),
           print_error_lambda: print_error_lambda
         )
 
-        expect(ENV.fetch('TEST_INIT_VAR', nil)).to eq('loaded')
+        expect(manager.get_required_env!('TEST_INIT_VAR')).to eq('loaded')
+        expect(ENV.fetch('TEST_INIT_VAR', nil)).to be_nil
+      end
+    end
+
+    it 'keeps multiple instances isolated from each other' do
+      with_tmp_file(named: 'a.env', content: "SHARED_KEY=from_a\n") do |path_a|
+        with_tmp_file(named: 'b.env', content: "SHARED_KEY=from_b\n") do |path_b|
+          manager_a = described_class.new(
+            env_file_name: File.basename(path_a),
+            env_file_folder: File.dirname(path_a),
+            print_error_lambda: print_error_lambda
+          )
+          manager_b = described_class.new(
+            env_file_name: File.basename(path_b),
+            env_file_folder: File.dirname(path_b),
+            print_error_lambda: print_error_lambda
+          )
+
+          expect(manager_a.get_required_env!('SHARED_KEY')).to eq('from_a')
+          expect(manager_b.get_required_env!('SHARED_KEY')).to eq('from_b')
+        end
+      end
+    end
+
+    it 'lets values in the process ENV take precedence over the .env file' do
+      ENV['PRECEDENCE_KEY'] = 'from_env'
+
+      with_tmp_file(named: 'p.env', content: "PRECEDENCE_KEY=from_file\n") do |path|
+        manager = described_class.new(
+          env_file_name: File.basename(path),
+          env_file_folder: File.dirname(path),
+          print_error_lambda: print_error_lambda
+        )
+
+        expect(manager.get_required_env!('PRECEDENCE_KEY')).to eq('from_env')
       end
     end
 

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -69,6 +69,42 @@ describe EnvManager do
         expect(ENV.fetch('TEST_INIT_VAR', nil)).to eq('loaded')
       end
     end
+
+    it 'warns when the env file does not exist' do
+      ENV.delete('CI')
+
+      expect(FastlaneCore::UI).to receive(:important).with(/env file not found/)
+
+      described_class.new(
+        env_file_name: 'nonexistent.env',
+        env_file_folder: '/tmp/no-such-dir',
+        print_error_lambda: print_error_lambda
+      )
+    end
+
+    it 'does not warn when the env file exists' do
+      with_tmp_file(named: 'exists.env', content: '') do |path|
+        expect(FastlaneCore::UI).not_to receive(:important)
+
+        described_class.new(
+          env_file_name: File.basename(path),
+          env_file_folder: File.dirname(path),
+          print_error_lambda: print_error_lambda
+        )
+      end
+    end
+
+    it 'does not warn on CI even if the env file is missing' do
+      ENV['CI'] = 'true'
+
+      expect(FastlaneCore::UI).not_to receive(:important)
+
+      described_class.new(
+        env_file_name: 'nonexistent.env',
+        env_file_folder: '/tmp/no-such-dir',
+        print_error_lambda: print_error_lambda
+      )
+    end
   end
 
   describe '#get_required_env!' do

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../lib/fastlane/plugin/wpmreleasetoolkit/env_manager/env_manager'
+
+describe EnvManager do
+  let(:errors) { [] }
+  let(:print_error_lambda) do
+    lambda do |message|
+      errors << message
+      raise message
+    end
+  end
+
+  # Capture and restore ENV state around each test
+  around do |example|
+    saved_env = ENV.to_h
+    example.run
+  ensure
+    ENV.replace(saved_env)
+  end
+
+  describe '#initialize' do
+    it 'sets env_path from folder and file name' do
+      manager = described_class.new(
+        env_file_name: 'my-app.env',
+        env_file_folder: '/tmp/test-env',
+        print_error_lambda: print_error_lambda
+      )
+
+      expect(manager.env_path).to eq('/tmp/test-env/my-app.env')
+    end
+
+    it 'defaults env_file_folder to ~/.a8c-apps' do
+      manager = described_class.new(
+        env_file_name: 'my-app.env',
+        print_error_lambda: print_error_lambda
+      )
+
+      expect(manager.env_path).to eq(File.join(Dir.home, '.a8c-apps', 'my-app.env'))
+    end
+
+    it 'sets env_example_path' do
+      manager = described_class.new(
+        env_file_name: 'my-app.env',
+        example_env_file_path: 'custom/example.env',
+        print_error_lambda: print_error_lambda
+      )
+
+      expect(manager.env_example_path).to eq('custom/example.env')
+    end
+
+    it 'defaults env_example_path to fastlane/example.env' do
+      manager = described_class.new(
+        env_file_name: 'my-app.env',
+        print_error_lambda: print_error_lambda
+      )
+
+      expect(manager.env_example_path).to eq('fastlane/example.env')
+    end
+
+    it 'loads the .env file via Dotenv' do
+      with_tmp_file(named: 'test.env', content: "TEST_INIT_VAR=loaded\n") do |path|
+        described_class.new(
+          env_file_name: File.basename(path),
+          env_file_folder: File.dirname(path),
+          print_error_lambda: print_error_lambda
+        )
+
+        expect(ENV.fetch('TEST_INIT_VAR', nil)).to eq('loaded')
+      end
+    end
+  end
+
+  describe '#get_required_env!' do
+    subject(:manager) do
+      described_class.new(
+        env_file_name: 'test.env',
+        env_file_folder: env_file_folder,
+        print_error_lambda: print_error_lambda
+      )
+    end
+
+    let(:env_file_folder) { '/tmp/nonexistent-env-folder' }
+
+    it 'returns the value when the env var is set' do
+      ENV['TEST_KEY'] = 'test_value'
+
+      expect(manager.get_required_env!('TEST_KEY')).to eq('test_value')
+    end
+
+    context 'when the env var is missing' do
+      before { ENV.delete('MISSING_KEY') }
+
+      it 'prints a CI-specific error when running on CI' do
+        ENV['CI'] = 'true'
+
+        expect { manager.get_required_env!('MISSING_KEY') }
+          .to raise_error("Environment variable 'MISSING_KEY' is not set.")
+      end
+
+      it 'suggests adding the var to the env file when the file exists' do
+        ENV.delete('CI')
+
+        in_tmp_dir do |tmpdir|
+          env_path = File.join(tmpdir, 'test.env')
+          File.write(env_path, '')
+
+          local_manager = described_class.new(
+            env_file_name: 'test.env',
+            env_file_folder: tmpdir,
+            print_error_lambda: print_error_lambda
+          )
+
+          expect { local_manager.get_required_env!('MISSING_KEY') }
+            .to raise_error("Environment variable 'MISSING_KEY' is not set. Consider adding it to #{env_path}.")
+        end
+      end
+
+      it 'prints setup instructions when the env file does not exist' do
+        ENV.delete('CI')
+
+        expect { manager.get_required_env!('MISSING_KEY') }
+          .to raise_error(%r{test\.env not found in /tmp/nonexistent-env-folder})
+      end
+    end
+
+    it 'prints an error when the env var is set but empty' do
+      ENV['EMPTY_KEY'] = ''
+
+      expect { manager.get_required_env!('EMPTY_KEY') }
+        .to raise_error(/is set but empty/)
+    end
+  end
+
+  describe '#require_env_vars!' do
+    subject(:manager) do
+      described_class.new(
+        env_file_name: 'test.env',
+        env_file_folder: '/tmp',
+        print_error_lambda: print_error_lambda
+      )
+    end
+
+    it 'validates each key' do
+      ENV['KEY_A'] = 'a'
+      ENV['KEY_B'] = 'b'
+
+      result_a = manager.get_required_env!('KEY_A')
+      result_b = manager.get_required_env!('KEY_B')
+
+      manager.require_env_vars!('KEY_A', 'KEY_B')
+
+      expect(result_a).to eq('a')
+      expect(result_b).to eq('b')
+    end
+
+    it 'raises on the first missing key' do
+      ENV['KEY_A'] = 'a'
+      ENV.delete('KEY_B')
+
+      expect { manager.require_env_vars!('KEY_A', 'KEY_B') }
+        .to raise_error(/KEY_B/)
+    end
+  end
+
+  describe 'class-level convenience methods' do
+    before do
+      described_class.set_up(
+        env_file_name: 'test.env',
+        env_file_folder: '/tmp',
+        print_error_lambda: print_error_lambda
+      )
+    end
+
+    describe '.get_required_env!' do
+      it 'delegates to the default instance' do
+        ENV['CLASS_KEY'] = 'class_value'
+
+        expect(described_class.get_required_env!('CLASS_KEY')).to eq('class_value')
+      end
+    end
+
+    describe '.require_env_vars!' do
+      it 'delegates to the default instance' do
+        ENV['CK1'] = 'v1'
+        ENV['CK2'] = 'v2'
+
+        expect(described_class.get_required_env!('CK1')).to eq('v1')
+        expect(described_class.get_required_env!('CK2')).to eq('v2')
+      end
+    end
+  end
+end

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -20,6 +20,7 @@ describe EnvManager do
     example.run
   ensure
     ENV.replace(saved_env)
+    described_class.default_print_error_lambda = nil
   end
 
   describe '#initialize' do
@@ -321,10 +322,7 @@ describe EnvManager do
             env_file_folder: '/tmp',
             print_error_lambda: print_error_lambda
           )
-        end.to raise_error(
-          FastlaneCore::Interface::FastlaneError,
-          'EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.'
-        )
+        end.to raise_error('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.')
       end
     end
 
@@ -337,9 +335,10 @@ describe EnvManager do
 
       it 'raises a clear error when called before set_up' do
         described_class.reset!
+        described_class.default_print_error_lambda = print_error_lambda
 
         expect { described_class.get_required_env!('CLASS_KEY') }
-          .to raise_error(FastlaneCore::Interface::FastlaneError, 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
+          .to raise_error('EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
       end
     end
 
@@ -354,9 +353,10 @@ describe EnvManager do
 
       it 'raises a clear error when called before set_up' do
         described_class.reset!
+        described_class.default_print_error_lambda = print_error_lambda
 
         expect { described_class.require_env_vars!('CK1', 'CK2') }
-          .to raise_error(FastlaneCore::Interface::FastlaneError, 'EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
+          .to raise_error('EnvManager is not configured. Call `EnvManager.set_up(...)` first.')
       end
     end
 

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -313,6 +313,21 @@ describe EnvManager do
 
     after { described_class.reset! }
 
+    describe '.set_up' do
+      it 'raises a clear error when called twice without reset' do
+        expect do
+          described_class.set_up(
+            env_file_name: 'other.env',
+            env_file_folder: '/tmp',
+            print_error_lambda: print_error_lambda
+          )
+        end.to raise_error(
+          FastlaneCore::Interface::FastlaneError,
+          'EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.'
+        )
+      end
+    end
+
     describe '.get_required_env!' do
       it 'delegates to the default instance' do
         ENV['CLASS_KEY'] = 'class_value'

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -172,6 +172,8 @@ describe EnvManager do
       )
     end
 
+    after { described_class.reset! }
+
     describe '.get_required_env!' do
       it 'delegates to the default instance' do
         ENV['CLASS_KEY'] = 'class_value'
@@ -187,6 +189,28 @@ describe EnvManager do
 
         expect(described_class.get_required_env!('CK1')).to eq('v1')
         expect(described_class.get_required_env!('CK2')).to eq('v2')
+      end
+    end
+
+    describe '.reset!' do
+      it 'clears the default instance' do
+        expect(described_class).to be_configured
+
+        described_class.reset!
+
+        expect(described_class).not_to be_configured
+      end
+    end
+
+    describe '.configured?' do
+      it 'returns false before set_up' do
+        described_class.reset!
+
+        expect(described_class).not_to be_configured
+      end
+
+      it 'returns true after set_up' do
+        expect(described_class).to be_configured
       end
     end
   end

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -302,9 +302,8 @@ describe EnvManager do
   end
 
   describe 'class-level convenience methods' do
-    before { described_class.reset! }
-
     before do
+      described_class.reset!
       described_class.set_up(
         env_file_name: 'test.env',
         env_file_folder: '/tmp',

--- a/spec/env_manager_spec.rb
+++ b/spec/env_manager_spec.rb
@@ -333,6 +333,30 @@ describe EnvManager do
           )
         end.to raise_error('EnvManager is already configured. Call `EnvManager.reset!` before calling `EnvManager.set_up(...)` again.')
       end
+
+      it 'does not overwrite the default instance when the error lambda does not raise' do
+        # Set up with a non-raising error lambda so we can verify the guard behavior
+        described_class.reset!
+        non_raising_errors = []
+        non_raising_lambda = ->(message) { non_raising_errors << message }
+
+        described_class.set_up(
+          env_file_name: 'test.env',
+          env_file_folder: '/tmp',
+          print_error_lambda: non_raising_lambda
+        )
+        original_default = described_class.send(:instance_variable_get, :@default)
+
+        # Second call should not overwrite the original
+        described_class.set_up(
+          env_file_name: 'other.env',
+          env_file_folder: '/tmp',
+          print_error_lambda: non_raising_lambda
+        )
+
+        expect(described_class.send(:instance_variable_get, :@default)).to equal(original_default)
+        expect(non_raising_errors).to include(a_string_matching(/already configured/))
+      end
     end
 
     describe '.get_required_env!' do


### PR DESCRIPTION
## What does it do?

Adds `EnvManager`, a helper class for loading `.env` files and accessing environment variables with clear error messages.

Originally developed in the Gravatar-SDK-iOS repo, then adapted for the release toolkit.

<!-- blue -->
> [!NOTE]  
> The diff is big, but it's 2/3 tests

- Loads env vars from a `.env` file via Dotenv at initialization
- `get_required_env!(key)` returns the value or raises with a context-aware message (CI vs. local, file exists vs. missing)
- `require_env_vars!(*keys)` validates multiple keys at once, failing fast on the first missing one — accepts both varargs and arrays
- Warns at init when the `.env` file is missing (suppressed on CI)
- Instance-based design with class-level convenience methods (`set_up`, `get_required_env!`, `reset!`, `configured?`) for backward compatibility
- Error and warning output decoupled via injectable lambdas, defaulting to Fastlane UI
- CI environment helpers (`build_number`, `branch_name`, `commit_hash`, `pull_request_number`, `pr_number_or_branch_name`)

## Example adoption

See Automattic/simplenote-ios#1742 for an example of migrating a project from a local `EnvManager` copy to the release-toolkit version.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.