### PR TITLE
Release 12.4.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,26 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 12.4.0
+
+### New Features
+
 - Introduce new `openai_ask` action to get responses to a prompt/question from OpenAI API. [#621]
 - Allow `extract_release_notes_for_version` to return the extracted release notes without saving to a file. [#623]
 
 ### Bug Fixes
 
 - Remove period from "Update draft release notes..." commit message [#622]
-
-### Internal Changes
-
-_None_
 
 ## 12.3.4
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (12.3.4)
+    fastlane-plugin-wpmreleasetoolkit (12.4.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '12.3.4'
+    VERSION = '12.4.0'
   end
 end


### PR DESCRIPTION
Releasing new version 12.4.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- Introduce new `openai_ask` action to get responses to a prompt/question from OpenAI API. [#621]
- Allow `extract_release_notes_for_version` to return the extracted release notes without saving to a file. [#623]

### Bug Fixes

- Remove period from "Update draft release notes..." commit message [#622]


```
