### PR TITLE
Add `buildkite_add_trigger_step` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Introduce `buildkite_add_trigger_step` action, to insert a `trigger:` step in the current pipeline to trigger a child build from the current build. [#648]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
@@ -38,10 +38,10 @@ module Fastlane
         }.to_yaml
 
         # Use buildkite-agent to upload the pipeline
-        _stdout, stderr, _status = Open3.capture3('buildkite-agent', 'pipeline', 'upload', stdin_data: trigger_yaml)
+        _stdout, stderr, status = Open3.capture3('buildkite-agent', 'pipeline', 'upload', stdin_data: trigger_yaml)
 
         # Check for errors
-        UI.user_error!("Failed to upload pipeline: #{stderr}") unless stderr.empty?
+        UI.user_error!("Failed to upload pipeline: #{stderr}") unless status.success?
 
         # Log success
         UI.success("Added a trigger step to the current Buildkite build to start a new build for #{pipeline_file} on branch #{branch}")

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
@@ -16,7 +16,7 @@ module Fastlane
         pipeline_file = params[:pipeline_file]
         build_name = File.basename(pipeline_file, '.yml')
         message = params[:message] || build_name
-        branch = params[:branch] || `git rev-parse --abbrev-ref HEAD`.strip
+        branch = params[:branch] || sh('git', 'rev-parse', '--abbrev-ref', 'HEAD').strip
         environment = params[:environment] || {}
         buildkite_pipeline_slug = params[:buildkite_pipeline_slug]
         async = params[:async]

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
@@ -5,7 +5,13 @@ require 'open3'
 module Fastlane
   module Actions
     class BuildkiteAddTriggerStepAction < Action
+      BUILDKITE_ENV_ERROR_MESSAGE = 'This action can only be run from within a Buildkite build'
+
       def self.run(params)
