### PR TITLE
Add parameter to iOS Lint to make failing on extra strings optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### New Features
 
-- The `ios_lint_localizations` action now accepts a `fail_on_extra_strings` parameter (defaulting to `true`) to control whether to report violations when finding strings in translations that are not present in the base language. [#631]
+- The `ios_lint_localizations` action now accepts a `fail_on_strings_not_in_base_language` parameter (defaulting to `true`) to control whether to report violations when finding strings in translations that are not present in the base language. [#631]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### New Features
 
-_None_
+- The `ios_lint_localizations` action now accepts a `fail_on_extra_strings` parameter (defaulting to `true`) to control whether to report violations when finding strings in translations that are not present in the base language. [#631]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -37,7 +37,8 @@ module Fastlane
         helper.run(
           input_dir: resolve_path(params[:input_dir]),
           base_lang: params[:base_lang],
-          only_langs: params[:only_langs]
+          only_langs: params[:only_langs],
+          fail_on_extra_strings: params[:fail_on_extra_strings]
         )
       end
 
@@ -179,6 +180,14 @@ module Fastlane
             key: :check_duplicate_keys,
             env_name: 'FL_IOS_LINT_TRANSLATIONS_CHECK_DUPLICATE_KEYS',
             description: 'Checks the input files for duplicate keys',
+            optional: true,
+            default_value: true,
+            type: Boolean
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :fail_on_extra_strings,
+            env_name: 'FL_IOS_LINT_TRANSLATIONS_FAIL_ON_EXTRA_STRINGS',
+            description: 'Should we report violations when finding strings in translations that are not present in the base language',
             optional: true,
             default_value: true,
             type: Boolean

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localizations.rb
@@ -38,7 +38,7 @@ module Fastlane
           input_dir: resolve_path(params[:input_dir]),
           base_lang: params[:base_lang],
           only_langs: params[:only_langs],
-          fail_on_extra_strings: params[:fail_on_extra_strings]
+          fail_on_strings_not_in_base_language: params[:fail_on_strings_not_in_base_language]
         )
       end
 
@@ -185,8 +185,8 @@ module Fastlane
             type: Boolean
           ),
           FastlaneCore::ConfigItem.new(
-            key: :fail_on_extra_strings,
-            env_name: 'FL_IOS_LINT_TRANSLATIONS_FAIL_ON_EXTRA_STRINGS',
+            key: :fail_on_strings_not_in_base_language,
+            env_name: 'FL_IOS_LINT_TRANSLATIONS_FAIL_ON_STRINGS_NOT_IN_BASE_LANGUAGE',
             description: 'Should we report violations when finding strings in translations that are not present in the base language',
             optional: true,
             default_value: true,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
@@ -60,12 +60,12 @@ module Fastlane
         #
         # @param [String] input_dir The path (ideally absolute) to the directory containing the `.lproj` folders to parse
         # @param [String] base_lang The code name (i.e the basename of one of the `.lproj` folders) of the locale to use as the baseline
-        # @param [String] fail_on_extra_strings Whether to fail on extra strings
+        # @param [String] fail_on_strings_not_in_base_language Whether to fail on strings not in base language
         # @return [Hash<String, Array<String>>] A hash of violations, keyed by language code, whose values are the list of violation messages for that language
         #
-        def run(input_dir:, base_lang: DEFAULT_BASE_LANG, only_langs: nil, fail_on_extra_strings: true)
+        def run(input_dir:, base_lang: DEFAULT_BASE_LANG, only_langs: nil, fail_on_strings_not_in_base_language: true)
           check_swiftgen_installed || install_swiftgen!
-          find_diffs(input_dir: input_dir, base_lang: base_lang, only_langs: only_langs, fail_on_extra_strings: fail_on_extra_strings)
+          find_diffs(input_dir: input_dir, base_lang: base_lang, only_langs: only_langs, fail_on_strings_not_in_base_language: fail_on_strings_not_in_base_language)
         end
 
         ##################
@@ -161,12 +161,12 @@ module Fastlane
         # @param [String] input_dir The directory where the `.lproj` folders to scan are located
         # @param [String] base_lang The base language used as source of truth that all other languages will be compared against
         # @param [Array<String>] only_langs The list of languages to limit the generation for. Useful to focus only on a couple of issues or just one language
-        # @param [Boolean] fail_on_extra_strings Whether to fail on extra strings
+        # @param [Boolean] fail_on_strings_not_in_base_language Whether to fail on strings not in base language
         # @return [Hash<String, Array<String>>] A hash of violations, keyed by language code, whose values are the list of violation messages for that language
         #
         # @note The returned Hash contains keys only for locales with violations. Locales parsed but without any violations found will not appear in the resulting hash.
         #
-        def find_diffs(input_dir:, base_lang:, only_langs: nil, fail_on_extra_strings: true)
+        def find_diffs(input_dir:, base_lang:, only_langs: nil, fail_on_strings_not_in_base_language: true)
           Dir.mktmpdir('a8c-lint-translations-') do |tmpdir|
             # Run SwiftGen
             langs = only_langs.nil? ? nil : (only_langs + [base_lang]).uniq
@@ -183,7 +183,7 @@ module Fastlane
               next nil if params_for_lang.nil? || params_for_lang.empty?
 
               violations = params_for_lang.map do |key, param_types|
-                next "`#{key}` was unexpected, as it is not present in the base locale." if params_for_base_lang[key].nil? && fail_on_extra_strings
+                next "`#{key}` was unexpected, as it is not present in the base locale." if params_for_base_lang[key].nil? && fail_on_strings_not_in_base_language
                 next "`#{key}` expected placeholders for #{params_for_base_lang[key]} but found #{param_types} instead." if !params_for_base_lang[key].nil? && params_for_base_lang[key] != param_types
               end.compact
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
@@ -60,11 +60,12 @@ module Fastlane
         #
         # @param [String] input_dir The path (ideally absolute) to the directory containing the `.lproj` folders to parse
         # @param [String] base_lang The code name (i.e the basename of one of the `.lproj` folders) of the locale to use as the baseline
+        # @param [String] fail_on_extra_strings Whether to fail on extra strings
         # @return [Hash<String, Array<String>>] A hash of violations, keyed by language code, whose values are the list of violation messages for that language
         #
-        def run(input_dir:, base_lang: DEFAULT_BASE_LANG, only_langs: nil)
+        def run(input_dir:, base_lang: DEFAULT_BASE_LANG, only_langs: nil, fail_on_extra_strings: true)
           check_swiftgen_installed || install_swiftgen!
-          find_diffs(input_dir: input_dir, base_lang: base_lang, only_langs: only_langs)
+          find_diffs(input_dir: input_dir, base_lang: base_lang, only_langs: only_langs, fail_on_extra_strings: fail_on_extra_strings)
         end
 
         ##################
@@ -160,11 +161,12 @@ module Fastlane
         # @param [String] input_dir The directory where the `.lproj` folders to scan are located
         # @param [String] base_lang The base language used as source of truth that all other languages will be compared against
         # @param [Array<String>] only_langs The list of languages to limit the generation for. Useful to focus only on a couple of issues or just one language
+        # @param [Boolean] fail_on_extra_strings Whether to fail on extra strings
         # @return [Hash<String, Array<String>>] A hash of violations, keyed by language code, whose values are the list of violation messages for that language
         #
         # @note The returned Hash contains keys only for locales with violations. Locales parsed but without any violations found will not appear in the resulting hash.
         #
-        def find_diffs(input_dir:, base_lang:, only_langs: nil)
+        def find_diffs(input_dir:, base_lang:, only_langs: nil, fail_on_extra_strings: true)
           Dir.mktmpdir('a8c-lint-translations-') do |tmpdir|
             # Run SwiftGen
             langs = only_langs.nil? ? nil : (only_langs + [base_lang]).uniq
@@ -181,8 +183,8 @@ module Fastlane
               next nil if params_for_lang.nil? || params_for_lang.empty?
 
               violations = params_for_lang.map do |key, param_types|
-                next "`#{key}` was unexpected, as it is not present in the base locale." if params_for_base_lang[key].nil?
-                next "`#{key}` expected placeholders for #{params_for_base_lang[key]} but found #{param_types} instead." if params_for_base_lang[key] != param_types
+                next "`#{key}` was unexpected, as it is not present in the base locale." if params_for_base_lang[key].nil? && fail_on_extra_strings
+                next "`#{key}` expected placeholders for #{params_for_base_lang[key]} but found #{param_types} instead." if !params_for_base_lang[key].nil? && params_for_base_lang[key] != param_types
               end.compact
 
               [lang, violations] unless violations.empty?

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -62,8 +62,11 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
     # @param [Bool|nil] check_duplicate_keys If `nil`, the test will run the action with the default `check_duplicate_keys` parameter value.
     #        If a `Bool` value is given, it will pass that.
     #        Using either `Bool` or `nil` adds some cruft, but lets us validate the action default behavior, so it doesn't change unexpectedly.
+    # @param [Bool|nil] fail_on_extra_strings If `nil`, the test will run the action with the default `fail_on_extra_strings` parameter value.
+    #        If a `Bool` value is given, it will pass that.
+    #        Controls whether to report violations when finding strings in translations that are not present in the base language.
     #
-    def run_l10n_linter_test(data_file:, check_duplicate_keys: nil)
+    def run_l10n_linter_test(data_file:, check_duplicate_keys: nil, fail_on_extra_strings: nil)
       # Arrange: Prepare test files
       test_file = File.join(File.dirname(__FILE__), 'test-data', 'translations', 'ios_lint_localizations', "#{data_file}.yaml")
       yml = YAML.load_file(test_file)
@@ -86,6 +89,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
         base_lang: 'en'
       }
       parameters[:check_duplicate_keys] = check_duplicate_keys unless check_duplicate_keys.nil?
+      parameters[:fail_on_extra_strings] = fail_on_extra_strings unless fail_on_extra_strings.nil?
       result = run_described_fastlane_action(parameters)
 
       # Assert
@@ -204,6 +208,17 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
       )
 
       expect(result).to eq({ 'fr' => ['`key3` expected placeholders for [Int] but found [] instead.'] })
