### PR TITLE
Remove period from "Update draft release notes..." commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Remove period from "Update draft release notes..." commit message [#622]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -17,7 +17,7 @@ module Fastlane
         return if extracted_notes_file.nil?
 
         extracted_notes_file.close
-        check_and_commit_extracted_notes_file(extracted_notes_file_path, version)
+        commit_extracted_notes_file(extracted_notes_file_path, version)
       end
 
       def self.extract_notes(release_notes_file_path, version)
@@ -39,9 +39,13 @@ module Fastlane
         end
       end
 
-      def self.check_and_commit_extracted_notes_file(file_path, version)
-        Action.sh("git add #{file_path}")
-        Action.sh("git diff-index --quiet HEAD || git commit -m \"Update draft release notes for #{version}\"")
+      def self.commit_extracted_notes_file(file_path, version)
+        other_action.git_add(path: file_path)
+        other_action.git_commit(
+          path: file_path,
+          message: "Update draft release notes for #{version}",
+          allow_nothing_to_commit: true
+        )
       end
 
       def self.description

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -41,7 +41,7 @@ module Fastlane
 
       def self.check_and_commit_extracted_notes_file(file_path, version)
         Action.sh("git add #{file_path}")
-        Action.sh("git diff-index --quiet HEAD || git commit -m \"Update draft release notes for #{version}.\"")
+        Action.sh("git diff-index --quiet HEAD || git commit -m \"Update draft release notes for #{version}\"")
       end
 
       def self.description


### PR DESCRIPTION
## What does it do?

The first line of a commit message should not have a period (`.`)

I noticed this while looking at https://github.com/Automattic/pocket-casts-ios/pull/2484 in the context of p1733261974076509-slack-C029BMLUGRX.

I am not aware of any official Git documentation for the statement above. However, it has been a convention in all the projects and companies I worked on.

The style is also present in the example commit message from the official Git book. See
https://git-scm.com/docs/MyFirstContribution#:~:text=You%20will%20be%20presented%20with%20your,A%20U%20Thor%20%3Cauthor%40example.com%3E

The style is also used in other sources, such as:

- https://commit.style/
- https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form
- https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message

One could argue that the 50 to 72 character length and the period omission were characters economy constraints from back in the day of small screens and text-only interfaces. While that is true, I find the are many benefits in forcing oneself to be concise in the commit title/summary.

As for short line length, it works well for people like me, who use big font sizes because their eyes strain otherwise. 🤓

But aside from all the justifications above, having commit message titles without a period is the existing convention in this repo, which make this change a no-brainer.


## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.