### PR TITLE
Release 12.3.2 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Fix bug in `configure_apply` that could happen if run on a user machine that hasn't yet `git-pull` the latest commits from `~/.mobile-secrets` to a commit _after_ the new encryption key had been pushed. [#612]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 12.3.2
+
+### Bug Fixes
+
+- Fix bug in `configure_apply` that could happen if run on a user machine that hasn't yet `git-pull` the latest commits from `~/.mobile-secrets` to a commit _after_ the new encryption key had been pushed. [#612]
 
 ## 12.3.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (12.3.1)
+    fastlane-plugin-wpmreleasetoolkit (12.3.2)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '12.3.1'
+    VERSION = '12.3.2'
   end
 end


### PR DESCRIPTION
Releasing new version 12.3.2.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Fix bug in `configure_apply` that could happen if run on a user machine that hasn't yet `git-pull` the latest commits from `~/.mobile-secrets` to a commit _after_ the new encryption key had been pushed. [#612]


```
