### PR TITLE
Extract release notes lines to an array to later join it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix error in `extract_release_notes_for_version`, avoiding modifying a frozen string. [#644]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/extract_release_notes_for_version_action.rb
@@ -10,11 +10,11 @@ module Fastlane
         release_notes_file_path = params[:release_notes_file_path]
         extracted_notes_file_path = params[:extracted_notes_file_path]
 
-        extracted_notes = ''
+        extracted_lines = []
         extract_notes(release_notes_file_path, version) do |line|
-          extracted_notes += line
+          extracted_lines << line
         end
-        extracted_notes.chomp!('') # Remove any extra empty line(s) at the end
+        extracted_notes = extracted_lines.join.chomp('') # Combine lines and remove any extra empty line(s) at the end
 
         unless extracted_notes_file_path.nil? || extracted_notes_file_path.empty?
           File.write(extracted_notes_file_path, extracted_notes)


### PR DESCRIPTION
Internal reference: p1744652620596379-slack-C06CKSPHYA1

## What does it do?

There was an issue in the code due to the recent `frozen_string_literal` update and the fact that we're modifying with `chomp!` a String pre-initialized with an empty value.
I've updated the code a bit to extract the lines first to an array to later `join` + `chomp` it.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
