### PR TITLE
Fix file path issue in check_fonts_installed method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix `check_fonts_installed` step in `create_promo_screenshots` [#615]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -63,7 +63,7 @@ module Fastlane
         # Parse the first font in each `font-family` attribute found in all found CSS files.
         # Only the first in each `font-family` font list matters, as others are fallbacks we don't want to use anyway.
         font_families = all_stylesheets.flat_map do |s|
-          stylesheet_path = resolve_path(s) if can_resolve_path(s)
+          stylesheet_path = resolve_path(s)
           File.readlines(stylesheet_path).flat_map do |line|
             attr = line.match(/font-family: (.*);/)&.captures&.first
             attr.split(',').first.strip.gsub(/'(.*)'/, '\1').gsub(/"(.*)"/, '\1') unless attr.nil?

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -63,7 +63,8 @@ module Fastlane
         # Parse the first font in each `font-family` attribute found in all found CSS files.
         # Only the first in each `font-family` font list matters, as others are fallbacks we don't want to use anyway.
         font_families = all_stylesheets.flat_map do |s|
-          File.readlines(s).flat_map do |line|
+          stylesheet_path = resolve_path(s) if can_resolve_path(s)
+          File.readlines(stylesheet_path).flat_map do |line|
             attr = line.match(/font-family: (.*);/)&.captures&.first
             attr.split(',').first.strip.gsub(/'(.*)'/, '\1').gsub(/"(.*)"/, '\1') unless attr.nil?
           end


### PR DESCRIPTION
## What does it do?
This fixes an issue with accessing a file in `check_fonts_installed` method. Before, calling this from WCAndroid resulted in the following error:
```
No such file or directory @ rb_sysopen - playstoreres/assets/style.css
```

## Checklist before requesting a review

- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
