### PR TITLE
Fix the wrong variable naming in draw_text_to_canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix broken `draw_text_to_canvas` method for `create_promo_screenshots` [#614]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -282,9 +282,9 @@ module Fastlane
         begin
           temp_text_file = Tempfile.new
 
-          Action.sh('drawText', "html=#{text}", "maxWidth=#{width}", "maxHeight=#{height}", "output=#{tempTextFile.path}", "fontSize=#{font_size}", "stylesheet=#{stylesheet_path}", "alignment=#{position}")
+          Action.sh('drawText', "html=#{text}", "maxWidth=#{width}", "maxHeight=#{height}", "output=#{temp_text_file.path}", "fontSize=#{font_size}", "stylesheet=#{stylesheet_path}", "alignment=#{position}")
 
-          text_content = open_image(tempTextFile.path).trim
+          text_content = open_image(temp_text_file.path).trim
           text_frame = create_image(width, height)
           text_frame = case position
                        when 'left' then composite_image_left(text_frame, text_content, 0, 0)


### PR DESCRIPTION
## What does it do?
This fixes the incorrect variable naming in `draw_text_to_canvas` method.
Some variables were renamed in https://github.com/wordpress-mobile/release-toolkit/commit/be35b01fcebd38c5114780a3a5a6404e9f56187a, but `tempTextFile` was overlooked. 

## Checklist before requesting a review

- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