+        unless ENV.key?('BUILDKITE_JOB_ID')
+          UI.user_error!(BUILDKITE_ENV_ERROR_MESSAGE)
+        end
+
         # Extract parameters
         pipeline_file = params[:pipeline_file]
         build_name = File.basename(pipeline_file, '.yml')

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module Fastlane
+  module Actions
+    class BuildkiteAddTriggerStepAction < Action
+      def self.run(params)
+        # Extract parameters
+        pipeline_file = params[:pipeline_file]
+        build_name = File.basename(pipeline_file, '.yml')
+        message = params[:message] || build_name
+        branch = params[:branch] || `git rev-parse --abbrev-ref HEAD`.strip
+        environment = params[:environment] || {}
+        buildkite_pipeline_slug = params[:buildkite_pipeline_slug]
+        async = params[:async]
+        label = params[:label] || ":buildkite: Trigger #{build_name} on #{branch}"
+
+        # Add the PIPELINE environment variable to the environment hash
+        environment = environment.merge('PIPELINE' => pipeline_file)
+
+        # Create the trigger step YAML
+        trigger_yaml = {
+          'steps' => [
+            {
+              'trigger' => buildkite_pipeline_slug,
+              'label' => label,
+              'async' => async,
+              'build' => {
+                'branch' => branch,
+                'message' => message,
+                'env' => environment
+              }
+            },
+          ]
+        }.to_yaml
+
+        # Use buildkite-agent to upload the pipeline
+        _stdout, stderr, _status = Open3.capture3('buildkite-agent', 'pipeline', 'upload', stdin_data: trigger_yaml)
+
+        # Check for errors
+        UI.user_error!("Failed to upload pipeline: #{stderr}") unless stderr.empty?
+
+        # Log success
+        UI.success("Added a trigger step to the current Buildkite build to start a new build for #{pipeline_file} on branch #{branch}")
+      end
+
+      def self.description
+        'Adds a trigger step to the current Buildkite pipeline to start a new build from this one'
+      end
+
+      def self.details
+        <<~DETAILS
+          This action adds a `trigger` step to the current Buildkite build, to start a separate build from the current one.
+
+          This is slightly different to `buildkite-agent pipeline upload`-ing the YAML steps of the build directly to the current build,
+            as this approach ensures the triggered build starts from a clean and independant context.
+            - This is particularly important if the build being triggered rely on the fact that the current build pushed new commits
+              to the Git branch and we want the new build's steps to start from the new commit.
+            - This is also necessary for cases where we run builds on a mirror of the original Git repo (e.g. for pipelines of repos hosted
+              in a private GitHub Enterprise server, mirrored on GitHub.com for CI building purposes) and we want the new build being triggered
+              to initiate a new sync of the Git repo as part of the CI build bootstrap process, to get the latest commits.
+        DETAILS
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :buildkite_pipeline_slug,
+            env_name: 'BUILDKITE_PIPELINE_SLUG',
+            description: 'The slug of the Buildkite pipeline to trigger. Defaults to the same slug as the current pipeline, so usually not necessary to provide explicitly',
+            type: String,
+            optional: false # But most likely to be auto-provided by the ENV var of the current build and thus not needed to be provided explicitly
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :label,
+            description: 'Custom label for the trigger step. If not provided, defaults to ":buildkite: Trigger {`pipeline_file`\'s basename} on {branch}"',
+            type: String,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :pipeline_file,
+            description: 'The path (relative to `.buildkite/`) to the pipeline YAML file to use for the triggered build',
+            type: String,
+            optional: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :branch,
+            description: 'The branch to trigger the build on. Defaults to the Git branch currently checked out at the time of running the action (which is not necessarily the same as the `BUILDKITE_BRANCH` the current build initially started on)',
+            type: String,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :message,
+            description: 'The message / title to use for the triggered build. If not provided, defaults to the `pipeline_file`\'s basename',
+            type: String,
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :environment,
+            description: 'Environment variables to pass to the triggered build (in addition to the PIPELINE={pipeline_file} that will be automatically injected)',
+            type: Hash,
+            default_value: {},
+            optional: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :async,
+            description: 'Whether to trigger the build asynchronously (true) or wait for it to complete (false). Defaults to false',
+            type: Boolean,
+            default_value: false
+          ),
+        ]
+      end
+
+      def self.return_value
+        'Returns true if the pipeline was successfully uploaded. Throws a `user_error!` if it failed to upload the `trigger` step to the current build'
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.example_code
+        [
+          <<~CODE,
+            # Use default/inferred values for most parameters
+            buildkite_add_trigger_step(
+              pipeline_file: "release-build.yml",
+              environment: { "RELEASE_VERSION" => "1.2.3" },
+            )
+          CODE
+          <<~CODE,
+            # Use custom values for most parameters
+            buildkite_add_trigger_step(
+              label: "🚀 Trigger Release Build",
+              pipeline_file: "release-build.yml",
+              branch: "release/1.2.3",
+              message: "Release Build (123)",
+              environment: { "RELEASE_VERSION" => "1.2.3" },
+              async: false,
+            )
+          CODE
+        ]
+      end
+
+      def self.category
+        :building
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
@@ -15,6 +15,7 @@ module Fastlane
         buildkite_pipeline_slug = params[:buildkite_pipeline_slug]
         async = params[:async]
         label = params[:label] || ":buildkite: Trigger #{build_name} on #{branch}"
+        depends_on = params[:depends_on]&.then { |v| v.empty? ? nil : Array(v) }
 
         # Add the PIPELINE environment variable to the environment hash
         environment = environment.merge('PIPELINE' => pipeline_file)
@@ -30,8 +31,9 @@ module Fastlane
                 'branch' => branch,
                 'message' => message,
                 'env' => environment
-              }
-            },
+              },
+              'depends_on' => depends_on
+            }.compact,
           ]
         }.to_yaml
 
@@ -108,6 +110,14 @@ module Fastlane
             description: 'Whether to trigger the build asynchronously (true) or wait for it to complete (false). Defaults to false',
             type: Boolean,
             default_value: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :depends_on,
+            env_name: 'BUILDKITE_STEP_KEY', # This is the env var that Buildkite sets for the current step
+            description: 'The steps to depend on before triggering the build. Defaults to the current step this action is called from, if said step has a `key:` attribute set. Use an empty array to explicitly not depend on any step even if the current step has a `key`',
+            type: Array,
+            default_value: [],
+            optional: true
           ),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_add_trigger_step_action.rb
