### PR TITLE
Prevent frozen string errors in promo screenshots action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix `can't modify frozen String: "transparent"` and other `FrozenError` crashes in `promo_screenshots_action`. [#653]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -24,10 +24,12 @@ module Fastlane
     class PromoScreenshots
       def initialize
         if $skip_magick
-          message = "PromoScreenshots feature is currently disabled.\n"
-          message << "Please, install RMagick if you aim to generate the PromoScreenshots.\n"
-          message << "'bundle install --with screenshots' should do it if your project is configured for PromoScreenshots.\n"
-          message << 'Aborting.'
+          message = <<~MSG
+            PromoScreenshots feature is currently disabled.
+            Please, install RMagick if you aim to generate the PromoScreenshots.
+            'bundle install --with screenshots' should do it if your project is configured for PromoScreenshots.
+            Aborting.
+          MSG
           UI.user_error!(message)
         end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -402,10 +402,13 @@ module Fastlane
       end
 
       def create_image(width, height, background = 'transparent')
-        background.paint.to_hex
+        # The paint method we call below modifies the string in place.
+        # But if the string is frozen, we need to dup it first, otherwise we'll get a frozen string error.
+        working_background = background.frozen? ? background.dup : background
+        working_background.paint.to_hex
 
         Image.new(width, height) do
-          self.background_color = background
+          self.background_color = working_background
         end
       end
 


### PR DESCRIPTION
## What does it do?

See https://linear.app/a8c/issue/AINFRA-827. @jaclync shared a crash when running the promo screenshots generation in Woo. 

These changes address it.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
