### PR TITLE
Release 13.3.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Fix `can't modify frozen String: "transparent"` and other `FrozenError` crashes in `promo_screenshots_action`. [#653]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 13.3.1
+
+### Bug Fixes
+
+- Fix `can't modify frozen String: "transparent"` and other `FrozenError` crashes in `promo_screenshots_action`. [#653]
 
 ## 13.3.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.3.0)
+    fastlane-plugin-wpmreleasetoolkit (13.3.1)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.3.0'
+    VERSION = '13.3.1'
   end
 end


### PR DESCRIPTION
Releasing new version 13.3.1.

# What's Next


### Bug Fixes

- Fix `can't modify frozen String: "transparent"` and other `FrozenError` crashes in `promo_screenshots_action`. [#653]

---

See also https://linear.app/a8c/issue/AINFRA-827