+    end
+
+    it 'fails on extra strings in translations by default' do
+      run_l10n_linter_test(data_file: 'extra-strings-in-translations-error')
+    end
+
+    it 'do not report extra strings in translations when fail_on_extra_strings is false' do
+      run_l10n_linter_test(
+        data_file: 'extra-strings-in-translations-no-error',
+        fail_on_extra_strings: false
+      )
     end
   end
 end

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -62,11 +62,11 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
     # @param [Boolean, nil] check_duplicate_keys If `nil`, the test will run the action with the default `check_duplicate_keys` parameter value.
     #        If a `Boolean` value is given, it will pass that.
     #        Using either `Boolean` or `nil` adds some cruft, but lets us validate the action default behavior, so it doesn't change unexpectedly.
-    # @param [Boolean, nil] fail_on_extra_strings If `nil`, the test will run the action with the default `fail_on_extra_strings` parameter value.
+    # @param [Boolean, nil] fail_on_strings_not_in_base_language If `nil`, the test will run the action with the default `fail_on_strings_not_in_base_language` parameter value.
     #        If a `Boolean` value is given, it will pass that.
     #        Controls whether to report violations when finding strings in translations that are not present in the base language.
     #
-    def run_l10n_linter_test(data_file:, check_duplicate_keys: nil, fail_on_extra_strings: nil)
+    def run_l10n_linter_test(data_file:, check_duplicate_keys: nil, fail_on_strings_not_in_base_language: nil)
       # Arrange: Prepare test files
       test_file = File.join(File.dirname(__FILE__), 'test-data', 'translations', 'ios_lint_localizations', "#{data_file}.yaml")
       yml = YAML.load_file(test_file)
