### PR TITLE
Release 13.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@
 
 ### Breaking Changes
 
-- The `prototype_build_details_comment` action now relies on the `lane_context` of `firebase_app_distribution` instead of the one from `appcenter_upload` for the implicit metadata and download URL to use in the comment.
-  This is in the context of us moving from App Center (which will be shut down in March 2025) to Firebase App Distribution as our primary mechanism to distribute prototype builds. [#630]
+_None_
 
 ### New Features
 
-- Introduce `upload_build_to_apps_cdn` action to upload a build binary to the Apps CDN. [#636]
+_None_
 
 ### Bug Fixes
 
@@ -20,6 +19,17 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 13.0.0
+
+### Breaking Changes
+
+- The `prototype_build_details_comment` action now relies on the `lane_context` of `firebase_app_distribution` instead of the one from `appcenter_upload` for the implicit metadata and download URL to use in the comment.
+  This is in the context of us moving from App Center (which will be shut down in March 2025) to Firebase App Distribution as our primary mechanism to distribute prototype builds. [#630]
+
+### New Features
+
+- Introduce `upload_build_to_apps_cdn` action to upload a build binary to the Apps CDN. [#636]
 
 ## 12.5.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (12.5.0)
+    fastlane-plugin-wpmreleasetoolkit (13.0.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '12.5.0'
+    VERSION = '13.0.0'
   end
 end


### PR DESCRIPTION
Releasing new version 13.0.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Breaking Changes

- The `prototype_build_details_comment` action now relies on the `lane_context` of `firebase_app_distribution` instead of the one from `appcenter_upload` for the implicit metadata and download URL to use in the comment.
  This is in the context of us moving from App Center (which will be shut down in March 2025) to Firebase App Distribution as our primary mechanism to distribute prototype builds. [#630]

### New Features

- Introduce `upload_build_to_apps_cdn` action to upload a build binary to the Apps CDN. [#636]

```
