### PR TITLE
Release 12.3.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ _None_
 
 ### Bug Fixes
 
+_None_
+
+### Internal Changes
+
+_None_
+
+## 12.3.0
+
+### Bug Fixes
+
 - `create_release-backmerge_pull_request`: Fix the pre-check logic verifying if a PR is really needed or if there's nothing to backmerge. [#607]
 
 ### Internal Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ _None_
 
 ## 12.3.0
 
+### New Features
+
+- `buildkite_pipeline_upload`: prepend `.buildkite/` to the `pipeline_file` parameter to enforce our conventions [#608]
+
 ### Bug Fixes
 
 - `create_release-backmerge_pull_request`: Fix the pre-check logic verifying if a PR is really needed or if there's nothing to backmerge. [#607]
@@ -29,7 +33,6 @@ _None_
 ### Internal Changes
 
 - `buildkite_pipeline_upload`: makes sure all values passed in the environment parameter are strings [#608]
-- `buildkite_pipeline_upload`: prepend `.buildkite/` to the `pipeline_file` parameter to enforce our conventions [#608]
 
 ## 12.2.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (12.2.1)
+    fastlane-plugin-wpmreleasetoolkit (12.3.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '12.2.1'
+    VERSION = '12.3.0'
   end
 end


### PR DESCRIPTION
Releasing new version 12.3.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:

```
### New Features

- `buildkite_pipeline_upload`: prepend `.buildkite/` to the `pipeline_file` parameter to enforce our conventions [#608]

### Bug Fixes

- `create_release-backmerge_pull_request`: Fix the pre-check logic verifying if a PR is really needed or if there's nothing to backmerge. [#607]

### Internal Changes

- `buildkite_pipeline_upload`: makes sure all values passed in the environment parameter are strings [#608]


```