### PR TITLE
Release 13.1.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Fix error in `extract_release_notes_for_version`, avoiding modifying a frozen string. [#644]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 13.1.1
+
+### Bug Fixes
+
+- Fix error in `extract_release_notes_for_version`, avoiding modifying a frozen string. [#644]
 
 ## 13.1.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.1.0)
+    fastlane-plugin-wpmreleasetoolkit (13.1.1)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.1.0'
+    VERSION = '13.1.1'
   end
 end


### PR DESCRIPTION
Releasing new version 13.1.1.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Fix error in `extract_release_notes_for_version`, avoiding modifying a frozen string. [#644]


```
