### PR TITLE
Release `13.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 13.1.0
+
+### New Features
+
 - Make fastlane log actions as collapsible groups in Buildkite. [#638]
 - Add `api_url` parameter to `create_release_backmerge_pull_request` to support GitHub Enterprise. Also, updated the code so the intermediate branch tracks its remote branch after pushing. [#641]
 
@@ -17,10 +31,6 @@ _None_
 
 - Fix issue in `create_release_backmerge_pull_request` where calling another fastlane action from the `intermediate_branch_created_callback` proc now behaves correctly. [#641]
 - Fix an issue where `prototype_build_details_comment` added some unexpected metadata rows in the comment table if we didn't use `firebase_app_distribution` (e.g. for Prototype Builds uploaded to S3 and not using FAD) [#642]
-
-### Internal Changes
-
-_None_
 
 ## 13.0.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.0.0)
+    fastlane-plugin-wpmreleasetoolkit (13.1.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.0.0'
+    VERSION = '13.1.0'
   end
 end


### PR DESCRIPTION
Releasing new version 13.1.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:

```
### New Features

- Make fastlane log actions as collapsible groups in Buildkite. [#638]
- Add `api_url` parameter to `create_release_backmerge_pull_request` to support GitHub Enterprise. Also, updated the code so the intermediate branch tracks its remote branch after pushing. [#641]

### Bug Fixes

- Fix issue in `create_release_backmerge_pull_request` where calling another fastlane action from the `intermediate_branch_created_callback` proc now behaves correctly. [#641]
- Fix an issue where `prototype_build_details_comment` added some unexpected metadata rows in the comment table if we didn't use `firebase_app_distribution` (e.g. for Prototype Builds uploaded to S3 and not using FAD) [#642]


```
