### PR TITLE
Add handling of `origin` to method `point_to_same_commit?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Added the handling of remote to `GitHelper::point_to_same_commit?` [#590]
 
 ## 12.0.0
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -103,10 +103,7 @@ module Fastlane
         # if there's a callback, make sure it didn't switch branches
         other_action.ensure_git_branch(branch: "^#{intermediate_branch}/") unless intermediate_branch_created_callback.nil?
 
-        base_branch_ref = base_branch.start_with?('origin/') ? base_branch : "origin/#{base_branch}"
-        head_branch_ref = head_branch.start_with?('origin/') ? head_branch : "origin/#{head_branch}"
-
-        if Fastlane::Helper::GitHelper.point_to_same_commit?(base_branch_ref, head_branch_ref)
+        if Fastlane::Helper::GitHelper.point_to_same_commit?(base_branch, head_branch)
           UI.error("No differences between #{head_branch} and #{base_branch}. Skipping PR creation.")
           return nil
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -174,20 +174,23 @@ module Fastlane
       #
       # @param ref1 [String] the first git reference to check.
       # @param ref2 [String] the second git reference to check.
+      # @param remote_name [String] the name of the remote repository to use (default is 'origin').
+      #                             If nil or empty, no remote prefix will be used.
       #
       # @return [Boolean] true if the two references point to the same commit, false otherwise.
       #
-      def self.point_to_same_commit?(ref1, ref2)
+      def self.point_to_same_commit?(ref1, ref2, remote_name: 'origin')
         git_repo = Git.open(Dir.pwd)
 
+        ref1_full = remote_name.to_s.empty? ? ref1 : "#{remote_name}/#{ref1}"
+        ref2_full = remote_name.to_s.empty? ? ref2 : "#{remote_name}/#{ref2}"
         begin
-          ref1_commit = git_repo.gcommit(ref1)
-          ref2_commit = git_repo.gcommit(ref2)
+          ref1_commit = git_repo.gcommit(ref1_full)
+          ref2_commit = git_repo.gcommit(ref2_full)
         rescue StandardError => e
-          puts "Error: #{e.message}"
+          UI.error "Error fetching commits for #{ref1_full} and #{ref2_full}: #{e.message}"
           return false
         end
-
         ref1_commit.sha == ref2_commit.sha
       end
 

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -39,7 +39,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
 
       next if branch_exists_on_remote
 
-      allow(Fastlane::Helper::GitHelper).to receive(:point_to_same_commit?).with("origin/#{target_branch}", "origin/#{source_branch}").and_return(point_to_same_commit)
+      allow(Fastlane::Helper::GitHelper).to receive(:point_to_same_commit?).with(target_branch, source_branch).and_return(point_to_same_commit)
 
       next if point_to_same_commit
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -145,37 +145,37 @@ describe Fastlane::Helper::GitHelper do
     end
 
     it 'checks if a tag and a branch point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('1.0', 'another-branch')
+      same_commit = described_class.point_to_same_commit?('1.0', 'another-branch', remote_name: nil)
       expect(same_commit).to be false
     end
 
     it 'checks if a tag and a branch that had a merge point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('1.0', 'main')
+      same_commit = described_class.point_to_same_commit?('1.0', 'main', remote_name: nil)
       expect(same_commit).to be false
     end
 
     it 'checks if a tag and a commit hash point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('1.0', commit_hash(commit_message: 'commit D'))
+      same_commit = described_class.point_to_same_commit?('1.0', commit_hash(commit_message: 'commit D'), remote_name: nil)
       expect(same_commit).to be false
     end
 
     it 'checks if a commit hash and a branch point to the same commit' do
-      same_commit = described_class.point_to_same_commit?(commit_hash(commit_message: 'commit B'), 'another-branch')
+      same_commit = described_class.point_to_same_commit?(commit_hash(commit_message: 'commit B'), 'another-branch', remote_name: nil)
       expect(same_commit).to be false
     end
 
     it 'checks if commits between the same branch point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('feature-branch', 'feature-branch')
+      same_commit = described_class.point_to_same_commit?('feature-branch', 'feature-branch', remote_name: nil)
       expect(same_commit).to be true
     end
 
     it 'checks if commits between branches that have no difference point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('another-branch', 'new-branch')
+      same_commit = described_class.point_to_same_commit?('another-branch', 'new-branch', remote_name: nil)
       expect(same_commit).to be true
     end
 
     it 'raises error for a non-existent base_ref' do
-      expect { described_class.point_to_same_commit?('non-existent', 'main') }.to raise_error(StandardError)
+      expect { described_class.point_to_same_commit?('non-existent', 'main', remote_name: nil) }.to raise_error(StandardError)
     end
   end
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -66,7 +66,7 @@ describe Fastlane::Helper::GitHelper do
     expect(described_class.has_git_lfs?).to be false
   end
 
-  context('commit(message:, files:)') do
+  describe 'commit(message:, files:)' do
     before do
       allow_fastlane_action_sh
       @message = 'Some commit message with spaces'
@@ -110,7 +110,10 @@ describe Fastlane::Helper::GitHelper do
     end
   end
 
-  context('point_to_same_commit?(ref1, ref2)') do
+  describe 'point_to_same_commit?(ref1, ref2)' do
+    # We cannot test the happy path using a remote because the repo we use for the tests does not have a remote.
+    let(:remote_name) { nil }
+
     before do
       # Spec branching setup:
       #
@@ -145,37 +148,37 @@ describe Fastlane::Helper::GitHelper do
     end
 
     it 'checks if a tag and a branch point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('1.0', 'another-branch', remote_name: nil)
+      same_commit = described_class.point_to_same_commit?('1.0', 'another-branch', remote_name: remote_name)
       expect(same_commit).to be false
     end
 
     it 'checks if a tag and a branch that had a merge point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('1.0', 'main', remote_name: nil)
+      same_commit = described_class.point_to_same_commit?('1.0', 'main', remote_name: remote_name)
       expect(same_commit).to be false
     end
 
     it 'checks if a tag and a commit hash point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('1.0', commit_hash(commit_message: 'commit D'), remote_name: nil)
+      same_commit = described_class.point_to_same_commit?('1.0', commit_hash(commit_message: 'commit D'), remote_name: remote_name)
       expect(same_commit).to be false
     end
 
     it 'checks if a commit hash and a branch point to the same commit' do
-      same_commit = described_class.point_to_same_commit?(commit_hash(commit_message: 'commit B'), 'another-branch', remote_name: nil)
+      same_commit = described_class.point_to_same_commit?(commit_hash(commit_message: 'commit B'), 'another-branch', remote_name: remote_name)
       expect(same_commit).to be false
     end
 
     it 'checks if commits between the same branch point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('feature-branch', 'feature-branch', remote_name: nil)
+      same_commit = described_class.point_to_same_commit?('feature-branch', 'feature-branch', remote_name: remote_name)
       expect(same_commit).to be true
     end
 
     it 'checks if commits between branches that have no difference point to the same commit' do
-      same_commit = described_class.point_to_same_commit?('another-branch', 'new-branch', remote_name: nil)
+      same_commit = described_class.point_to_same_commit?('another-branch', 'new-branch', remote_name: remote_name)
       expect(same_commit).to be true
     end
 
     it 'raises error for a non-existent base_ref' do
-      expect { described_class.point_to_same_commit?('non-existent', 'main', remote_name: nil) }.to raise_error(StandardError)
+      expect { described_class.point_to_same_commit?('non-existent', 'main', remote_name: remote_name) }.to raise_error(StandardError)
     end
   end
 


### PR DESCRIPTION
## What does it do?

Starting from the comment https://github.com/wordpress-mobile/release-toolkit/pull/587#discussion_r1741270988, I realized we already have checks and logic in place to make sure the head and base branches start with `release/` and that it would make more sense to have any logic related to the `point_to_same_commit?` check locally vs. on remote in the method itself, so this PR  updates `point_to_same_commit?` for that.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
