### PR TITLE
Update `DateVersionCalculator` to move next year calculation decision to the clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- `DateVersionCalculator`: move next year calculation decision to the clients [#619]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/date_version_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/date_version_calculator.rb
@@ -8,19 +8,18 @@ module Fastlane
       class DateVersionCalculator < AbstractVersionCalculator
         # Calculate the next date-based release version.
         #
-        # If the current month is December, the method prompts the user to determine if the next
-        # release will be the first release of the next year. If so, it increments the major version
-        # and sets the minor version to 1, resetting the patch and build number components to zero.
-        # Otherwise, it calculates the next minor version.
+        # When increment_to_next_year is true, increments the major version (representing the year) and resets all other
+        # components (minor to 1, patch and build number to 0). Otherwise, calculates the
+        # next minor version using the parent class implementation.
         #
         # @param [AppVersion] version The version to calculate the next date-based release version for.
+        # @param [Boolean] increment_to_next_year Whether to increment the version to the next year. Defaults to false.
         #
         # @return [AppVersion] The next date-based release version.
         #
-        def next_release_version(version:)
-          new_version = version.dup
-          first_release_of_year = FastlaneCore::UI.confirm('Is this release the first release of next year?') if Time.now.month == 12
-          if first_release_of_year
+        def next_release_version(version:, increment_to_next_year: false)
+          if increment_to_next_year
+            new_version = version.dup
             new_version.major += 1
             new_version.minor = 1
             new_version.patch = 0

--- a/spec/date_version_calculator_spec.rb
+++ b/spec/date_version_calculator_spec.rb
@@ -2,40 +2,23 @@ require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::DateVersionCalculator do
   describe 'calculates the next release version when using date versioning' do
-    context 'when the current month is not December' do
-      it 'increments the minor version number without prompting the user' do
-        allow(Time).to receive(:now).and_return(Time.new(2024, 4, 15))
-        version = Fastlane::Models::AppVersion.new(2024, 13, 1, 1)
-        bumped_version = described_class.new.next_release_version(version: version)
+    context 'when skipping to the next year' do
+      it 'increments the major version number and sets the minor version to 1' do
+        version = Fastlane::Models::AppVersion.new(2023, 30, 1, 2)
+        bumped_version = described_class.new.next_release_version(version: version, increment_to_next_year: true)
         # Test that the original version is not modified
-        expect(version.to_s).to eq('2024.13.1.1')
-        expect(bumped_version.to_s).to eq('2024.14.0.0')
+        expect(version.to_s).to eq('2023.30.1.2')
+        expect(bumped_version.to_s).to eq('2024.1.0.0')
       end
     end
 
-    context 'when the current month is December' do
-      context 'when the release is the first release of the next year' do
-        it 'increments the major version number and sets the minor version number to 1' do
-          allow(Time).to receive(:now).and_return(Time.new(2023, 12, 3))
-          allow(FastlaneCore::UI).to receive(:confirm).and_return(true)
-          version = Fastlane::Models::AppVersion.new(2023, 30, 1, 2)
-          bumped_version = described_class.new.next_release_version(version: version)
-          # Test that the original version is not modified
-          expect(version.to_s).to eq('2023.30.1.2')
-          expect(bumped_version.to_s).to eq('2024.1.0.0')
-        end
-      end
-
-      context 'when the release is not the first release of the next year' do
-        it 'increments the minor version number' do
-          allow(Time).to receive(:now).and_return(Time.new(2023, 12, 1))
-          allow(FastlaneCore::UI).to receive(:confirm).and_return(false)
-          version = Fastlane::Models::AppVersion.new(2023, 30, 1, 2)
-          bumped_version = described_class.new.next_release_version(version: version)
-          # Test that the original version is not modified
-          expect(version.to_s).to eq('2023.30.1.2')
-          expect(bumped_version.to_s).to eq('2023.31.0.0')
-        end
+    context 'when not skipping to the next year' do
+      it 'increments the minor version number' do
+        version = Fastlane::Models::AppVersion.new(2023, 30, 1, 2)
+        bumped_version = described_class.new.next_release_version(version: version, increment_to_next_year: false)
+        # Test that the original version is not modified
+        expect(version.to_s).to eq('2023.30.1.2')
+        expect(bumped_version.to_s).to eq('2023.31.0.0')
       end
     end
   end


### PR DESCRIPTION
## What does it do?

Follow-up to the issue we have seen when releasing a new version in December, when `DateVersionCalculator` tried to ask for a user confirmation using `FastlaneCore::UI.confirm` while running a non-interactive session on CI via ReleasesV2.

This PR updates the code so that any time-specific logic (possibly using the user confirmation) could be implemented, if needed, on the clients of `release-toolkit`, while keeping the possibility in `DateVersionCalculator` to increment the `year` component of the version.


## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
