### PR TITLE
Release 12.3.3 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,18 @@ _None_
 
 ### Bug Fixes
 
-- Fix `check_fonts_installed` step in `create_promo_screenshots` [#615]
-- Fix broken `draw_text_to_canvas` method for `create_promo_screenshots` [#614]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 12.3.3
+
+### Bug Fixes
+
+- Fix `check_fonts_installed` step in `create_promo_screenshots` [#615]
+- Fix broken `draw_text_to_canvas` method for `create_promo_screenshots` [#614]
 
 ## 12.3.2
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (12.3.2)
+    fastlane-plugin-wpmreleasetoolkit (12.3.3)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '12.3.2'
+    VERSION = '12.3.3'
   end
 end


### PR DESCRIPTION
Releasing new version 12.3.3.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Fix `check_fonts_installed` step in `create_promo_screenshots` [#615]
- Fix broken `draw_text_to_canvas` method for `create_promo_screenshots` [#614]


```