@@ -61,8 +61,8 @@ module Fastlane
         <<~DETAILS
           This action adds a `trigger` step to the current Buildkite build, to start a separate build from the current one.
 
-          This is slightly different to `buildkite-agent pipeline upload`-ing the YAML steps of the build directly to the current build,
-            as this approach ensures the triggered build starts from a clean and independant context.
+          This is slightly different from `buildkite-agent pipeline upload`-ing the YAML steps of the build directly to the current build,
+            as this approach ensures the triggered build starts from a clean and independent context.
             - This is particularly important if the build being triggered rely on the fact that the current build pushed new commits
               to the Git branch and we want the new build's steps to start from the new commit.
             - This is also necessary for cases where we run builds on a mirror of the original Git repo (e.g. for pipelines of repos hosted

--- a/spec/buildkite_add_trigger_step_action_spec.rb
+++ b/spec/buildkite_add_trigger_step_action_spec.rb
@@ -11,6 +11,7 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
   let(:buildkite_pipeline_slug) { 'test-pipeline' }
   let(:async) { false }
   let(:label) { nil } # Will use default
+  let(:depends_on) { nil } # Will use default
 
   def expected_yaml(
     pipeline_file: self.pipeline_file,
@@ -20,7 +21,8 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
     extra_env: environment,
     buildkite_pipeline_slug: self.buildkite_pipeline_slug,
     async: self.async,
-    label: self.label
+    label: self.label,
+    depends_on: self.depends_on
   )
     # Calculate the label based on whether a custom one was provided
     actual_label = label || ":buildkite: Trigger #{build_name} on #{branch}"
@@ -28,19 +30,23 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
     # Merge the environment with PIPELINE, ensuring PIPELINE is always set correctly
     actual_env = extra_env.merge('PIPELINE' => pipeline_file)
 
+    # Build the step hash
+    step = {
+      'trigger' => buildkite_pipeline_slug,
+      'label' => actual_label,
+      'async' => async,
+      'build' => {
+        'branch' => branch,
+        'message' => message,
+        'env' => actual_env
+      }
+    }
+
+    # Add depends_on if provided
+    step['depends_on'] = depends_on unless depends_on.nil?
+
     {
-      'steps' => [
-        {
-          'trigger' => buildkite_pipeline_slug,
-          'label' => actual_label,
-          'async' => async,
-          'build' => {
-            'branch' => branch,
-            'message' => message,
-            'env' => actual_env
-          }
-        },
-      ]
+      'steps' => [step]
     }.to_yaml
   end
 
@@ -54,14 +60,15 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
       .and_return(['', '', instance_double(Process::Status, success?: true)])
   end
 
-  # Unset the `BUILDKITE_PIPELINE_SLUG` env var while running each test case
-  # Otherwise when we run the tests on CI, the env var would be set as part of it running as a Buildkite job,
-  # and this would mess up our test environment and bias the test results
+  # Unset both BUILDKITE_PIPELINE_SLUG and BUILDKITE_STEP_KEY env vars while running each test case
   around do |example|
-    original_value = ENV['BUILDKITE_PIPELINE_SLUG']
+    original_pipeline_slug = ENV['BUILDKITE_PIPELINE_SLUG']
+    original_step_key = ENV['BUILDKITE_STEP_KEY']
     ENV.delete('BUILDKITE_PIPELINE_SLUG')
+    ENV.delete('BUILDKITE_STEP_KEY')
     example.run
-    ENV['BUILDKITE_PIPELINE_SLUG'] = original_value if original_value
+    ENV['BUILDKITE_PIPELINE_SLUG'] = original_pipeline_slug if original_pipeline_slug
+    ENV['BUILDKITE_STEP_KEY'] = original_step_key if original_step_key
   end
 
   context 'when all required parameters are provided' do
@@ -280,6 +287,99 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
         branch: branch,
         message: message,
         environment: custom_env,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+  end
+
+  context 'when testing depends_on parameter' do
+    it 'includes depends_on when provided with a single value' do
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(depends_on: ['step-1']))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async,
+        depends_on: 'step-1'
+      )
+    end
+
+    it 'includes depends_on when provided with multiple values' do
+      multiple_dependencies = ['step-1', 'step-2', 'step-3']
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(depends_on: multiple_dependencies))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async,
+        depends_on: multiple_dependencies
+      )
+    end
+
+    it 'does not include depends_on when provided with an empty array' do
+      empty_dependencies = []
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async,
+        depends_on: empty_dependencies
+      )
+    end
+
+    it 'uses BUILDKITE_STEP_KEY env var when depends_on is not provided and env var is set' do
+      ENV['BUILDKITE_STEP_KEY'] = 'step-from-env'
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(depends_on: ['step-from-env']))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'does not include depends_on when not provided and BUILDKITE_STEP_KEY is not set' do
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'does not include depends_on when not provided and BUILDKITE_STEP_KEY is empty string' do
+      ENV['BUILDKITE_STEP_KEY'] = ''
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
         buildkite_pipeline_slug: buildkite_pipeline_slug,
         async: async
       )

