### PR TITLE
Remove deprecated `create_release` in favor of `create_github_release`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Removed `build_gradle_path` parameter from `android_current_branch_is_hotfix`. [#579]
 - Deleted `Fastlane::Helper::Android::GitHelper` and `Fastlane::Helper::Ios::GitHelper`. [#579]
+- Renamed `create_release` to `create_github_release` for consistency. [#585, #588]
 - Deleted the following deprecated actions: [#577, #579, #586]
     - `android_betabuild_prechecks`
     - `android_build_prechecks`
@@ -46,7 +47,6 @@
 ### Bug Fixes
 
 - Fix `create_release_backmerge_pull_request_action` error when creating a backmerge to a branch not yet fetched locally. [#587]
-- Deprecated the `create_release` action, now renamed to `create_github_release` for consistency. [#585]
 
 ### Internal Changes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,6 +6,7 @@
 - Various helper methods and actions to calculate version bumps have been deleted (see `CHANGELOG.md` for the full list). Use the `Versioning` module for any version computation or automation.
 - `Fastlane::Helper:Android::GitHelper` and `Fastlane::Helper::Ios::GitHelper` have been removed. If you were using their respective `commit_version_bump` methods, you'll need to run the commit directly in your `Fastfile`, for example via Fastlane's `git_commit` action.
 - `android_tag_build` and `ios_tag_build` have been removed. Our recommended workflow for tagging releases relies on GitHub creating a tag when a GitHub release is published.
+- `create_release` has been removed. Use `create_github_release` instead.
 
 ## From `10.0.0` to `11.0.0`
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
@@ -98,16 +98,5 @@ module Fastlane
         true
       end
     end
-
-    # For backwards compatibility
-    class CreateReleaseAction < CreateGithubReleaseAction
-      def self.category
-        :deprecated
-      end
-
-      def self.deprecated_notes
-        "This action has been renamed `#{superclass.action_name}`"
-      end
-    end
   end
 end


### PR DESCRIPTION
_I was about to finalize 12.0.0 when I grepped for "depreacted" and realized a new deprecation landed on `trunk` while #580 was in progress._

Builds on top of
https://github.com/wordpress-mobile/release-toolkit/pull/585.

Those changes were merged just recently but their context was that of a minor update, unaware that `trunk` already included a breaking change.

Since we are breaking things, I'd say we might as well remove backward compatibility by forcing users that upgrade to 12.0.0 to rename `create_release` to `create_github_release`.

## What does it do?

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable - N.A.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
