### PR TITLE
Fix Backmerge PR Action branch validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- `create_release_backmerge_pull_request`: fix the backmerge PR branch validation in CI. [#646]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -114,8 +114,12 @@ module Fastlane
           Dir.chdir(FastlaneCore::FastlaneFolder.path) do
             intermediate_branch_created_callback.call(base_branch, intermediate_branch)
           end
+
           # Make sure the callback block didn't switch branches
-          other_action.ensure_git_branch(branch: "^#{intermediate_branch}$")
+          current_branch = Fastlane::Helper::GitHelper.current_git_branch
+          unless current_branch == intermediate_branch
+            UI.user_error!("The callback switched branches. Expected to be on '#{intermediate_branch}' branch but was on '#{current_branch}'.")
+          end
 
           # When a callback was provided, do the pre-check about valid PR _only_ at that point, in case the callback added new commits
           unless can_merge?(intermediate_branch, into: base_branch)

--- a/spec/create_release_backmerge_pull_request_spec.rb
+++ b/spec/create_release_backmerge_pull_request_spec.rb
@@ -52,7 +52,7 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
         allow(described_class).to receive(:can_merge?).with(head, into: base).and_return(false)
       end
 
-      allow(other_action_mock).to receive(:ensure_git_branch).with({ branch: "^#{expected_intermediate_branch}$" }).and_return(true)
+      allow(Fastlane::Helper::GitHelper).to receive(:current_git_branch).and_return(expected_intermediate_branch)
 
       next unless nothing_to_merge_between.nil? || nothing_to_merge_between.empty?
 
@@ -418,7 +418,8 @@ describe Fastlane::Actions::CreateReleaseBackmergePullRequestAction do
       )
 
       intermediate_branch = "merge/release-30.6-into-#{default_branch}"
-      expect(other_action_mock).to receive(:ensure_git_branch).with(branch: "^#{intermediate_branch}$")
+      allow(Fastlane::Helper::GitHelper).to receive(:current_git_branch).and_return(intermediate_branch)
+
       allow(Fastlane::UI).to receive(:message).with(anything)
       expect(Fastlane::UI).to receive(:message).with("branch created callback was called! #{default_branch} #{intermediate_branch}")
 


### PR DESCRIPTION
## What does it do?

Fix the Backmerge PR Action branch validation using `GitHelper.current_git_branch` instead of `ensure_git_branch`

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
