### PR TITLE
Fix bug in `configure_apply` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix bug in `configure_apply` that could happen if run on a user machine that hasn't yet `git-pull` the latest commits from `~/.mobile-secrets` to a commit _after_ the new encryption key had been pushed. [#612]
 
 ### Internal Changes
 
@@ -24,13 +24,13 @@ _None_
 
 ### Bug Fixes
 
-- Fix issue with post-processing of PR urls in the body of GitHub releases created via `create_github_release` [#610]
+- Fix issue with post-processing of PR urls in the body of GitHub releases created via `create_github_release`. [#610]
 
 ## 12.3.0
 
 ### New Features
 
-- `buildkite_pipeline_upload`: prepend `.buildkite/` to the `pipeline_file` parameter to enforce our conventions [#608]
+- `buildkite_pipeline_upload`: prepend `.buildkite/` to the `pipeline_file` parameter to enforce our conventions. [#608]
 
 ### Bug Fixes
 
@@ -38,7 +38,7 @@ _None_
 
 ### Internal Changes
 
-- `buildkite_pipeline_upload`: makes sure all values passed in the environment parameter are strings [#608]
+- `buildkite_pipeline_upload`: makes sure all values passed in the environment parameter are strings. [#608]
 
 ## 12.2.1
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -10,11 +10,10 @@ module Fastlane
   module Actions
     class ConfigureApplyAction < Action
       def self.run(params = {})
-        # Preflight
-        UI.user_error!('Decryption key could not be found') if Fastlane::Helper::ConfigureHelper.encryption_key.nil?
-
         # Checkout the right commit hash etc. before applying the configuration
         prepare_repository do
+          UI.user_error!('Decryption key could not be found') if Fastlane::Helper::ConfigureHelper.encryption_key.nil?
+
           # Copy/decrypt the files
           files_to_copy.each do |file_reference|
             apply_file(file_reference, params[:force])


### PR DESCRIPTION
## What does it do?

When a new encryption key is recently added and pushed to `~/.mobile-secrets` by one developer, other developers will likely not yet have their own `~/.mobile-secrets` repo pulled to that latest commit that includes the new encryption key.

This means that in those scenarios, after a new project is set up for `configure` and a new encryption key is added, any other developer who would be told to "please now run `bundle exec fastlane run configure_apply`" will have the command fail, because on their local machine their `~/.mobile-secrets` would not yet have the new encryption key, and the preflight test we did about this at the start of the action would error early.

The fix is easy: make sure we only check for the presence of the encryption key _after_ we have entered the `prepare_repository` block and thus pulled and checked out the correct commit of `~/.mobile-secrets` first.

Related conversation: p1731606985135599/1731586195.925939-slack-C04PWEZSYFL

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.