### PR TITLE
Introduce monkey-patch to auto-insert collapsible sections in Buildkite logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Make fastlane log actions as collapsible groups in Buildkite. [#638]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/buildkite_aware_log_groups.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/buildkite_aware_log_groups.rb
@@ -2,7 +2,7 @@
 
 require 'fastlane'
 
-# This monkey-patch adds Buildkite-aware logs to fastlane so it generates collapsible lgo group in Buildkite for each action execution.
+# This monkey-patch adds Buildkite-aware logs to fastlane so it generates a collapsible log group in Buildkite for each action execution.
 #
 # @env `FASTLANE_DISABLE_ACTIONS_BUILDKITE_LOG_GROUPS`
 #     Set this variable to '1' to disable the auto-application of the monkey patch.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/buildkite_aware_log_groups.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/buildkite_aware_log_groups.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'fastlane'
+
+# This monkey-patch adds Buildkite-aware logs to fastlane so it generates collapsible lgo group in Buildkite for each action execution.
+#
+# @env `FASTLANE_DISABLE_ACTIONS_BUILDKITE_LOG_GROUPS`
+#     Set this variable to '1' to disable the auto-application of the monkey patch.
+
+unless !ENV.key?('BUILDKITE') || FastlaneCore::Env.truthy?('FASTLANE_DISABLE_ACTIONS_BUILDKITE_LOG_GROUPS')
+  FastlaneCore::UI.verbose('Monkey-patching fastlane to add Buildkite-aware log groups for each action execution')
+
+  module Fastlane
+    module Actions
+      module SharedValues
+        # This differs from the existing `SharedValues::LANE_NAME`, which always contains the name of the **top-level** lane
+        CURRENTLY_RUNNING_LANE_NAME = :CURRENTLY_RUNNING_LANE_NAME
+      end
+
+      module BuildkiteLogActionsAsCollapsibleGroups
+        def execute_action(action_name, &)
+          unless %w[is_ci? is_ci].include?(action_name)
+            current_lane = lane_context[SharedValues::CURRENTLY_RUNNING_LANE_NAME]
+            lane_name_prefix = (current_lane || '').empty? ? '' : "[lane :#{current_lane}]"
+            puts "~~~ :fastlane: #{lane_name_prefix} #{action_name}"
+          end
+          super
+        end
+      end
+
+      class << self
+        prepend BuildkiteLogActionsAsCollapsibleGroups
+      end
+    end
+
+    class Runner
+      prepend(Module.new do
+        def current_lane=(lane_name)
+          super
+          Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::CURRENTLY_RUNNING_LANE_NAME] = lane_name
+        end
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## What

This PR introduces a monkey-patch of the `Fastlane::Runner#execute_action` method to print a `~~~ :fastlane: [lane :#{lane_name}] #{action}` collapsible group log output for every action called in your `Fastfile`.

> [!NOTE]
> This idea was inspired by https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/fastlane/Fastfile#L156-L179

This will make the Buildkite logs for jobs running fastlane lanes better organized and easier to navigate, as each action will now have its own collapsible section.

## Testing

I have created some dummy branches in `Tumblr-iOS` and `WordPress-iOS`, making their `Gemfile` point to this PR's branch of the `release-toolkit` then triggering a Buildkite build

### Tumblr iOS

Buildkite build: https://buildkite.com/automattic/tumblr-ios/builds/32406

<img width="587" alt="image" src="https://github.com/user-attachments/assets/74510abe-e2c4-46a5-b114-7f00a34c82e7" />

### WordPress iOS

Buildkite build: https://buildkite.com/automattic/wordpress-ios/builds/26131

Compare [Buildkite output from _before_ that monkey-patch—but with the ad-hoc patch that has been in WPiOS's Fastfile since a while](https://buildkite.com/automattic/wordpress-ios/builds/26123/summary/annotations?sid=019584a9-01df-4d9a-b5f6-39533bc6e85b#019584a9-0244-49be-91e9-1e5b65c6361f/324)—with [new Buildkite output from the monkey-patch (and with ad-hoc patch in WPiOS's Fastfile removed](https://buildkite.com/automattic/wordpress-ios/builds/26131/canvas?sid=01958585-0113-42a4-a611-20f9eae42474#01958585-01fc-4e33-b4f8-5a1a53fd4120/1261)

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/412c0fe7-9a47-487f-b471-d9625f47a06f" />

## What's Next

Once this PR lands, we should remove [the ad-hoc patch code that was implemented in WPiOS's `Fastfile`](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/fastlane/Fastfile#L156-L179), to use this patch from `release-toolkit` instead, to avoid WPiOS having double logging of the collapsible group sections in Buildkite.