### PR TITLE
Use a Mermaid graph in the backmerge PR body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- The backmerge PR body now use a [Mermaid](https://mermaid.js.org) graph to represent the Git tree [#594]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -110,17 +110,41 @@ module Fastlane
 
         other_action.push_to_git_remote(tags: false)
 
+        # Live playground to edit this graph
+        # https://mermaid.live/edit#pako:eNqNkU1PwzAMhv9KZanqpWVFwCVHQOKCxoFrLl7itdGaZEoTTWjqf8eLOo2i8eGTPx77TewjKK8JBJTlUbqCzTgTRTEHJ6s6E18C7vtqkc4li8Y9BnSqX6MlBqoYkttV9Y_cW9AUGLxt2_Y7Nfb-8OStNfEVNzQwtcVhpCU1XUJ2p7KU7vzAXNlkmSLQQDjS6v7m4S7nVU9q51O8UsmSv7jzSEuho9Xc3pzaG-Oib_KXlxr_QL8onbuuVy9unvrXbKiBCV645qvme0mIPVmSINjVtMU0RAm8O0YxRf_-4RQIbqca0l5jpGeDXUALIu9_-gRejKzU
+        meramid_git_graph = <<~GRAPH
+          ```mermaid
+          %%{
+            init: {
+              'gitGraph': {
+                'mainBranchName': 'trunk',
+                'mainBranchOrder': 1000,
+                'showCommitLabel': false
+              }
+            }
+          }%%
+          gitGraph
+             branch #{head_branch}
+             checkout #{head_branch}
+             commit
+             commit
+             commit
+             branch #{intermediate_branch}
+             checkout #{intermediate_branch}
+             commit
+             checkout #{base_branch}
+             commit
+             commit
+             merge #{base_branch}
+          ```
+        GRAPH
+
         pr_body = <<~BODY
           Merging `#{head_branch}` into `#{base_branch}`.
 
           Via intermediate branch `#{intermediate_branch}`, to help fix conflicts if any:
-          ```
-          #{head_branch.rjust(40)}  ----o-- - - -
-          #{' ' * 40}       \\
-          #{intermediate_branch.rjust(40)}        `---.
-          #{' ' * 40}             \\
-          #{base_branch.rjust(40)}  ------------x- - -
-          ```
+
+          #{meramid_git_graph}
         BODY
 
         other_action.create_pull_request(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -139,12 +139,29 @@ module Fastlane
           ```
         GRAPH
 
+        ascii_git_graph = <<~GRAPH
+          ```
+          #{head_branch.rjust(40)}  ----o-- - - -
+          #{' ' * 40}       \\
+          #{intermediate_branch.rjust(40)}        `---.
+          #{' ' * 40}             \\
+          #{base_branch.rjust(40)}  ------------x- - -
+          ```
+        GRAPH
+
         pr_body = <<~BODY
           Merging `#{head_branch}` into `#{base_branch}`.
 
           Via intermediate branch `#{intermediate_branch}`, to help fix conflicts if any:
 
           #{meramid_git_graph}
+
+          <details>
+          <summary>Expand to see an ASCII representation of the Git graph above</summary>
+
+          #{ascii_git_graph}
+
+          </details>
         BODY
 
         other_action.create_pull_request(

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -117,7 +117,7 @@ module Fastlane
           %%{
             init: {
               'gitGraph': {
-                'mainBranchName': 'trunk',
+                'mainBranchName': '#{base_branch}',
                 'mainBranchOrder': 1000,
                 'showCommitLabel': false
               }


### PR DESCRIPTION
## What does it do?

I was waiting for CI to finish on a backmerge PR looking at the ASCII art describing the merge and got side tracked into this nerd indulgence:

<img width="724" alt="image" src="https://github.com/user-attachments/assets/a69e6d82-ae3e-428b-8429-23155c07b835">

- Pros: It's neat and colorful and "pro"
- Cons: It's bound to break or change if/when there's a Mermaid syntax 

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable - N.A.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider. - N.A.