--- a/spec/buildkite_add_trigger_step_action_spec.rb
+++ b/spec/buildkite_add_trigger_step_action_spec.rb
@@ -52,7 +52,7 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
 
   before do
     # Mock the git command to return our test branch
-    allow(described_class).to receive(:`).with('git rev-parse --abbrev-ref HEAD').and_return(branch)
+    allow(described_class).to receive(:sh).with('git', 'rev-parse', '--abbrev-ref', 'HEAD').and_return("#{branch}\n")
 
     # Mock the pipeline upload command to return a success status
     allow(Open3).to receive(:capture3)

--- a/spec/buildkite_add_trigger_step_action_spec.rb
+++ b/spec/buildkite_add_trigger_step_action_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
+  let(:pipeline_file) { 'test-pipeline.yml' }
+  let(:build_name) { 'test-pipeline' }
+  let(:branch) { 'test-branch' }
+  let(:message) { 'Test Build' }
+  let(:environment) { { 'TEST_VAR' => 'test-value' } }
+  let(:buildkite_pipeline_slug) { 'test-pipeline' }
+  let(:async) { false }
+  let(:label) { nil } # Will use default
+
+  def expected_yaml(
+    pipeline_file: self.pipeline_file,
+    build_name: self.build_name,
+    branch: self.branch,
+    message: self.message,
+    extra_env: environment,
+    buildkite_pipeline_slug: self.buildkite_pipeline_slug,
+    async: self.async,
+    label: self.label
+  )
+    # Calculate the label based on whether a custom one was provided
+    actual_label = label || ":buildkite: Trigger #{build_name} on #{branch}"
+
+    # Merge the environment with PIPELINE, ensuring PIPELINE is always set correctly
+    actual_env = extra_env.merge('PIPELINE' => pipeline_file)
+
+    {
+      'steps' => [
+        {
+          'trigger' => buildkite_pipeline_slug,
+          'label' => actual_label,
+          'async' => async,
+          'build' => {
+            'branch' => branch,
+            'message' => message,
+            'env' => actual_env
+          }
+        },
+      ]
+    }.to_yaml
+  end
+
+  before do
+    # Mock the git command to return our test branch
+    allow(described_class).to receive(:`).with('git rev-parse --abbrev-ref HEAD').and_return(branch)
+
+    # Mock the pipeline upload command to return a success status
+    allow(Open3).to receive(:capture3)
+      .with('buildkite-agent', 'pipeline', 'upload', stdin_data: anything)
+      .and_return(['', '', instance_double(Process::Status, success?: true)])
+  end
+
+  context 'when all required parameters are provided' do
+    it 'uploads the correct pipeline YAML' do
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'uses the current branch when not provided' do
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'uses a custom label when provided' do
+      custom_label = '🚀 Custom Trigger Label'
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(label: custom_label))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async,
+        label: custom_label
+      )
+    end
+
+    it 'uses async: true when specified' do
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(async: true))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: true
+      )
+    end
+  end
+
+  context 'when the pipeline upload fails' do
+    it 'raises a user error with the error message' do
+      error_message = 'Failed to upload pipeline'
+      allow(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+        .and_return(['', error_message, instance_double(Process::Status, success?: false)])
+
+      expect(FastlaneCore::UI).to receive(:user_error!).with("Failed to upload pipeline: #{error_message}")
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+  end
+
+  context 'when required parameters are missing' do
+    it 'raises an error when pipeline_file is not provided' do
+      expect do
+        run_described_fastlane_action(
+          branch: branch,
+          message: message,
+          environment: environment,
+          buildkite_pipeline_slug: buildkite_pipeline_slug,
+          async: async
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /No value found for 'pipeline_file'/)
+    end
+
+    it 'raises an error when buildkite_pipeline_slug is not provided' do
+      expect do
+        run_described_fastlane_action(
+          pipeline_file: pipeline_file,
+          branch: branch,
+          message: message,
+          environment: environment,
+          async: async
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /No value found for 'buildkite_pipeline_slug'/)
+    end
+  end
+
+  context 'when testing parameter default values and custom values' do
+    it 'uses the pipeline file basename as message when not provided' do
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(message: build_name))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'uses an empty environment hash when not provided' do
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(extra_env: {}))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'uses async: false when not provided' do
+      # This is already tested in the default case, but let's make it explicit
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug
+      )
+    end
+
+    it 'uses the default label when not provided' do
+      # This is already tested in the default case, but let's make it explicit
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'allows overriding the default message with a custom one' do
+      custom_message = 'Custom Build Message'
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(message: custom_message))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: custom_message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'allows overriding the default branch with a custom one' do
+      custom_branch = 'custom-branch'
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(branch: custom_branch))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: custom_branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'allows overriding the default environment with a custom one' do
+      custom_env = { 'CUSTOM_VAR' => 'custom-value' }
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(extra_env: custom_env))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: custom_env,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'preserves the PIPELINE environment variable even when custom environment is provided' do
+      custom_env = { 'CUSTOM_VAR' => 'custom-value', 'PIPELINE' => 'should-be-overridden.yml' }
+      expect(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(extra_env: { 'CUSTOM_VAR' => 'custom-value' }))
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: custom_env,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+  end
+end

