### PR TITLE
Make `create_release_backmerge_pull_request` delete existing branch before creating it anew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- `create_release_backmerge_pull_request` now deletes existing intermediate branches before creating them anew. [#601]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -92,7 +92,7 @@ module Fastlane
         intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
 
         if Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: intermediate_branch)
-          UI.important("An intermediate branch `#{intermediate_branch}` already existed on the remote. It will be deleted and any associated existing PR will be closed.")
+          UI.important("An intermediate branch `#{intermediate_branch}` already exists on the remote. It will be deleted and GitHub will close any associated existing PR.")
           Fastlane::Helper::GitHelper.delete_remote_branch_if_exists!(intermediate_branch)
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -92,10 +92,11 @@ module Fastlane
         intermediate_branch = "merge/#{head_branch.gsub('/', '-')}-into-#{base_branch.gsub('/', '-')}"
 
         if Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: intermediate_branch)
-          UI.user_error!("The intermediate branch `#{intermediate_branch}` already exists. Please check if there is an existing Pull Request that needs to be merged or closed first, or delete the branch.")
-          return nil
+          UI.important("An intermediate branch `#{intermediate_branch}` already existed on the remote. It will be deleted and any associated existing PR will be closed.")
+          Fastlane::Helper::GitHelper.delete_remote_branch_if_exists!(intermediate_branch)
         end
 
+        Fastlane::Helper::GitHelper.delete_local_branch_if_exists!(intermediate_branch)
         Fastlane::Helper::GitHelper.create_branch(intermediate_branch)
 
         intermediate_branch_created_callback&.call(base_branch, intermediate_branch)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -232,6 +232,32 @@ module Fastlane
         !Action.sh('git', 'ls-remote', '--heads', remote_name, branch_name).empty?
       end
 
+      # Delete a local branch if it exists.
+      #
+      # @param [String] branch_name The name of the local branch to delete.
+      # @return [Boolean] true if the branch was deleted, false if not (e.g. no such local branch existed in the first place)
+      #
+      def self.delete_local_branch_if_exists!(branch_name)
+        git_repo = Git.open(Dir.pwd)
+        return false unless git_repo.is_local_branch?(branch_name)
+
+        git_repo.branch(branch_name).delete
+        true
+      end
+
+      # Delete a remote branch if it exists.
+      #
+      # @param [String] branch_name The name of the remote branch to delete.
+      # @param [String] remote_name The name of the remote to delete the branch from. Defaults to 'origin'
+      # @return [Boolean] true if the branch was deleted, false if not (e.g. no such local branch existed in the first place)
+      #
+      def self.delete_remote_branch_if_exists!(branch_name, remote_name: 'origin')
+        git_repo = Git.open(Dir.pwd)
+        return false unless git_repo.branches.any? { |b| b.remote&.name == remote_name && b.name == branch_name }
+
+        git_repo.push(remote_name, branch_name, delete: true)
+      end
+
       # Checks whether a given path is ignored by Git, relying on Git's `check-ignore` under the hood.
       #
       # @param [String] path The path to check against `.gitignore`

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -322,7 +322,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
 
       intermediate_branches.each do |branch|
         expect(FastlaneCore::UI).to receive(:important)
-          .with("An intermediate branch `#{branch}` already existed on the remote. It will be deleted and any associated existing PR will be closed.")
+          .with("An intermediate branch `#{branch}` already exists on the remote. It will be deleted and GitHub will close any associated existing PR.")
         expect(Fastlane::Helper::GitHelper).to receive(:delete_remote_branch_if_exists!).with(branch)
         expect(Fastlane::Helper::GitHelper).to receive(:delete_local_branch_if_exists!).with(branch)
       end


### PR DESCRIPTION
# What does it do?

This updates `create_release_backmerge_pull_request` to delete the intermediate branch if it already exists before creating it anew.

This is mostly to fix an issue that PocketCasts iOS folks have been running into when running the `new_beta_release` lane from their machine, while the `merge/release-x.y-into-trunk` intermediate branch that had been created from the previous beta (or during `code_freeze`) had not been deleted from their local working copy, thus making the backmerge PR creation fail. (see p1728400101439009/1727442098.188059-slack-C029BMLUGRX&channel=C029BMLUGRX&message_ts=1728400101.439009)

# Rationale:

## Case when the intermediate branch already exists **in the local working copy**

When this happens, this is likely a leftover from a previous backmerge PR (from a previous run of `code_freeze` or `new_beta_release` created locally, where the remote branch might have been deleted since, but the Release Manager have not deleted the intermediate branch from their working copy locally.
This is what happened to Daniele and Sergio in the last 2 sprints of PocketCasts iOS (see p1728400101439009/1727442098.188059-slack-C029BMLUGRX&channel=C029BMLUGRX&message_ts=1728400101.439009)

As such, it makes sense to delete the local intermediate branch before recreating it anew for those cases.

> [!NOTE]
> I am aware that this problem will disappear all by itself once PocketCasts iOS will have migrated to Release-on-CI, and the `new_beta_release` lane being run on CI instead of on developers' machines. But (1) I'll still need a sprint or two to land release-on-CI in PocketCasts iOS, and probably likewise for PCAndroid (2) It is still good practice to make sure that, even if a project is configured to use Release-on-CI, it is still possible to run the lanes locally on occasion and have them still not break your local setup.

## Case when the intermediate branch already exists **on the remote**

Previously this was an error that made the action fail on purpose, with a custom error mentioning that a backmerge PR already exist and the RM should close it first.

But in practice, that behavior created more issues than it was worth, because when such a case happened, Release Managers are not sure how to proceed. Indeed:
 - The existing PR is typically from a previous beta so it's not like merging the existing backmerge PR would allow you to move on—you'd still had to rebase it or create a new one
 - But it's not like you can re-run `new_beta_release` either after having merged or closed the first backmerge PR, since you only want to create the backmerge PR not do the whole dance of a new beta
 - And having the RM manually create the backmerge PR themselves isn't ideal either, because in such case they can easily forget to create an intermediate branch, and would thus risk to accidentally merge the BASE (e.g. `trunk`) into the BASE (e.g. `release/x.y`) during conflict resolution

So instead I think it makes more sense in those cases to delete the intermediate branch from the remote—which will make GitHub close the associated PR when the PR's head branch gets deleted—and recreate it anew, with a warning( `UI.important`, yellow in the logs)
 - If the first backmerge PR was not merged in time, it makes sense anyway to close it and create a new one that points to a more recent intermediate branch that would include more commits from `release/*` anyway
 - Reviewers who might have already started commenting on the previous backmerge PR that hadn't been merged in time would be notified of the PR being closed, so even if there had been some conversation or conflict resolution happening already on that initial backmerge PR, they'd be notified and think about reproducing them on the new backmerge PR.

In any case, even if such a situation would still require developers and RMs to sync with each other, it's still a better outcome IMHO than having the lane or ReleaseV2 task fail and the RM being lost and needing to ask us for support.

# Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] ~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~