@@ -89,7 +89,7 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
         base_lang: 'en'
       }
       parameters[:check_duplicate_keys] = check_duplicate_keys unless check_duplicate_keys.nil?
-      parameters[:fail_on_extra_strings] = fail_on_extra_strings unless fail_on_extra_strings.nil?
+      parameters[:fail_on_strings_not_in_base_language] = fail_on_strings_not_in_base_language unless fail_on_strings_not_in_base_language.nil?
       result = run_described_fastlane_action(parameters)
 
       # Assert
@@ -210,21 +210,21 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
       expect(result).to eq({ 'fr' => ['`key3` expected placeholders for [Int] but found [] instead.'] })
     end
 
-    it 'fails on extra strings in translations by default' do
+    it 'fails on strings not in base language by default' do
       run_l10n_linter_test(data_file: 'extra-strings-in-translations-error')
     end
 
-    it 'does not report extra strings in translations when fail_on_extra_strings is false' do
+    it 'does not report strings not in base language when fail_on_strings_not_in_base_language is false' do
       run_l10n_linter_test(
         data_file: 'extra-strings-in-translations-no-error',
-        fail_on_extra_strings: false
+        fail_on_strings_not_in_base_language: false
       )
     end
 
-    it 'does report extra strings in translations when fail_on_extra_strings is true' do
+    it 'does report strings not in base language when fail_on_strings_not_in_base_language is true' do
       run_l10n_linter_test(
         data_file: 'extra-strings-in-translations-error',
-        fail_on_extra_strings: true
+        fail_on_strings_not_in_base_language: true
       )
     end
   end

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -59,11 +59,11 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
     # Helper function that DRYs the code running each test.
     #
     # @param [String] data_file The name, without extension or "test-lint-ios-" prefix, of the YML file containing the test input and expected output.