--- a/spec/buildkite_add_trigger_step_action_spec.rb
+++ b/spec/buildkite_add_trigger_step_action_spec.rb
@@ -130,14 +130,32 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
     end
   end
 
-  context 'when the pipeline upload fails' do
-    it 'raises a user error with the error message' do
+  context 'when pipeline upload errors' do
+    it 'raises a user error when the command fails' do
       error_message = 'Failed to upload pipeline'
       allow(Open3).to receive(:capture3)
         .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
         .and_return(['', error_message, instance_double(Process::Status, success?: false)])
 
       expect(FastlaneCore::UI).to receive(:user_error!).with("Failed to upload pipeline: #{error_message}")
+
+      run_described_fastlane_action(
+        pipeline_file: pipeline_file,
+        branch: branch,
+        message: message,
+        environment: environment,
+        buildkite_pipeline_slug: buildkite_pipeline_slug,
+        async: async
+      )
+    end
+
+    it 'does not error when the command succeeds, even with stderr output' do
+      stderr_message = 'Some warning message'
+      allow(Open3).to receive(:capture3)
+        .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml)
+        .and_return(['', stderr_message, instance_double(Process::Status, success?: true)])
+
+      expect(FastlaneCore::UI).not_to receive(:user_error!)
 
       run_described_fastlane_action(
         pipeline_file: pipeline_file,

--- a/spec/buildkite_add_trigger_step_action_spec.rb
+++ b/spec/buildkite_add_trigger_step_action_spec.rb
@@ -310,7 +310,7 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
     end
 
     it 'includes depends_on when provided with multiple values' do
-      multiple_dependencies = ['step-1', 'step-2', 'step-3']
+      multiple_dependencies = %w[step-1 step-2 step-3]
       expect(Open3).to receive(:capture3)
         .with('buildkite-agent', 'pipeline', 'upload', stdin_data: expected_yaml(depends_on: multiple_dependencies))
 

--- a/spec/buildkite_add_trigger_step_action_spec.rb
+++ b/spec/buildkite_add_trigger_step_action_spec.rb
@@ -60,15 +60,27 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
       .and_return(['', '', instance_double(Process::Status, success?: true)])
   end
 
-  # Unset both BUILDKITE_PIPELINE_SLUG and BUILDKITE_STEP_KEY env vars while running each test case
+  # Stub BUILDKITE_* env vars while running each test case
   around do |example|
     original_pipeline_slug = ENV['BUILDKITE_PIPELINE_SLUG']
     original_step_key = ENV['BUILDKITE_STEP_KEY']
+    original_job_id = ENV['BUILDKITE_JOB_ID']
+
+    # Unset BUILDKITE_PIPELINE_SLUG and BUILDKITE_STEP_KEY env vars because they'd otherwise be used as default values for ConfigItems of the action
     ENV.delete('BUILDKITE_PIPELINE_SLUG')
     ENV.delete('BUILDKITE_STEP_KEY')
+    # Set BUILDKITE_JOB_ID to a non-empty value to satisfy the check in the action, unless `remove_job_id: true` is used in the example metadata
+    if example.metadata[:remove_job_id]
+      ENV.delete('BUILDKITE_JOB_ID')
+    else
+      ENV['BUILDKITE_JOB_ID'] = '1337'
+    end
+
     example.run
+
     ENV['BUILDKITE_PIPELINE_SLUG'] = original_pipeline_slug if original_pipeline_slug
     ENV['BUILDKITE_STEP_KEY'] = original_step_key if original_step_key
+    ENV['BUILDKITE_JOB_ID'] = original_job_id if original_job_id
   end
 
   context 'when all required parameters are provided' do
@@ -191,6 +203,20 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
           async: async
         )
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /No value found for 'buildkite_pipeline_slug'/)
+    end
+
+    it 'raises an error when BUILDKITE_JOB_ID is not set', :remove_job_id do
+      # NOTE: the `:remove_job_id` metadata set on this spec example is used in the `around` block to unset BUILDKITE_JOB_ID for this test
+      expect do
+        run_described_fastlane_action(
+          pipeline_file: pipeline_file,
+          branch: branch,
+          message: message,
+          environment: environment,
+          buildkite_pipeline_slug: buildkite_pipeline_slug,
+          async: async
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, Fastlane::Actions::BuildkiteAddTriggerStepAction::BUILDKITE_ENV_ERROR_MESSAGE)
     end
   end
 

