### PR TITLE
Add periods to PR template list entries that didn't have it

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 ## Checklist before requesting a review
 
-- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations
-- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
-- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
+- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations.
+- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
+- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
 - [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
 - [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.


### PR DESCRIPTION
This way, all entries have a period and the template is homogeneous.

_Just something that caught my eye in #627. Not sure why it too so long to notice..._

Below is the template as generate with the version on `trunk` 👇 

## Checklist before requesting a review

- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
