### PR TITLE
Allow `extract_release_notes_for_version` to return the extracted release notes without saving to a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _None_
 ### New Features
 
 - Introduce new `openai_ask` action to get responses to a prompt/question from OpenAI API. [#621]
+- Allow `extract_release_notes_for_version` to return the extracted release notes without saving to a file. [#623]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -8,16 +8,18 @@ module Fastlane
         release_notes_file_path = params[:release_notes_file_path]
         extracted_notes_file_path = params[:extracted_notes_file_path]
 
-        extracted_notes_file = File.open(extracted_notes_file_path, 'w') unless extracted_notes_file_path.blank?
-
+        extracted_notes = ''
         extract_notes(release_notes_file_path, version) do |line|
-          extracted_notes_file.nil? ? puts(line) : extracted_notes_file.write(line)
+          extracted_notes += line
+        end
+        extracted_notes.chomp!('') # Remove any extra empty line(s) at the end
+
+        unless extracted_notes_file_path.nil? || extracted_notes_file_path.empty?
+          File.write(extracted_notes_file_path, extracted_notes)
+          commit_extracted_notes_file(extracted_notes_file_path, version)
         end
 
-        return if extracted_notes_file.nil?
-
-        extracted_notes_file.close
-        commit_extracted_notes_file(extracted_notes_file_path, version)
+        extracted_notes
       end
 
       def self.extract_notes(release_notes_file_path, version)
@@ -57,7 +59,7 @@ module Fastlane
       end
 
       def self.return_value
-        # If your method provides a return value, you can describe here what it does
+        'The content of the extracted release notes (the same text as what was written in the `extracted_notes_file_path` if one was provided)'
       end
 
       def self.details


### PR DESCRIPTION
## What does it do?

As it says on the tin.

The old implementation kinda had half-support for the case where we didn't provide a destination file path, but printed the result using `puts` instead of returning it as a value of the action.

## Why?

This change will be useful in particular for my work on PocketCasts automation, as when automating the submission to TestFlight and creating the GitHub Release for beta builds, the PocketCasts team wants to always use the latest release notes extracted from `CHANGELOG.md` when submitting to external testers in TestFlight or creating the GH Release (since they might have added some new entries to the `CHANGELOG.md` as part of landing some bugfixes during the beta phase and want to include those as well).

This means we can't really rely on just reading the content of the `release_notes.txt` file that was previously extracted as part of `code_freeze`, as that file won't include the latest changes at the time we do a new beta. But we don't need to save the re-extracted content into the `release_notes.txt` file and re-commit the changes again at those stages, so calling the action without a `extracted_notes_file_path:` parameter and just manipulating the returned string would be better for those use cases.

## Testing

I've tested this by pointing PocketCasts-iOS's `Gemfile` to my local copy of `release-toolkit` that contained this change and calling `extract_release_notes_for_version` without an `extracted_notes_file_path:` parameter and `UI.message`-printing the returned value.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
