### PR TITLE
Fix post-processing of PR URLs in `create_github_release` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix issue with post-processing of PR urls in the body of GitHub releases created via `create_github_release` [#610]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
@@ -9,8 +9,10 @@ module Fastlane
         version = params[:version]
         assets = params[:release_assets]
         release_notes = params[:release_notes_file_path].nil? ? '' : File.read(params[:release_notes_file_path])
-        # Replace full URLS to PRs/Issues with shorthand, because GitHub does not render them properly otherwise.
-        release_notes.gsub!(%r{https://github.com/([^/]*/[^/]*)/(pulls?|issues?)/([0-9]*)}, '\1#\3')
+        # Replace full URLs to PRs/Issues that are in `[https://some-url]` brackets with shorthand, because GitHub does not render them properly otherwise.
+        # That syntax is sometimes used by devs in `RELEASE-NOTES.txt` when pointing to a PR to another repo (e.g. Gutenberg PR from WP repo).
+        # We should NOT transform URLs to PRs/Issues that are in `[text](url)` form (those are valid), only the ones directly in `[]` brackets.
+        release_notes.gsub!(%r{\[https://github.com/([^/]*/[^/]*)/(pulls?|issues?)/([0-9]*)\]}, '[\1#\3]')
         prerelease = params[:prerelease]
         is_draft = params[:is_draft]
 


### PR DESCRIPTION
**Related internal reference**: p1731397370353649/1729610708.303749-slack-C028JAG44VD (h/t @MiSikora for noticing the issue)

# What does it do?

We post-process URLs used in `create_github_release` to account for WP devs using them in square brackets in their release notes while this is not rendered as link in Markdown by GitHub. But that post-processing was too eager and also replacing valid URLs that were used outside square brackets but instead inside valid Markdown link syntax.

This PR fixes this to only post-process URLs that are within square brackets.

# Details

## Past Context: WP iOS/Android `RELEASE-NOTES.txt` syntax

In WordPress iOS and Android, they use the `- Description of change [#1234]` syntax for most of their changelog entries to reference PRs of that repo in the changelog. But when a changelog entry references a PR from another repo (mostly commonly gutenberg), they then use the `- Description of change [https://github.com/wordpress-mobile/gutenberg-mobile/pull/nnnn]` syntax instead ([example](https://github.com/wordpress-mobile/WordPress-iOS/blob/7ca8f48864768bb876910bfd7d7bc3b6d93b9f2c/RELEASE-NOTES.txt#L28-L29))

This syntax would break the rendering in GitHub Releases because GitHub does not parse URLs that are inside `[…]` as URLs (so it doesn't replace them with a proper link with shorter title etc):

> Example of how it'd render if I edit the description of a WPiOS GitHub Release to use the URLs to Gutenberg PRs in square brackets the same way they were used in the `RELEASE-NOTES.txt` file back then:
> ![](https://github.com/user-attachments/assets/096062fd-44df-43ea-b8a2-7d00ee44afd2)

For that reason, a while ago we introduced a post-processing of the release notes passed to `create_github_release` to replace full URLs to PRs (e.g. `https://github.com/wordpress-mobile/gutenberg-mobile/pull/1234`) with their shorthand (i.e. `wordpress-mobile/gutenberg-mobile#1234`) before using it as the description body of the GitHub Release

## Fast-forward to now

Some other projects also use full URLs in their `CHANGELOG` / `RELEASE-NOTES` files used for `create_github_release`, except that unlike WordPress, they use those URLs with proper Markdown syntax for links, e.g. `[#123](https://github.com/automattic/pocket-casts-android/pulls/123)`, as opposed to `[https://github.com/automattic/pocket-casts-android/pulls/123]`.

This means that those are already valid links and should be left untouched. But post-processing them the same way we did so far for every PR or issue URL instead end up replacing those texts with `[#123](Automattic/pocket-casts-android#123)` in the GitHub Release body instead, which leads to incorrect links (interpreted as a relative link to the GitHub Release's own URL).

We thus need to ensure those are not post-processed like the ones from WP iOS/Android, and that only URLs that are within square brackets are post-processed.

# Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] ~~Add Unit Tests (aka `specs/*_spec.rb`) if applicable~~
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~~