### PR TITLE
[Internal] Remove Danger check about GitHub milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- Remove Danger check for milestones, as we don't really use GitHub milestones in this repo. [#617]
 
 ## 12.3.3
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -49,6 +49,4 @@ labels_checker.check(
   required_labels: []
 )
 
-milestone_checker.check_milestone_due_date(days_before_due: 5)
-
 warn("No reviewers have been set for this PR yet. Please request a review from **@\u2060wordpress-mobile/apps-infrastructure**.") unless github_utils.requested_reviewers?


### PR DESCRIPTION
Since we don't really use those in this repo that much

## What does it do?

## Checklist before requesting a review

- [x] ~~Run `bundle exec rubocop` to test for code style violations and recommendations~~
- [ ] ~~Add Unit Tests (aka `specs/*_spec.rb`) if applicable~~ N/A
- [ ] ~~Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass~~ N/A
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~~ N/A