--- a/spec/buildkite_add_trigger_step_action_spec.rb
+++ b/spec/buildkite_add_trigger_step_action_spec.rb
@@ -54,6 +54,16 @@ describe Fastlane::Actions::BuildkiteAddTriggerStepAction do
       .and_return(['', '', instance_double(Process::Status, success?: true)])
   end
 
+  # Unset the `BUILDKITE_PIPELINE_SLUG` env var while running each test case
+  # Otherwise when we run the tests on CI, the env var would be set as part of it running as a Buildkite job,
+  # and this would mess up our test environment and bias the test results
+  around do |example|
+    original_value = ENV['BUILDKITE_PIPELINE_SLUG']
+    ENV.delete('BUILDKITE_PIPELINE_SLUG')
+    example.run
+    ENV['BUILDKITE_PIPELINE_SLUG'] = original_value if original_value
+  end
+
   context 'when all required parameters are provided' do
     it 'uploads the correct pipeline YAML' do
       expect(Open3).to receive(:capture3)


### PR DESCRIPTION
Closes AINFRA-98

## What does it do?

This implements a new fastlane action that allows to append [a `trigger` step](https://buildkite.com/docs/pipelines/configure/step-types/trigger-step) to the current build so that Buildkite would trigger a new, dependent sub-build of the current build.

<details><summary>How does this differ from other existing <tt>buildkite_*</tt> actions we already have?</summary>

 - This differs from the `buildkite_trigger_build` existing action—which uses the Buildkite REST API to trigger a build from outside a Buildkite build, typically when running a lane from your local terminal
 - This differs from calling `buildkite-agent pipeline upload #{pipeline_file}` to upload the steps of a YML pipeline file directly on the current Build, as instead it actually triggers a child build from the current build. The main different with this is that the triggered child build starts with a brand new build context, especially the `BUILDKITE_BRANCH` that the new build is started on will be the `branch` you asked the trigger to run on (typically the current branch you were checked out at the time you called that action), **even if** the current build started on a different branch and then switched to a new branch since, or pushed new commits since.
</details>

## Why is this needed?

This will be needed especially during the release process of our apps, when we have tasks like the code-freeze that is responsible for creating a new branch + bumping the version, before compiling a beta build from the new branch and commit that just got pushed.

This action will be particularly useful for the case of our repos hosted in private GitHub Enterprise instances (e.g. Tumblr), for which their initial `pipeline upload` step to upload the root YAML pipeline file of a build also takes care of mirroring the latest commit of the `BUILDKITE_BRANCH` that that build starts on to an instance accessible by our other CI agents / builders, so that those CI agents can use that mirror repo as a source to checkout the source code they need to operate. 

<details><summary>Details</summary>

Because of that particular mechanism, if a CI agent that runs in the LAN where the GH:E instance lives (and thus use the real repo) creates a new branch (e.g. `release/*` during code-freeze) and/or pushes a new commit (e.g. version bump), other agents that operate outside the LAN of the GH:E instance and that only use the GitHub.com mirror of the repo won't see the new branch or commits until the mirror is synchronized with the latest GH:E as part of a brand new CI build.

This is why just uploading the steps of the pipeline file directly on the current build won't work for those cases of repos hosted on GH:E; even if the commands that are in charge of building the beta were to `git checkout release/${RELEASE_VERSION}` and `git pull` (like we do for other repos hosted in GitHub.com), since the new branch and commit are only on the GH:E repo but not on the mirror at that time, that wouldn't help. Only triggering a **separate** CI build (as a child build of the current one) would allow our architecture to re-sync the git mirrors and the new jobs running on other agents to see the new branch and commit.
</details>

## Testing

[I created a `use-trigger-action` branch on Tumblr-iOS](https://github.tumblr.net/Tumblr/ios/pull/29788) which:
 - Switched the `Gemfile` to point `release-toolkit` to this PR's branch
 - Update the Fastfile's `trigger_buildkite_build` helper to call this new `buildkite_add_trigger_step` action instead of invoking the `trigger-build.sh` custom script
 - Create a dummy `fake_code_freeze` lane that:
    - Creates a `test/AINFRA-98` branch from the current branch
    - Simulates a dummy version bump and push it
    - Then calls `trigger_buildkite_build` helper method (and this this action) to trigger the `fake-beta-build.yml` pipeline
    - Which in turns just prints some git debug information instead of doing an actual build

Then I used the "New Build" button on Buildkite to trigger a build on that `use-trigger-action` branch using `PIPELINE=release-pipelines/fake-code-freeze.yml`
 - [This is the resulting parent test build](https://buildkite.com/automattic/tumblr-ios/builds/33589/steps) and [its call to the action](https://buildkite.com/automattic/tumblr-ios/builds/33589/steps?sid=0196d9fc-690f-4fa7-8aa1-d0409e44d318#0196d9fc-6947-497b-a9fc-9b02fb3eff8a/221-223)
 - [This is the child build that got triggered, with its git debugging information](https://buildkite.com/automattic/tumblr-ios/builds/33590/steps?sid=0196d9fd-3146-44a5-91b8-d488a6b5d847#0196d9fd-3183-43aa-9578-46a515a4a2f7/347-349)

Notice how:
 - The "Trigger fake-beta-build on test/AINFRA-98" properly shows in the Canvas view as dependent on the job that created it, making it less confusing that the current setup
    ![](https://github.com/user-attachments/assets/c6691b87-ce70-4dcb-be99-b0ccd18c3dea)
 - The child build that got triggered [ran on the expected commit](https://buildkite.com/automattic/tumblr-ios/builds/33590/steps?sid=0196d9fd-3146-44a5-91b8-d488a6b5d847#0196d9fd-3183-43aa-9578-46a515a4a2f7/347-349), being able to find on the GitHub.com mirror [the commit that was pushed to GH:E by the parent build](https://buildkite.com/automattic/tumblr-ios/builds/33589/steps?sid=0196d9fc-690f-4fa7-8aa1-d0409e44d318#0196d9fc-6947-497b-a9fc-9b02fb3eff8a/195-200)

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~~
