### PR TITLE
Fix some PR refs in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,9 @@ _None_
 ### Breaking Changes
 
 - Removed `build_gradle_path` parameter from `android_current_branch_is_hotfix`. [#579]
-- Deleted `Fastlane::Helper::Android::GitHelper` and `Fastlane::Helper::Ios::GitHelper`. [#579]
+- Deleted `Fastlane::Helper::Android::GitHelper` and `Fastlane::Helper::Ios::GitHelper`. [#580]
 - Renamed `create_release` to `create_github_release` for consistency. [#585, #588]
-- Deleted the following deprecated actions: [#577, #579, #586]
+- Deleted the following deprecated actions: [#577, #579, #580, #586]
     - `android_betabuild_prechecks`
     - `android_build_prechecks`
     - `android_bump_version_beta`


### PR DESCRIPTION
Noticed some entries in the CHANGELOG were pointing to the wrong PR number when I did some issue triaging on https://github.com/wordpress-mobile/release-toolkit/issues/525
