### PR TITLE
Add `:git_graph_type` to backmerge action

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -6,6 +6,9 @@ module Fastlane
     class CreateReleaseBackmergePullRequestAction < Action
       DEFAULT_BRANCH = 'trunk'.freeze
 
+      GIT_GRAPH_TYPES = %i[mermaid ascii both none].freeze
+      GIT_GRAPH_TYPES_STRING = GIT_GRAPH_TYPES.map { |t| ":#{t}" }.join(', ').freeze
+
       def self.run(params)
         token = params[:github_token]
         repository = params[:repository]
@@ -48,7 +51,8 @@ module Fastlane
             milestone: target_milestone&.number,
             reviewers: reviewers,
             team_reviewers: team_reviewers,
-            intermediate_branch_created_callback: intermediate_branch_created_callback
+            intermediate_branch_created_callback: intermediate_branch_created_callback,
+            git_graph_type: params[:git_graph_type]
           )
         end.compact
       end
@@ -88,7 +92,7 @@ module Fastlane
       #
       # @return [String] The URL of the created Pull Request, or `nil` if no PR was created.
       #
-      def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:, intermediate_branch_created_callback:)
+      def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:, intermediate_branch_created_callback:, git_graph_type:)
         intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
 
         if Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: intermediate_branch)
@@ -149,19 +153,32 @@ module Fastlane
           ```
         GRAPH
 
+        git_graph = case git_graph_type
+                    when :both
+                      <<~GRAPH
+                        #{meramid_git_graph}
+
+                        <details>
+                        <summary>Expand to see an ASCII representation of the Git graph above</summary>
+
+                        #{ascii_git_graph}
+                      GRAPH
+                    when :mermaid
+                      meramid_git_graph
+                    when :ascii
+                      ascii_git_graph
+                    when :none
+                      ''
+                    else
+                      UI.user_error!("Unsupported Git graph type '#{params[:git_graph_type]}'")
+                    end
+
         pr_body = <<~BODY
           Merging `#{head_branch}` into `#{base_branch}`.
 
           Via intermediate branch `#{intermediate_branch}`, to help fix conflicts if any:
 
-          #{meramid_git_graph}
-
-          <details>
-          <summary>Expand to see an ASCII representation of the Git graph above</summary>
-
-          #{ascii_git_graph}
-
-          </details>
+          #{git_graph}
         BODY
 
         other_action.create_pull_request(
@@ -244,6 +261,14 @@ module Fastlane
                                        description: 'Callback to allow for the caller to perform operations on the intermediate branch before pushing. The call back receives two parameters: the base (target) branch for the PR and the intermediate branch name',
                                        optional: true,
                                        type: Proc),
+          FastlaneCore::ConfigItem.new(key: :git_graph_type,
+                                       description: "The type of Git graph to show. Possible values: #{GIT_GRAPH_TYPES_STRING}",
+                                       optional: true,
+                                       type: Symbol,
+                                       default_value: :both,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Unsupported Git graph type '#{value}'. Supported values are: #{GIT_GRAPH_TYPES_STRING}.") unless GIT_GRAPH_TYPES.include?(value)
+                                       end),
           Fastlane::Helper::GithubHelper.github_token_config_item,
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -92,7 +92,7 @@ module Fastlane
       #
       # @return [String] The URL of the created Pull Request, or `nil` if no PR was created.
       #
-      def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:, intermediate_branch_created_callback:, git_graph_type:)
+      def self.create_backmerge_pr(token:, repository:, title:, head_branch:, base_branch:, labels:, milestone:, reviewers:, team_reviewers:, intermediate_branch_created_callback:, git_graph_type:) # rubocop:disable Metrics/ParameterLists
         intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
 
         if Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: intermediate_branch)


### PR DESCRIPTION
## What does it do?

What it says on the title. Follow up to @iangmaia 's suggestion from https://github.com/wordpress-mobile/release-toolkit/pull/594#discussion_r1773949128 because:

1. I want to add some tests to the logic
1. This is a low priority task so I won't be working on it with urgency, therefore I don't want to hold #594 because of that

## Checklist before requesting a review

- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
