### PR TITLE
`buildkite_pipeline_upload`: make sure `environment` keys and values are Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ _None_
 
 ### Internal Changes
 
-_None_
+- `buildkite_pipeline_upload`: makes sure all values passed in the environment parameter are strings [#608]
+- `buildkite_pipeline_upload`: prepend .buildkite to the pipeline_file parameter to enforce our conventions [#608]
 
 ## 12.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ _None_
 ### Internal Changes
 
 - `buildkite_pipeline_upload`: makes sure all values passed in the environment parameter are strings [#608]
-- `buildkite_pipeline_upload`: prepend .buildkite to the pipeline_file parameter to enforce our conventions [#608]
+- `buildkite_pipeline_upload`: prepend `.buildkite/` to the `pipeline_file` parameter to enforce our conventions [#608]
 
 ## 12.2.1
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
@@ -5,7 +5,8 @@ module Fastlane
       DEFAULT_ENV_FILE = File.join(DEFAULT_BUILDKITE_PIPELINE_FOLDER, 'shared-pipeline-vars').freeze
 
       def self.run(params)
-        pipeline_file = File.join(DEFAULT_BUILDKITE_PIPELINE_FOLDER, params[:pipeline_file])
+        pipeline_file = params[:pipeline_file]
+        pipeline_file = File.join(DEFAULT_BUILDKITE_PIPELINE_FOLDER, pipeline_file) unless File.absolute_path?(pipeline_file)
         env_file = params[:env_file]
         # Both keys and values need to be passed as strings
         environment = params[:environment].to_h { |k, v| [k.to_s, v.to_s] }

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
@@ -6,7 +6,8 @@ module Fastlane
       def self.run(params)
         pipeline_file = params[:pipeline_file]
         env_file = params[:env_file]
-        environment = params[:environment]
+        # Both keys and values need to be passed as strings
+        environment = params[:environment].to_h { |k, v| [k.to_s, v.to_s] }
 
         UI.user_error!("Pipeline file not found: #{pipeline_file}") unless File.exist?(pipeline_file)
         UI.user_error!('This action can only be called from a Buildkite CI build') unless ENV['BUILDKITE'] == 'true'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
@@ -34,7 +34,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(
             key: :pipeline_file,
-            description: 'The path to the YAML pipeline file to upload',
+            description: 'The path to the YAML pipeline file to upload. If a relative path is provided, it will be prefixed with the `.buildkite/` folder path. Absolute paths are used as-is',
             optional: false,
             type: String
           ),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
@@ -1,10 +1,11 @@
 module Fastlane
   module Actions
     class BuildkitePipelineUploadAction < Action
-      DEFAULT_ENV_FILE = File.join('.buildkite', 'shared-pipeline-vars').freeze
+      DEFAULT_BUILDKITE_PIPELINE_FOLDER = '.buildkite'.freeze
+      DEFAULT_ENV_FILE = File.join(DEFAULT_BUILDKITE_PIPELINE_FOLDER, 'shared-pipeline-vars').freeze
 
       def self.run(params)
-        pipeline_file = params[:pipeline_file]
+        pipeline_file = File.join(DEFAULT_BUILDKITE_PIPELINE_FOLDER, params[:pipeline_file])
         env_file = params[:env_file]
         # Both keys and values need to be passed as strings
         environment = params[:environment].to_h { |k, v| [k.to_s, v.to_s] }
@@ -12,7 +13,7 @@ module Fastlane
         UI.user_error!("Pipeline file not found: #{pipeline_file}") unless File.exist?(pipeline_file)
         UI.user_error!('This action can only be called from a Buildkite CI build') unless ENV['BUILDKITE'] == 'true'
 
-        UI.message "Adding steps from `#{pipeline_file}` to the current build"
+        UI.message("Adding steps from `#{pipeline_file}` to the current build")
 
         if env_file && File.exist?(env_file)
           UI.message(" - Sourcing environment file beforehand: #{env_file}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
@@ -8,7 +8,7 @@ module Fastlane
         pipeline_file = params[:pipeline_file]
         pipeline_file = File.join(DEFAULT_BUILDKITE_PIPELINE_FOLDER, pipeline_file) unless File.absolute_path?(pipeline_file)
         env_file = params[:env_file]
-        # Both keys and values need to be passed as strings
+        # Both keys and values need to be passed as strings otherwise Fastlane.sh will fail to parse the command.
         environment = params[:environment].to_h { |k, v| [k.to_s, v.to_s] }
 
         UI.user_error!("Pipeline file not found: #{pipeline_file}") unless File.exist?(pipeline_file)

--- a/spec/buildkite_pipeline_upload_action_spec.rb
+++ b/spec/buildkite_pipeline_upload_action_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Fastlane::Actions::BuildkitePipelineUploadAction do
   let(:pipeline_file) { 'path/to/pipeline.yml' }
+  let(:loaded_pipeline_file) { File.join('.buildkite', pipeline_file) }
   let(:env_file) { 'path/to/env_file' }
   let(:env_file_default) { Fastlane::Actions::BuildkitePipelineUploadAction::DEFAULT_ENV_FILE }
   let(:environment) { { 'AKEY' => 'AVALUE' } }
@@ -23,14 +24,14 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
     end
 
     it 'raises an error when pipeline_file does not exist' do
-      allow(File).to receive(:exist?).with(pipeline_file).and_return(false)
+      allow(File).to receive(:exist?).with(loaded_pipeline_file).and_return(false)
       expect do
         run_described_fastlane_action(pipeline_file: pipeline_file)
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /Pipeline file not found/)
     end
 
     it 'raises an error when not running on Buildkite' do
-      allow(File).to receive(:exist?).with(pipeline_file).and_return(true)
+      allow(File).to receive(:exist?).with(loaded_pipeline_file).and_return(true)
       allow(ENV).to receive(:[]).with('BUILDKITE').and_return(nil)
 
       expect do
@@ -39,10 +40,10 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
     end
 
     it 'passes the environment hash to the shell command' do
-      allow(File).to receive(:exist?).with(pipeline_file).and_return(true)
+      allow(File).to receive(:exist?).with(loaded_pipeline_file).and_return(true)
       expect(Fastlane::Action).to receive(:sh).with(
         environment,
-        'buildkite-agent', 'pipeline', 'upload', pipeline_file
+        'buildkite-agent', 'pipeline', 'upload', loaded_pipeline_file
       )
       expect_upload_pipeline_message
 
@@ -53,11 +54,11 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
     end
 
     it 'passes the environment hash to the shell command also with an env_file' do
-      allow(File).to receive(:exist?).with(pipeline_file).and_return(true)
+      allow(File).to receive(:exist?).with(loaded_pipeline_file).and_return(true)
       allow(File).to receive(:exist?).with(env_file).and_return(true)
       expect(Fastlane::Action).to receive(:sh).with(
         environment,
-        "source #{env_file.shellescape} && buildkite-agent pipeline upload #{pipeline_file.shellescape}"
+        "source #{env_file.shellescape} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
       )
       expect_upload_pipeline_message
       expect_sourcing_env_file_message(env_file)
@@ -72,13 +73,13 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
 
   describe 'pipeline upload' do
     before do
-      allow(File).to receive(:exist?).with(pipeline_file).and_return(true)
+      allow(File).to receive(:exist?).with(loaded_pipeline_file).and_return(true)
     end
 
     it 'calls the right command to upload the pipeline without env_file' do
       expect(Fastlane::Action).to receive(:sh).with(
         environment_default,
-        'buildkite-agent', 'pipeline', 'upload', pipeline_file
+        'buildkite-agent', 'pipeline', 'upload', loaded_pipeline_file
       )
       expect_upload_pipeline_message
 
@@ -89,7 +90,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
       allow(File).to receive(:exist?).with(env_file).and_return(true)
       expect(Fastlane::Action).to receive(:sh).with(
         environment_default,
-        "source #{env_file.shellescape} && buildkite-agent pipeline upload #{pipeline_file.shellescape}"
+        "source #{env_file.shellescape} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
       )
       expect_upload_pipeline_message
       expect_sourcing_env_file_message(env_file)
@@ -105,7 +106,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
       allow(File).to receive(:exist?).with(non_existent_env_file).and_return(false)
       expect(Fastlane::Action).to receive(:sh).with(
         environment_default,
-        'buildkite-agent', 'pipeline', 'upload', pipeline_file
+        'buildkite-agent', 'pipeline', 'upload', loaded_pipeline_file
       )
       expect(Fastlane::UI).not_to receive(:message).with(/Sourcing environment file/)
 
@@ -119,7 +120,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
       allow(File).to receive(:exist?).with(env_file_default).and_return(true)
       expect(Fastlane::Action).to receive(:sh).with(
         environment_default,
-        "source #{env_file_default} && buildkite-agent pipeline upload #{pipeline_file.shellescape}"
+        "source #{env_file_default} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
       )
       expect_upload_pipeline_message
       expect_sourcing_env_file_message(env_file_default)
@@ -132,7 +133,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
 
   describe 'error handling' do
     it 'raises an error when the pipeline upload fails' do
-      allow(File).to receive(:exist?).with(pipeline_file).and_return(true)
+      allow(File).to receive(:exist?).with(loaded_pipeline_file).and_return(true)
       allow(Fastlane::Action).to receive(:sh).and_raise(StandardError.new('Upload failed'))
 
       expect do
@@ -145,7 +146,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
 
   def expect_upload_pipeline_message
     expect(Fastlane::UI).to receive(:message).with(
-      "Adding steps from `#{pipeline_file}` to the current build"
+      "Adding steps from `#{loaded_pipeline_file}` to the current build"
     )
   end
 

--- a/spec/buildkite_pipeline_upload_action_spec.rb
+++ b/spec/buildkite_pipeline_upload_action_spec.rb
@@ -129,6 +129,43 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
         pipeline_file: pipeline_file
       )
     end
+
+    it 'prefixes relative pipeline paths with the `.buildkite/` folder' do
+      relative_path = 'relative/pipeline.yml'
+      expected_path = File.join('.buildkite', relative_path)
+      allow(File).to receive(:exist?).with(expected_path).and_return(true)
+      allow(File).to receive(:absolute_path?).with(relative_path).and_return(false)
+
+      expect(Fastlane::Action).to receive(:sh).with(
+        environment_default,
+        'buildkite-agent', 'pipeline', 'upload', expected_path
+      )
+      expect(Fastlane::UI).to receive(:message).with(
+        "Adding steps from `#{expected_path}` to the current build"
+      )
+
+      run_described_fastlane_action(
+        pipeline_file: relative_path
+      )
+    end
+
+    it 'uses absolute pipeline paths as-is' do
+      absolute_path = '/absolute/path/to/pipeline.yml'
+      allow(File).to receive(:exist?).with(absolute_path).and_return(true)
+      allow(File).to receive(:absolute_path?).with(absolute_path).and_return(true)
+
+      expect(Fastlane::Action).to receive(:sh).with(
+        environment_default,
+        'buildkite-agent', 'pipeline', 'upload', absolute_path
+      )
+      expect(Fastlane::UI).to receive(:message).with(
+        "Adding steps from `#{absolute_path}` to the current build"
+      )
+
+      run_described_fastlane_action(
+        pipeline_file: absolute_path
+      )
+    end
   end
 
   describe 'error handling' do


### PR DESCRIPTION
## What does it do?

Follow-up to the discussions in https://github.com/woocommerce/woocommerce-android/pull/12839/files#r1821331463. This PR:
- Makes sure all values passed in the `environment` parameter are strings
- Always prepend `.buildkite` to the `pipeline_file` parameter , enforcing our conventions


## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
