### PR TITLE
Enable `frozen_strings_literal`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,13 +30,6 @@ Style/EmptyMethod:
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
-# Enabling the 'frozen_string_literal: true' comment is nice but should be done with extra care
-# because enabling it on code that accidentally mutates string literals will crash at runtime
-# (e.g. `name = 'Hello'` then later `name << ' world'` will crash if the comment is enabled)
-# So we might enable it at some point, be we will need very careful review that this doesn't break everything.
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 # Unicode is pretty standard by now, and we want to be able to use em-dash, ellipsis, and unicode characters
 # to provide nice Monodraw.app graphs and similar, without being limited only by ascii.
 Style/AsciiComments:
@@ -48,7 +41,7 @@ Style/AsciiComments:
 # which would be incorrect and not what we want
 Style/StringConcatenation:
   Enabled: false
-  
+
 # This rule was enforced after upgrading Rubocop from `1.22.1` to `1.50.2`. We are disabling this rule for the
 # time being so that we don't see any unexpected behavior when running Release Toolkit actions that could be
 # changed by this rule. See https://github.com/wordpress-mobile/release-toolkit/pull/464#pullrequestreview-1396569629

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-_None_
+- The library now uses immutable literals, via `# frozen_strings_literal: true`. This may result in runtime issues that we will address ASAP once discovered [#626]
 
 ## 12.4.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source('https://rubygems.org')
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake'
 require 'tmpdir'
 
@@ -30,7 +32,7 @@ task :docstats, [:path] do |_, args|
   sh('yard', 'stats', '--list-undoc', path)
 end
 
-GEM_NAME = 'fastlane-plugin-wpmreleasetoolkit'.freeze
+GEM_NAME = 'fastlane-plugin-wpmreleasetoolkit'
 VERSION_FILE = File.join('lib', 'fastlane', 'plugin', 'wpmreleasetoolkit', 'version.rb')
 
 desc 'Create a new version of the release-toolkit gem'

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fastlane/plugin/wpmreleasetoolkit/version'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lane :test do
   wpmreleasetoolkit
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/plugin/wpmreleasetoolkit/version'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_localize_libs_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/android/android_localize_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_update_metadata_source_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/metadata/release_note_metadata_block'
 require_relative '../../helper/metadata/release_note_short_metadata_block'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/an_validate_lib_strings_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/android/android_localize_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_build_preflight.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AndroidBuildPreflightAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_avd_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_avd_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AndroidCreateAvdAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_create_xml_release_notes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AndroidCreateXmlReleaseNotesAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_current_branch_is_hotfix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     module SharedValues

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_file_by_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_file_by_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AndroidDownloadFileByVersionAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_download_translations_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This action is the new version of android_update_metadata (AndroidUpdateMetadataAction) and should now be used instead of that one
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_firebase_test.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_firebase_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_launch_emulator_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_launch_emulator_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AndroidLaunchEmulatorAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_send_app_size_metrics.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_send_app_size_metrics.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 require_relative '../../helper/app_size_metrics_helper'
 
 module Fastlane
   module Actions
     class AndroidSendAppSizeMetricsAction < Action
       # Keys used by the metrics payload
-      AAB_FILE_SIZE_KEY = 'AAB File Size'.freeze                     # value from `File.size` of the `.aab`
-      UNIVERSAL_APK_FILE_SIZE_KEY = 'Universal APK File Size'.freeze # value from `File.size` of the Universal `.apk`
-      UNIVERSAL_APK_SPLIT_NAME = 'Universal'.freeze                  # pseudo-name of the split representing the Universal `.apk`
-      APK_OPTIMIZED_FILE_SIZE_KEY = 'Optimized APK File Size'.freeze # value from `apkanalyzer apk file-size`
-      APK_OPTIMIZED_DOWNLOAD_SIZE_KEY = 'Download Size'.freeze       # value from `apkanalyzer apk download-size`
+      AAB_FILE_SIZE_KEY = 'AAB File Size'                     # value from `File.size` of the `.aab`
+      UNIVERSAL_APK_FILE_SIZE_KEY = 'Universal APK File Size' # value from `File.size` of the Universal `.apk`
+      UNIVERSAL_APK_SPLIT_NAME = 'Universal'                  # pseudo-name of the split representing the Universal `.apk`
+      APK_OPTIMIZED_FILE_SIZE_KEY = 'Optimized APK File Size' # value from `apkanalyzer apk file-size`
+      APK_OPTIMIZED_DOWNLOAD_SIZE_KEY = 'Download Size'       # value from `apkanalyzer apk download-size`
 
       def self.run(params)
         # Check input parameters

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_shutdown_emulator_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_shutdown_emulator_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AndroidShutdownEmulatorAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_update_release_notes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AndroidUpdateReleaseNotesAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_annotate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_annotate_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class BuildkiteAnnotateAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_metadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_metadata_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class BuildkiteMetadataAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class BuildkitePipelineUploadAction < Action
-      DEFAULT_BUILDKITE_PIPELINE_FOLDER = '.buildkite'.freeze
+      DEFAULT_BUILDKITE_PIPELINE_FOLDER = '.buildkite'
       DEFAULT_ENV_FILE = File.join(DEFAULT_BUILDKITE_PIPELINE_FOLDER, 'shared-pipeline-vars').freeze
 
       def self.run(params)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_trigger_build_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class BuildkiteTriggerBuildAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_for_toolkit_updates_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_for_toolkit_updates_action.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'rubygems/command_manager'
 
 module Fastlane
   module Actions
     class CheckForToolkitUpdatesAction < Action
-      TOOLKIT_SPEC_NAME = 'fastlane-plugin-wpmreleasetoolkit'.freeze
+      TOOLKIT_SPEC_NAME = 'fastlane-plugin-wpmreleasetoolkit'
 
       def self.run(params)
         updater = Gem::CommandManager.instance[:update]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_translation_progress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/check_translation_progress.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class CheckTranslationProgressAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/circleci_trigger_job_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/circleci_trigger_job_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class CircleciTriggerJobAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/close_milestone_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'date'
 require_relative '../../helper/github_helper'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/comment_on_pr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/copy_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/copy_branch_protection_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'date'
 require_relative '../../helper/github_helper'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_new_milestone_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'date'
 require_relative '../../helper/github_helper'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 
 module Fastlane
   module Actions
     class CreateReleaseBackmergePullRequestAction < Action
-      DEFAULT_BRANCH = 'trunk'.freeze
+      DEFAULT_BRANCH = 'trunk'
 
       def self.run(params)
         token = params[:github_token]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/firebase_login.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/firebase_login.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_between_tags.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/get_prs_between_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_downloadmetadata_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/metadata_download_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/gp_update_metadata_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../helper/metadata/release_note_metadata_block'
 require_relative '../../helper/metadata/release_note_short_metadata_block'
 require_relative '../../helper/metadata/whats_new_metadata_block'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'net/http'
 require 'json'
@@ -8,7 +10,7 @@ module Fastlane
       OPENAI_API_ENDPOINT = URI('https://api.openai.com/v1/chat/completions').freeze
 
       PREDEFINED_PROMPTS = {
-        release_notes: <<~PROMPT.freeze
+        release_notes: <<~PROMPT
           Act like a mobile app marketer who wants to prepare release notes for Google Play and App Store.
           Do not write it point by point and keep it under 350 characters. It should be a unique paragraph.
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/promo_screenshots_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'fastlane/action'
 require 'active_support/all'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/prototype_build_details_comment_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class PrototypeBuildDetailsCommentAction < Action
@@ -36,13 +38,13 @@ module Fastlane
       # @!group Helpers
       #####################################################
 
-      NO_INSTALL_URL_ERROR_MESSAGE = <<~NO_URL_ERROR.freeze
+      NO_INSTALL_URL_ERROR_MESSAGE = <<~NO_URL_ERROR
         No URL provided to download or install the app.
          - Either use this action right after using `appcenter_upload` and provide an `app_center_org_name` (so that this action can use the link to the App Center build)
          - Or provide an explicit value for the `download_url` parameter
       NO_URL_ERROR
 
-      DEFAULT_APP_CENTER_FOOTNOTE = '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'.freeze
+      DEFAULT_APP_CENTER_FOOTNOTE = '<em>Automatticians: You can use our internal self-serve MC tool to give yourself access to App Center if needed.</em>'
 
       # A small model struct to consolidate and pack all the values related to App Center
       #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/publish_github_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/publish_github_release_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/remove_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/remove_branch_protection_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/set_branch_protection_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/set_branch_protection_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/set_milestone_frozen_marker_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/set_milestone_frozen_marker_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_assigned_milestone_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/update_assigned_milestone_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require_relative '../../helper/github_helper'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_to_s3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'digest/sha1'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_add_files_to_copy_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fileutils'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fileutils'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_download_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fileutils'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'fileutils'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_update_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_validate_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AddDevelopmentCertificatesToProvisioningProfilesAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_devices_to_provisioning_profiles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class AddAllDevicesToProvisioningProfilesAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosBuildPreflightAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module Fastlane
   module Actions
     class IosCheckBetaDepsAction < Action
-      ALL_PODS_STABLE_MESSAGE = 'All pods are pointing to a stable version. You can continue with the code freeze.'.freeze
-      NON_STABLE_PODS_MESSAGE = "Please create a new stable version of those pods and update the Podfile to the newly released version before continuing with the code freeze:\n".freeze
+      ALL_PODS_STABLE_MESSAGE = 'All pods are pointing to a stable version. You can continue with the code freeze.'
+      NON_STABLE_PODS_MESSAGE = "Please create a new stable version of those pods and update the Podfile to the newly released version before continuing with the code freeze:\n"
 
       def self.run(params)
         yaml = YAML.load_file(params[:lockfile])

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_check_beta_deps.rb
@@ -33,7 +33,7 @@ module Fastlane
           end
         end
 
-        message = ''
+        message = String.new
         if non_stable_pods.empty?
           message << ALL_PODS_STABLE_MESSAGE
         else

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_download_strings_files_from_glotpress.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosDownloadStringsFilesFromGlotpressAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_extract_keys_from_strings_files.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_extract_keys_from_strings_files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosExtractKeysFromStringsFilesAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_generate_strings_file_from_code.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_generate_strings_file_from_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosGenerateStringsFileFromCodeAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_store_app_sizes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../helper/ios/ios_adc_app_sizes_helper'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosLintLocalizationsAction < Action
@@ -68,7 +70,7 @@ module Fastlane
         duplicate_keys
       end
 
-      RETRY_MESSAGE = <<~MSG.freeze
+      RETRY_MESSAGE = <<~MSG
         Inconsistencies found during Localization linting.
         You need to fix them before continuing. From this point on, you should either:
 
@@ -91,7 +93,7 @@ module Fastlane
         Did you fix the `.strings` files locally and want to lint them again?
       MSG
 
-      ABORT_MESSAGE = <<~MSG.freeze
+      ABORT_MESSAGE = <<~MSG
         Inconsistencies found during Localization linting. Aborting.
       MSG
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_strings_files.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_merge_strings_files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosMergeStringsFilesAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_send_app_size_metrics.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_send_app_size_metrics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'plist'
 require_relative '../../helper/app_size_metrics_helper'
 
@@ -5,9 +7,9 @@ module Fastlane
   module Actions
     class IosSendAppSizeMetricsAction < Action
       # Keys used by the metrics payload
-      IPA_FILE_SIZE_KEY = 'File Size'.freeze         # value from `File.size` of the Universal `.ipa`
-      IPA_DOWNLOAD_SIZE_KEY = 'Download Size'.freeze # value from `app-thinning.plist`
-      IPA_INSTALL_SIZE_KEY = 'Install Size'.freeze   # value from `app-thinning.plist`
+      IPA_FILE_SIZE_KEY = 'File Size'         # value from `File.size` of the Universal `.ipa`
+      IPA_DOWNLOAD_SIZE_KEY = 'Download Size' # value from `app-thinning.plist`
+      IPA_INSTALL_SIZE_KEY = 'Install Size'   # value from `app-thinning.plist`
 
       def self.run(params)
         # Check input parameters

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_metadata_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosUpdateMetadataSourceAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Actions
     class IosUpdateReleaseNotesAction < Action

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_emulator_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Helper
     module Android

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_localize_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane_core/ui/ui'
 require 'fileutils'
 require 'nokogiri'
@@ -9,7 +11,7 @@ module Fastlane
   module Helper
     module Android
       module LocalizeHelper
-        LIB_SOURCE_XML_ATTR = 'a8c-src-lib'.freeze
+        LIB_SOURCE_XML_ATTR = 'a8c-src-lib'
 
         # Checks if `string_node` has the `content_override` flag set
         def self.skip_string_by_tag?(string_node)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_tools_path_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane_core/ui/ui'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/android/android_version_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Helper
     module Android
@@ -5,9 +7,9 @@ module Fastlane
       #
       module VersionHelper
         # The key used in internal version Hash objects to hold the versionName value
-        VERSION_NAME = 'name'.freeze
+        VERSION_NAME = 'name'
         # The key used in internal version Hash objects to hold the versionCode value
-        VERSION_CODE = 'code'.freeze
+        VERSION_CODE = 'code'
         # The index for the major version number part
         MAJOR_NUMBER = 0
         # The index for the minor version number part
@@ -15,9 +17,9 @@ module Fastlane
         # The index for the hotfix version number part
         HOTFIX_NUMBER = 2
         # The prefix used in front of the versionName for alpha versions
-        ALPHA_PREFIX = 'alpha-'.freeze
+        ALPHA_PREFIX = 'alpha-'
         # The suffix used in the versionName for RC (beta) versions
-        RC_SUFFIX = '-rc'.freeze
+        RC_SUFFIX = '-rc'
 
         # Extract the version name and code from the release version of the app from `version.properties file`
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/app_size_metrics_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/app_size_metrics_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'net/http'
 require 'zlib'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ci_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ci_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane_core/ui/ui'
 require 'net/http'
 require 'uri'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'English'
 require 'fastlane_core/ui/ui'
 require 'fileutils'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
@@ -21,23 +21,19 @@ module Fastlane
 
       def self.encrypt(plain_text, key)
         # Ensure consistent encoding
-        plain_text.force_encoding(Encoding::UTF_8)
+        sanitized_plain_text = plain_text.dup.force_encoding(Encoding::UTF_8)
 
         cipher = cipher(OperationType::ENCRYPT)
         cipher.key = key
 
-        encrypted = cipher.update(plain_text)
-        encrypted << cipher.final
-
-        encrypted
+        cipher.update(sanitized_plain_text) + cipher.final
       end
 
       def self.decrypt(encrypted, key)
         cipher = cipher(OperationType::DECRYPT)
         cipher.key = key
 
-        decrypted = cipher.update(encrypted)
-        decrypted << cipher.final
+        decrypted = cipher.update(encrypted) + cipher.final
 
         # Ensure consistent encoding
         decrypted.force_encoding(Encoding::UTF_8)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/encryption_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/filesystem_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane_core/ui/ui'
 require 'fileutils'
 require 'digest'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/git_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'git'
 
 module Fastlane
@@ -6,7 +8,7 @@ module Fastlane
     #
     module GitHelper
       # Fallback default branch of the client repository.
-      DEFAULT_GIT_BRANCH = 'trunk'.freeze
+      DEFAULT_GIT_BRANCH = 'trunk'
 
       # Checks if the given path, or current directory if no path is given, is inside a Git repository
       #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane_core/ui/ui'
 require 'octokit'
 require 'open-uri'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/glotpress_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'uri'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/interactive_prompt_reminder.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/interactive_prompt_reminder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fastlane_core'
 
 # The features in this file are controlled by the following ENV vars:
@@ -24,7 +26,7 @@ require 'fastlane_core'
 module FastlaneCore
   # NOTE: FastlaneCore::UI delegates to the FastlaneCore::Shell implementation when output is the terminal
   class Shell
-    DEFAULT_PROMPT_REMINDER_MESSAGE = 'An interactive prompt is waiting for you in the Terminal!'.freeze
+    DEFAULT_PROMPT_REMINDER_MESSAGE = 'An interactive prompt is waiting for you in the Terminal!'
     DEFAULT_PROMPT_REMINDER_DELAYS = [30, 180, 600].freeze
 
     # Calls the block given and remind the user with a vocal message if the block does not return after specific delays.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_adc_app_sizes_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spaceship'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'json'
 require 'nokogiri'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'tmpdir'
 
@@ -5,9 +7,9 @@ module Fastlane
   module Helper
     module Ios
       class L10nLinterHelper
-        SWIFTGEN_VERSION = '6.6.2'.freeze
-        DEFAULT_BASE_LANG = 'en'.freeze
-        CONFIG_FILE_NAME = 'swiftgen-stringtypes.yml'.freeze
+        SWIFTGEN_VERSION = '6.6.2'
+        DEFAULT_BASE_LANG = 'en'
+        CONFIG_FILE_NAME = 'swiftgen-stringtypes.yml'
 
         attr_reader :install_path, :version
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
@@ -36,7 +36,7 @@ module Fastlane
           in_quoted_key: {
             '"' => lambda do |state, _|
               state.found_key = state.buffer.string.dup
-              state.buffer.string = ''
+              state.buffer = StringIO.new
               :after_quoted_key_before_eq
             end,
             /./u => lambda do |state, c|

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_strings_file_validation_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Helper
     module Ios

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_version_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'xcodeproj'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/metadata_block.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/metadata_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Helper
     # Basic line handler

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/release_note_metadata_block.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/release_note_metadata_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'metadata_block'
 require_relative 'standard_metadata_block'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/release_note_short_metadata_block.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/release_note_short_metadata_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'release_note_metadata_block'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/standard_metadata_block.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/standard_metadata_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'metadata_block'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/unknown_metadata_block.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/unknown_metadata_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'metadata_block'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/whats_new_metadata_block.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata/whats_new_metadata_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'standard_metadata_block'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/metadata_download_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'net/http'
 require 'json'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 begin
   $skip_magick = false

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/release_notes_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Helper
     module ReleaseNotesHelper

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/user_agent.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/user_agent.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Wpmreleasetoolkit
-    USER_AGENT = 'Automattic App Release Automator; https://github.com/wordpress-mobile/release-toolkit/'.freeze
+    USER_AGENT = 'Automattic App Release Automator; https://github.com/wordpress-mobile/release-toolkit/'
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/app_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Models
     # The AppVersion model represents a version of an app with major, minor, patch, and build number components.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/build_code.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/build_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Models
     # The `BuildCode` model represents a build code for an app. This could be the Version Code for an Android app or

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require_relative 'file_reference'
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/file_reference.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   class Configuration
     class FileReference

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_account.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_account.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   class FirebaseAccount
     def self.activate_service_account_with_key_file(key_file_path)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_device.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_device.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   class FirebaseDevice
     attr_reader :model, :version, :locale, :orientation

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_test_lab_result.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_test_lab_result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   class FirebaseTestLabResult
     def initialize(log_file_path:)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_test_runner.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/firebase_test_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'uri'
 require 'fileutils'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/abstract_version_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/abstract_version_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/date_build_code_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/date_build_code_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/date_version_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/date_version_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'abstract_version_calculator'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/marketing_version_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/marketing_version_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'abstract_version_calculator'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/semantic_version_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/semantic_version_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'abstract_version_calculator'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/simple_build_code_calculator.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/calculators/simple_build_code_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/files/android_version_file.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/files/android_version_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'java-properties'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/files/ios_version_file.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/files/ios_version_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'xcodeproj'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/abstract_version_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/abstract_version_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../calculators/abstract_version_calculator'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/four_part_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/four_part_build_code_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../formatters/four_part_version_formatter'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/four_part_version_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/four_part_version_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'abstract_version_formatter'
 
 module Fastlane

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/rc_notation_version_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/rc_notation_version_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'abstract_version_formatter'
 
 module Fastlane
@@ -7,7 +9,7 @@ module Fastlane
       # formatter for apps that may use versions in the format of `1.2.3-rc-4`.
       class RCNotationVersionFormatter < AbstractVersionFormatter
         # The string identifier used for beta versions in Android.
-        RC_SUFFIX = 'rc'.freeze
+        RC_SUFFIX = 'rc'
 
         # Parse the version string into an AppVersion instance
         #

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/simple_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/simple_build_code_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning

--- a/rakelib/changelog_parser.rake
+++ b/rakelib/changelog_parser.rake
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class ChangelogParser
-  PENDING_SECTION_TITLE = 'Trunk'.freeze
-  EMPTY_PLACEHOLDER = '_None_'.freeze
+  PENDING_SECTION_TITLE = 'Trunk'
+  EMPTY_PLACEHOLDER = '_None_'
   SUBSECTIONS_SEMVER_MAP = { 'Breaking Changes': 3, 'New Features': 2, 'Bug Fixes': 1, 'Internal Changes': 1 }.freeze
 
   def initialize(file: 'CHANGELOG.md')

--- a/rakelib/console.rake
+++ b/rakelib/console.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Console
   # ANSI colors
   RED = 1

--- a/rakelib/git_helpers.rake
+++ b/rakelib/git_helpers.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cgi'
 
 module GitHelper

--- a/spec/abstract_version_calculator_spec.rb
+++ b/spec/abstract_version_calculator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionCalculator do

--- a/spec/abstract_version_formatter_spec.rb
+++ b/spec/abstract_version_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::AbstractVersionFormatter do

--- a/spec/an_localize_libs_action_spec.rb
+++ b/spec/an_localize_libs_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::AnLocalizeLibsAction do

--- a/spec/an_update_metadata_source_spec.rb
+++ b/spec/an_update_metadata_source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'shared_examples_for_update_metadata_source_action'
 

--- a/spec/android_firebase_test_spec.rb
+++ b/spec/android_firebase_test_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidFirebaseTestAction do

--- a/spec/android_localize_helper_spec.rb
+++ b/spec/android_localize_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'fileutils'
 require 'tmpdir'

--- a/spec/android_send_app_size_metrics_spec.rb
+++ b/spec/android_send_app_size_metrics_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe Fastlane::Actions::AndroidSendAppSizeMetricsAction do

--- a/spec/android_update_release_notes_spec.rb
+++ b/spec/android_update_release_notes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::AndroidUpdateReleaseNotesAction do

--- a/spec/android_version_file_spec.rb
+++ b/spec/android_version_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'java-properties'
 

--- a/spec/android_version_helper_spec.rb
+++ b/spec/android_version_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Helper::Android::VersionHelper do

--- a/spec/app_size_metrics_helper_spec.rb
+++ b/spec/app_size_metrics_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe Fastlane::Helper::AppSizeMetricsHelper do

--- a/spec/app_version_spec.rb
+++ b/spec/app_version_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Models::AppVersion do

--- a/spec/build_code_spec.rb
+++ b/spec/build_code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Models::BuildCode do

--- a/spec/buildkite_annotate_action_spec.rb
+++ b/spec/buildkite_annotate_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::BuildkiteAnnotateAction do

--- a/spec/buildkite_metadata_action_spec.rb
+++ b/spec/buildkite_metadata_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::BuildkiteMetadataAction do

--- a/spec/buildkite_pipeline_upload_action_spec.rb
+++ b/spec/buildkite_pipeline_upload_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::BuildkitePipelineUploadAction do

--- a/spec/buildkite_trigger_build_action_spec.rb
+++ b/spec/buildkite_trigger_build_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'buildkit'
 

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'webmock/rspec'
 

--- a/spec/check_localization_progress_spec.rb
+++ b/spec/check_localization_progress_spec.rb
@@ -299,7 +299,7 @@ describe Fastlane::Actions::CheckTranslationProgressAction do
 end
 
 def generate_glotpress_response_body(languages:)
-  response = ''
+  response = String.new
   response << generate_glotpress_response_header
   languages.each do |language|
     response << generate_glotpress_response_for_language(
@@ -337,7 +337,7 @@ def generate_glotpress_response_header
 end
 
 def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:, waiting:, untranslated:, progress:)
-  res = "<tr class=\"odd\">\n"
+  res = "<tr class=\"odd\">\n".dup
   res << generate_glotpress_response_header_for_language(lang: lang, lang_code: lang_code, progress: progress)
   res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'translated', status: 'current', string_count: current)
   res << generate_glotpress_response_for_language_status(lang_code: lang_code, status_main: 'fuzzy', status: 'fuzzy', string_count: fuzzy)
@@ -347,7 +347,7 @@ def generate_glotpress_response_for_language(lang:, lang_code:, current:, fuzzy:
 end
 
 def generate_glotpress_response_header_for_language(lang:, lang_code:, progress:)
-  res = "<td>\n"
+  res = "<td>\n".dup
   res << "<strong><a href=\"/projects/apps/whatever/dev/#{lang_code}/default/\">#{lang}</a></strong>\n"
   res << "<span class=\"bubble morethan90\">#{progress}%</span>\n" if progress.to_i > 90
   res << "</td>\n"

--- a/spec/ci_helper_spec.rb
+++ b/spec/ci_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'webmock/rspec'
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Configuration do

--- a/spec/configure_helper_spec.rb
+++ b/spec/configure_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Helper::ConfigureHelper do

--- a/spec/copy_branch_protection_action_spec.rb
+++ b/spec/copy_branch_protection_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tmpdir'
 

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do

--- a/spec/date_build_code_calculator_spec.rb
+++ b/spec/date_build_code_calculator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::DateBuildCodeCalculator do

--- a/spec/date_version_calculator_spec.rb
+++ b/spec/date_version_calculator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::DateVersionCalculator do

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do

--- a/spec/encryption_helper_spec.rb
+++ b/spec/encryption_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Helper::EncryptionHelper do

--- a/spec/file_reference_spec.rb
+++ b/spec/file_reference_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.shared_examples 'shared examples' do

--- a/spec/find_previous_tag_spec.rb
+++ b/spec/find_previous_tag_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'webmock/rspec'
 

--- a/spec/firebase_account_spec.rb
+++ b/spec/firebase_account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::FirebaseAccount do

--- a/spec/firebase_device_spec.rb
+++ b/spec/firebase_device_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::FirebaseDevice do

--- a/spec/firebase_login_spec.rb
+++ b/spec/firebase_login_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::FirebaseLoginAction do

--- a/spec/firebase_test_lab_result_spec.rb
+++ b/spec/firebase_test_lab_result_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::FirebaseTestLabResult do

--- a/spec/firebase_test_runner_spec.rb
+++ b/spec/firebase_test_runner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::FirebaseTestRunner do

--- a/spec/four_part_build_code_formatter_spec.rb
+++ b/spec/four_part_build_code_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::FourPartBuildCodeFormatter do

--- a/spec/four_part_version_formatter_spec.rb
+++ b/spec/four_part_version_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::FourPartVersionFormatter do

--- a/spec/get_prs_between_tags_spec.rb
+++ b/spec/get_prs_between_tags_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'webmock/rspec'
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 require_relative 'spec_helper'
 

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'webmock/rspec'
 

--- a/spec/gp_update_metadata_source_spec.rb
+++ b/spec/gp_update_metadata_source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'shared_examples_for_update_metadata_source_action'
 

--- a/spec/ios_check_beta_deps_spec.rb
+++ b/spec/ios_check_beta_deps_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::IosCheckBetaDepsAction do

--- a/spec/ios_download_strings_files_from_glotpress_spec.rb
+++ b/spec/ios_download_strings_files_from_glotpress_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tmpdir'
 

--- a/spec/ios_extract_keys_from_strings_files_spec.rb
+++ b/spec/ios_extract_keys_from_strings_files_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tmpdir'
 

--- a/spec/ios_generate_strings_file_from_code_spec.rb
+++ b/spec/ios_generate_strings_file_from_code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tmpdir'
 

--- a/spec/ios_l10n_helper_spec.rb
+++ b/spec/ios_l10n_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe Fastlane::Helper::Ios::L10nHelper do

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'fileutils'
 require 'tmpdir'

--- a/spec/ios_merge_strings_files_spec.rb
+++ b/spec/ios_merge_strings_files_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::IosMergeStringsFilesAction do

--- a/spec/ios_send_app_size_metrics_spec.rb
+++ b/spec/ios_send_app_size_metrics_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe Fastlane::Actions::IosSendAppSizeMetricsAction do

--- a/spec/ios_strings_file_validation_helper_spec.rb
+++ b/spec/ios_strings_file_validation_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Helper::Ios::StringsFileValidationHelper do

--- a/spec/ios_update_metadata_source_spec.rb
+++ b/spec/ios_update_metadata_source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'shared_examples_for_update_metadata_source_action'
 

--- a/spec/ios_update_release_notes_spec.rb
+++ b/spec/ios_update_release_notes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::IosUpdateReleaseNotesAction do

--- a/spec/ios_version_file_spec.rb
+++ b/spec/ios_version_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::IOSVersionFile do

--- a/spec/marketing_version_calculator_spec.rb
+++ b/spec/marketing_version_calculator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::MarketingVersionCalculator do

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::OpenaiAskAction do

--- a/spec/promo_screenshots_helper_spec.rb
+++ b/spec/promo_screenshots_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # require 'shellwords'
 # require_relative './spec_helper'
 #

--- a/spec/prototype_build_details_comment_action_spec.rb
+++ b/spec/prototype_build_details_comment_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe Fastlane::Actions::PrototypeBuildDetailsCommentAction do

--- a/spec/publish_github_release_spec.rb
+++ b/spec/publish_github_release_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::PublishGithubReleaseAction do

--- a/spec/rc_notation_version_formatter_spec.rb
+++ b/spec/rc_notation_version_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::RCNotationVersionFormatter do

--- a/spec/release_notes_helper_spec.rb
+++ b/spec/release_notes_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 require_relative 'spec_helper'
 
@@ -59,7 +61,7 @@ describe Fastlane::Helper::ReleaseNotesHelper do
   end
 end
 
-FAKE_CONTENT = <<~CONTENT.freeze
+FAKE_CONTENT = <<~CONTENT
   1.2.3
   -----
   - Item 1 for v1.2.3
@@ -73,7 +75,7 @@ FAKE_CONTENT = <<~CONTENT.freeze
   - Item 2 for v1.2.2
 CONTENT
 
-NEW_SECTION = <<~CONTENT.freeze
+NEW_SECTION = <<~CONTENT
   New Section
   -----
 

--- a/spec/remove_branch_protection_action_spec.rb
+++ b/spec/remove_branch_protection_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tmpdir'
 

--- a/spec/semantic_version_calculator_spec.rb
+++ b/spec/semantic_version_calculator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::SemanticVersionCalculator do

--- a/spec/set_branch_protection_action_spec.rb
+++ b/spec/set_branch_protection_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tmpdir'
 

--- a/spec/set_milestone_frozen_marker_action_spec.rb
+++ b/spec/set_milestone_frozen_marker_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'tmpdir'
 

--- a/spec/shared_examples_for_update_metadata_source_action.rb
+++ b/spec/shared_examples_for_update_metadata_source_action.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.shared_examples 'update_metadata_source_action' do |options|

--- a/spec/simple_build_code_calculator_spec.rb
+++ b/spec/simple_build_code_calculator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::SimpleBuildCodeCalculator do

--- a/spec/simple_build_code_formatter_spec.rb
+++ b/spec/simple_build_code_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::SimpleBuildCodeFormatter do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 
 require 'simplecov'

--- a/spec/standard_metadata_block_spec.rb
+++ b/spec/standard_metadata_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 require_relative 'spec_helper'
 

--- a/spec/update_assigned_milestone_spec.rb
+++ b/spec/update_assigned_milestone_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Fastlane::Actions::UpdateAssignedMilestoneAction do

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec_helper'
 
 describe Fastlane::Actions::UploadToS3Action do


### PR DESCRIPTION
## What does it do?

Closes #625

Because most of the changes were done by `bundle exec rubocop -A` I addressed the test failures resulting to the code switching to immutable strings in dedicated commits. I hope it makes it easier to review.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider. — N.A.
