### PR TITLE
Update Danger setup to run via Buildkite + Add RuboCop linter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,12 +64,21 @@ steps:
     agents:
       queue: "default"
 
-  - label: "☢️ Danger - PR Check"
-    command: danger
-    key: danger
-    if: build.pull_request.id != null
-    retry:
-      manual:
-        permit_on_passed: true
-    agents:
-      queue: linter
+  - group: "Linters"
+    steps:
+      - label: ☢️ Danger - PR Check
+        command: danger
+        key: danger
+        if: build.pull_request.id != null
+        retry:
+          manual:
+            permit_on_passed: true
+        agents:
+          queue: linter
+
+      - label: ":rubocop: Rubocop"
+        command: rubocop
+        key: rubocop
+        if: build.pull_request.id != null
+        agents:
+          queue: linter

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,3 +63,13 @@ steps:
     plugins: [*docker_plugin]
     agents:
       queue: "default"
+
+  - label: "☢️ Danger - PR Check"
+    command: danger
+    key: danger
+    if: build.pull_request.id != null
+    retry:
+      manual:
+        permit_on_passed: true
+    agents:
+      queue: linter

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -2,7 +2,7 @@ name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [labeled, unlabeled, milestoned, demilestoned]
+    types: [labeled, unlabeled, milestoned, demilestoned, review_requested, review_request_removed]
 
 jobs:
   dangermattic:

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -1,13 +1,18 @@
-name: ☢️ Danger
+name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize, edited, review_requested, review_request_removed, labeled, unlabeled, milestoned, demilestoned]
+    types: [labeled, unlabeled, milestoned, demilestoned]
 
 jobs:
   dangermattic:
-    # runs on draft PRs only for opened / synchronize events
-    if: ${{ (github.event.pull_request.draft == false) || (github.event.pull_request.draft == true && contains(fromJSON('["opened", "synchronize"]'), github.event.action)) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@v1.0.0
+    if: ${{ (github.event.pull_request.draft == false) }}
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.2.2
+    with:
+      org-slug: automattic
+      pipeline-slug: release-toolkit
+      retry-step-key: danger
+      build-commit-sha: ${{ github.event.pull_request.head.sha }}
+      cancel-running-github-jobs: false
     secrets:
-      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}
+      buildkite-api-token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.2.2
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1
     with:
       org-slug: automattic
       pipeline-slug: release-toolkit

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -2,7 +2,7 @@ name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [labeled, unlabeled, milestoned, demilestoned, review_requested, review_request_removed]
+    types: [labeled, unlabeled, milestoned, demilestoned, ready_for_review, review_requested, review_request_removed]
 
 jobs:
   dangermattic:


### PR DESCRIPTION
## What does it do?

In https://github.com/wordpress-mobile/release-toolkit/pull/410, Danger failed to run because of an issue installing native extensions. This made @iangmaia and I realize that Dangermattic in this repo was not set up with the modern Buildkite configuration, but still run on GitHub Actions.

This PR updates the Danger step up.

<img width="1721" alt="image" src="https://github.com/user-attachments/assets/460d7cb3-5d79-485f-9d15-8f9ed0dda5a6" />


![image](https://github.com/user-attachments/assets/a868512b-4c7d-43f3-84e1-344befa95ae4)


I used WordPress at [`d7cc886`](https://github.com/wordpress-mobile/WordPress-iOS/commit/d7cc886bdc286e0aa6a95991d43054979cc3016a) at the template.

While I was at it, I also added a CI step to run the RuboCop linter.

![image](https://github.com/user-attachments/assets/a868512b-4c7d-43f3-84e1-344befa95ae4)


## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations. — N.A.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable. — N.A.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass. — N.A.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section. — N.A.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider. — N.A.
