### PR TITLE
Release 12.1.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,22 @@ _None_
 
 ### New Features
 
-- `ios_generate_strings_file_from_code` now accepts an `output_encoding:` optional parameter. [#591]
-  This is typically useful if you prefer your generated files to be UTF-8 rather than the default UTF-16 that `genstrings` is using.
+_None_
 
 ### Bug Fixes
 
 _None_
+
+### Internal Changes
+
+_None_
+
+## 12.1.0
+
+### New Features
+
+- `ios_generate_strings_file_from_code` now accepts an `output_encoding:` optional parameter. [#591]
+  This is typically useful if you prefer your generated files to be UTF-8 rather than the default UTF-16 that `genstrings` is using.
 
 ### Internal Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (12.0.0)
+    fastlane-plugin-wpmreleasetoolkit (12.1.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '12.0.0'
+    VERSION = '12.1.0'
   end
 end


### PR DESCRIPTION
Releasing new version 12.1.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- `ios_generate_strings_file_from_code` now accepts an `output_encoding:` optional parameter. [#591]
  This is typically useful if you prefer your generated files to be UTF-8 rather than the default UTF-16 that `genstrings` is using.

### Internal Changes

- Added the handling of remote to `GitHelper::point_to_same_commit?` [#590]


```
