### PR TITLE
Release 12.3.4 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ _None_
 
 ### Bug Fixes
 
+_None_
+
+### Internal Changes
+
+_None_
+
+## 12.3.4
+
+### Bug Fixes
+
 - `DateVersionCalculator`: move next year calculation decision to the clients [#619]
 
 ### Internal Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (12.3.3)
+    fastlane-plugin-wpmreleasetoolkit (12.3.4)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '12.3.3'
+    VERSION = '12.3.4'
   end
 end


### PR DESCRIPTION
Releasing new version 12.3.4.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- `DateVersionCalculator`: move next year calculation decision to the clients [#619]

### Internal Changes

- Remove Danger check for milestones, as we don't really use GitHub milestones in this repo. [#617]


```
