### PR TITLE
Drop `build.gradle` support when `version.properties` can be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking Changes
 
-_None_
+- Remove `build_gradle_path` parameter from `android_current_branch_is_hotfix` [#579]
 
 ### New Features
 
@@ -18,15 +18,26 @@ _None_
 
 ### Internal Changes
 
-- Deprecated the following actions: [#577]
+- Deprecated the following actions: [#577, #579]
     - `android_betabuild_prechecks`
     - `android_build_prechecks`
+    - `android_bump_version_beta`
+    - `android_bump_version_final_release`
+    - `android_bump_version_hotfix`
+    - `android_bump_version_release`
     - `android_codefreeze_prechecks`
     - `android_completecodefreeze_prechecks`
     - `android_finalize_prechecks`
+    - `android_get_alpha_version`
+    - `android_get_app_version`
+    - `android_get_release_version`
     - `android_hotfix_prechecks`
+    - `android_tag_build`
     - `ios_betabuild_prechecks`
     - `ios_build_prechecks`
+    - `ios_bump_version_beta`
+    - `ios_bump_version_hotfix`
+    - `ios_bump_version_release`
     - `ios_codefreeze_prechecks`
     - `ios_completecodefreeze_prechecks`
     - `ios_finalize_prechecks`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,9 @@
 # Migration Instructions for Major Releases
 
+## From 11.x to 12.0.0
+
+- `android_current_branch_is_hotfix` no longer supports the `build_gradle_path` parameter. Convert the project to define `versionName` and `versionCode` in `version.properties` and call `android_current_branch_is_hotfix` with `version_properties_path`.
+
 ## From `10.0.0` to `11.0.0`
 
 - The `ios_check_beta_deps` now uses the `Podfile.lock` instead of `Podfile` for its detection. If you called this action with an explicit `podfile: …` argument, you'll have to update the call to use `lockfile:` instead—or remove that argument completely from your call and rely on its default value being `Podfile.lock`.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_beta.rb
@@ -78,6 +78,14 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_final_release.rb
@@ -70,6 +70,14 @@ module Fastlane
         ]
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_hotfix.rb
@@ -79,6 +79,14 @@ module Fastlane
         ]
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_bump_version_release.rb
@@ -97,6 +97,14 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
@@ -8,11 +8,10 @@ module Fastlane
       def self.run(params)
         require_relative '../../helper/android/android_version_helper'
 
-        build_gradle_path = params[:build_gradle_path]
         version_properties_path = params[:version_properties_path]
 
         version = Fastlane::Helper::Android::VersionHelper.get_release_version(
-          build_gradle_path: build_gradle_path,
+          build_gradle_path: nil,
           version_properties_path: version_properties_path
         )
         Fastlane::Helper::Android::VersionHelper.is_hotfix?(version)
@@ -32,16 +31,10 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :build_gradle_path,
-                                       description: 'Path to the build.gradle file',
-                                       type: String,
-                                       optional: true,
-                                       conflicting_options: [:version_properties_path]),
           FastlaneCore::ConfigItem.new(key: :version_properties_path,
                                        description: 'Path to the version.properties file',
                                        type: String,
-                                       optional: true,
-                                       conflicting_options: [:build_gradle_path]),
+                                       optional: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_alpha_version.rb
@@ -49,6 +49,14 @@ module Fastlane
         'Return the alpha version of the app'
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
         ['Automattic']

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_app_version.rb
@@ -49,6 +49,14 @@ module Fastlane
         'Return the public version of the app'
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
         ['Automattic']

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_get_release_version.rb
@@ -49,6 +49,14 @@ module Fastlane
         'Return the public version of the app'
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
         ['Automattic']

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_tag_build.rb
@@ -58,6 +58,14 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. If you need to tag the repo to track the current build version, please do it directly from the Fastfile.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_beta.rb
@@ -40,6 +40,14 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_hotfix.rb
@@ -53,6 +53,14 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_bump_version_release.rb
@@ -58,6 +58,14 @@ module Fastlane
       def self.return_value
       end
 
+      def self.category
+        :deprecated
+      end
+
+      def self.deprecated_notes
+        'This action is deprecated and will be removed in the next major version update of the Release Toolkit. Please use the formatters and calculators in the Versioning module to automate version changes.'
+      end
+
       def self.authors
         ['Automattic']
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_git_helper.rb
@@ -9,6 +9,7 @@ module Fastlane
         # This typically commits the `version.properties` inside root folder or `build.gradle` file
         # inside the project subfolder.
         #
+        # @deprecated Please commit version using the native Fastlane Git APIs in your project's Fastfile.
         def self.commit_version_bump(build_gradle_path:, version_properties_path:)
           if File.exist?(version_properties_path)
             git_commit(


### PR DESCRIPTION
With the introduction of the `Versioning` module, all users should define `versionName` and `versionCode` in a dedicated `version.properties` file. All projects currently using the new versioning APIs do so via `version.properties`. Supporting `build.gradle` only adds complexity to the code for the sake of those few projects (only Simplenote Android, I think) that have not yet migrated. We're better off dropping support here and migrate the remaining projects.

Internal ref: paaHJt-6gp-p2

Looking at the code, the bulk of actions accepting the parameter are actually actions we should deprecate or that have already been deprecated in #576. 

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.

## Where to go from here

To remove the `build.gradle` support, this PR had to introduce a breaking change.

I opened #580 on top of this PR to bank on that breaking change and remove all the deprecated actions as part of a new major release.

Or... I could revert the breaking change and merge this as is, as a deprecation only PR. And save the breaking change for later. 

I have a subliminal feeling of friction about shipping a new major version... But, rationally, I don't see why we should slow down the pace. So, all in all, I think the best way forward would be to ship a new major version.