-    # @param [Bool|nil] check_duplicate_keys If `nil`, the test will run the action with the default `check_duplicate_keys` parameter value.
-    #        If a `Bool` value is given, it will pass that.
-    #        Using either `Bool` or `nil` adds some cruft, but lets us validate the action default behavior, so it doesn't change unexpectedly.
-    # @param [Bool|nil] fail_on_extra_strings If `nil`, the test will run the action with the default `fail_on_extra_strings` parameter value.
-    #        If a `Bool` value is given, it will pass that.
+    # @param [Boolean, nil] check_duplicate_keys If `nil`, the test will run the action with the default `check_duplicate_keys` parameter value.
+    #        If a `Boolean` value is given, it will pass that.
+    #        Using either `Boolean` or `nil` adds some cruft, but lets us validate the action default behavior, so it doesn't change unexpectedly.
+    # @param [Boolean, nil] fail_on_extra_strings If `nil`, the test will run the action with the default `fail_on_extra_strings` parameter value.
+    #        If a `Boolean` value is given, it will pass that.
     #        Controls whether to report violations when finding strings in translations that are not present in the base language.
     #
     def run_l10n_linter_test(data_file:, check_duplicate_keys: nil, fail_on_extra_strings: nil)

--- a/spec/ios_lint_localizations_spec.rb
+++ b/spec/ios_lint_localizations_spec.rb
@@ -214,10 +214,17 @@ describe Fastlane::Actions::IosLintLocalizationsAction do
       run_l10n_linter_test(data_file: 'extra-strings-in-translations-error')
     end
 
-    it 'do not report extra strings in translations when fail_on_extra_strings is false' do
+    it 'does not report extra strings in translations when fail_on_extra_strings is false' do
       run_l10n_linter_test(
         data_file: 'extra-strings-in-translations-no-error',
         fail_on_extra_strings: false
+      )
+    end
+
+    it 'does report extra strings in translations when fail_on_extra_strings is true' do
+      run_l10n_linter_test(
+        data_file: 'extra-strings-in-translations-error',
+        fail_on_extra_strings: true
       )
     end
   end

--- a/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-error.yaml
+++ b/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-error.yaml
@@ -1,9 +1,9 @@
 test_data:
-  en:
-    '"base_string" = "This is in the base language";'
-  fr:
-    '"base_string" = "This is in French";
-     "extra_string" = "This string only exists in French";'
+  en: |-
+    "base_string" = "This is in the base language";
+  fr: |-
+    "base_string" = "This is in French";
+    "extra_string" = "This string only exists in French";
 
 result:
   fr:

--- a/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-error.yaml
+++ b/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-error.yaml
@@ -1,0 +1,10 @@
+test_data:
+  en:
+    '"base_string" = "This is in the base language";'
+  fr:
+    '"base_string" = "This is in French";
+     "extra_string" = "This string only exists in French";'
+
+result:
+  fr:
+    - '`extra_string` was unexpected, as it is not present in the base locale.'

--- a/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-no-error.yaml
+++ b/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-no-error.yaml
@@ -1,0 +1,8 @@
+test_data:
+  en:
+    '"base_string" = "This is in the base language";'
+  fr:
+    '"base_string" = "This is in French";
+     "extra_string" = "This string only exists in French";'
+
+result: {}

--- a/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-no-error.yaml
+++ b/spec/test-data/translations/ios_lint_localizations/extra-strings-in-translations-no-error.yaml
@@ -1,8 +1,8 @@
 test_data:
-  en:
-    '"base_string" = "This is in the base language";'
-  fr:
-    '"base_string" = "This is in French";
-     "extra_string" = "This string only exists in French";'
+  en: |-
+    "base_string" = "This is in the base language";
+  fr: |-
+    "base_string" = "This is in French";
+    "extra_string" = "This string only exists in French";
 
 result: {}


### PR DESCRIPTION
Internal reference: pdnsEh-210-p2

## What does it do?

This PR adds to the `ios_lint_localizations` action a `fail_on_extra_strings` parameter to control whether to report violations when finding strings in translations that are not present in the base language. 

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
