### PR TITLE
Add custom prefix configuration to `DerivedBuildCodeFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- Add the possibility to configure DerivedBuildCodeFormatter configure a versioning prefix instead of always defaulting to 1. [#656]
+- Add the possibility to configure in DerivedBuildCodeFormatter a versioning prefix instead of always defaulting to 1. [#656]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Add the possibility to configure DerivedBuildCodeFormatter configure a versioning prefix instead of always defaulting to 1. [#656]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -67,16 +67,9 @@ module Fastlane
           end
 
           # Check if it's a valid integer
-          begin
-            prefix_int = Integer(prefix_str)
-          rescue ArgumentError
-            UI.user_error!("Prefix must be an integer digit (0-9) or empty string, got: '#{prefix_str}'")
-          end
+          return if ('0'..'9').include?(prefix_str)
 
-          # Check if it's within valid range (0-9)
-          return if prefix_int.between?(0, 9)
-
-          UI.user_error!("Prefix must be a single digit (0-9), got: #{prefix_int}")
+          UI.user_error!("Prefix must be an integer digit (0-9) or empty string, got: '#{prefix_str}'")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -6,9 +6,18 @@ module Fastlane
       # The `DerivedBuildCodeFormatter` class is a specialized build code formatter for derived build codes.
       # It takes in an AppVersion object and derives a build code from it.
       class DerivedBuildCodeFormatter
+        # Initialize the formatter with a configurable prefix.
+        #
+        # @param [String] prefix The prefix to use for the build code. Must be a single digit (0-9). Defaults to '1' for backward compatibility.
+        #
+        def initialize(prefix: '1')
+          validate_prefix!(prefix)
+          @prefix = prefix.to_s
+        end
+
         # Calculate the next derived build code.
         #
-        # This method derives a new build code from the given AppVersion object by concatenating the digit 1,
+        # This method derives a new build code from the given AppVersion object by concatenating the configured prefix,
         # the major version, the minor version, the patch version, and the build number.
         #
         # @param [AppVersion] version The AppVersion object to derive the next build code from.
@@ -19,15 +28,55 @@ module Fastlane
         # @return [String] The formatted build code string.
         #
         def build_code(build_code = nil, version:)
-          format(
-            # 1 is appended to the beginning of the string in case there needs to be additional platforms or
-            # extensions that could then use a different digit prefix such as 2, etc.
-            '1%<major>.2i%<minor>.2i%<patch>.2i%<build_number>.2i',
+          result = format(
+            # The prefix is configurable to allow for additional platforms or
+            # extensions that could use a different digit prefix such as 2, etc.
+            '%<prefix>s%<major>.2i%<minor>.2i%<patch>.2i%<build_number>.2i',
+            prefix: @prefix,
             major: version.major,
             minor: version.minor,
             patch: version.patch,
             build_number: version.build_number
           )
+
+          # Only trim leading zeros when prefix is empty (to avoid removing explicit "0" prefix)
+          if @prefix.empty?
+            result.gsub(/^0+/, '')
+          else
+            result
+          end
+        end
+
+        private
+
+        # Validates that the prefix is a valid single digit (0-9) or empty string.
+        #
+        # @param [String] prefix The prefix to validate
+        #
+        # @raise [StandardError] If the prefix is invalid
+        #
+        def validate_prefix!(prefix)
+          prefix_str = prefix.to_s
+
+          # Allow empty string
+          return if prefix_str.empty?
+
+          # Check if it's longer than 1 character
+          if prefix_str.length > 1
+            UI.user_error!("Prefix must be a single digit or empty string, got: '#{prefix_str}' (length: #{prefix_str.length})")
+          end
+
+          # Check if it's a valid integer
+          begin
+            prefix_int = Integer(prefix_str)
+          rescue ArgumentError
+            UI.user_error!("Prefix must be an integer digit (0-9) or empty string, got: '#{prefix_str}'")
+          end
+
+          # Check if it's within valid range (0-9)
+          return if prefix_int.between?(0, 9)
+
+          UI.user_error!("Prefix must be a single digit (0-9), got: #{prefix_int}")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -39,12 +39,7 @@ module Fastlane
             build_number: version.build_number
           )
 
-          # Only trim leading zeros when prefix is empty (to avoid removing explicit "0" prefix)
-          if @prefix.empty?
-            result.gsub(/^0+/, '')
-          else
-            result
-          end
+          result.gsub(/^0+/, '')
         end
 
         private

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -8,9 +8,9 @@ module Fastlane
       class DerivedBuildCodeFormatter
         # Initialize the formatter with a configurable prefix.
         #
-        # @param [String] prefix The prefix to use for the build code. Must be a single digit (0-9), or the empty string. Defaults to '1' for backward compatibility.
+        # @param [String] prefix The prefix to use for the build code. Must be a single digit (0-9), or empty string / nil.
         #
-        def initialize(prefix: '1')
+        def initialize(prefix: nil)
           prefix ||= ''
           validate_prefix!(prefix)
           @prefix = prefix.to_s

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -8,9 +8,10 @@ module Fastlane
       class DerivedBuildCodeFormatter
         # Initialize the formatter with a configurable prefix.
         #
-        # @param [String] prefix The prefix to use for the build code. Must be a single digit (0-9). Defaults to '1' for backward compatibility.
+        # @param [String] prefix The prefix to use for the build code. Must be a single digit (0-9), or the empty string. Defaults to '1' for backward compatibility.
         #
         def initialize(prefix: '1')
+          prefix ||= ''
           validate_prefix!(prefix)
           @prefix = prefix.to_s
         end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -37,7 +37,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
         formatter = described_class.new(prefix: '0')
         build_code_string = formatter.build_code(version: version)
-        expect(build_code_string.to_s).to eq('012345678')
+        expect(build_code_string.to_s).to eq('12345678')
       end
     end
 

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -63,6 +63,22 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         expect(build_code_string.to_s).to eq('1')
       end
     end
+
+    context 'with nil prefix' do
+      it 'treats nil prefix as empty string and derives build code without prefix' do
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        formatter = described_class.new(prefix: nil)
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('1020304')
+      end
+
+      it 'treats nil prefix as empty string for two-digit major version' do
+        version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
+        formatter = described_class.new(prefix: nil)
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('12345678')
+      end
+    end
   end
 
   describe 'prefix validation' do

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -4,16 +4,102 @@ require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
   describe 'derives a build code from an AppVersion object' do
-    it 'derives the build code from version numbers that are single digits' do
-      version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
-      build_code_string = described_class.new.build_code(version: version)
-      expect(build_code_string.to_s).to eq('101020304')
+    context 'with default prefix (backward compatibility)' do
+      it 'derives the build code from version numbers that are single digits' do
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        build_code_string = described_class.new.build_code(version: version)
+        expect(build_code_string.to_s).to eq('101020304')
+      end
+
+      it 'derives the build code from version numbers that are two digits' do
+        version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
+        build_code_string = described_class.new.build_code(version: version)
+        expect(build_code_string.to_s).to eq('112345678')
+      end
     end
 
-    it 'derives the build code from version numbers that are two digits' do
-      version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
-      build_code_string = described_class.new.build_code(version: version)
-      expect(build_code_string.to_s).to eq('112345678')
+    context 'with explicit prefix' do
+      it 'derives the build code with prefix "1"' do
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        formatter = described_class.new(prefix: '1')
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('101020304')
+      end
+
+      it 'derives the build code with prefix "2"' do
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        formatter = described_class.new(prefix: '2')
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('201020304')
+      end
+
+      it 'derives the build code with prefix "0"' do
+        version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
+        formatter = described_class.new(prefix: '0')
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('012345678')
+      end
+    end
+
+    context 'with empty prefix' do
+      it 'derives the build code without prefix and trims leading zeros' do
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        formatter = described_class.new(prefix: '')
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('1020304')
+      end
+
+      it 'derives the build code without prefix for two-digit major version' do
+        version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
+        formatter = described_class.new(prefix: '')
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('12345678')
+      end
+
+      it 'handles edge case with all zeros after removing leading zeros' do
+        version = Fastlane::Models::AppVersion.new(0, 0, 0, 1)
+        formatter = described_class.new(prefix: '')
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('1')
+      end
+    end
+  end
+
+  describe 'prefix validation' do
+    context 'with valid prefixes' do
+      it 'accepts single digits 0-9' do
+        (0..9).each do |digit|
+          expect { described_class.new(prefix: digit.to_s) }.not_to raise_error
+        end
+      end
+
+      it 'accepts empty string' do
+        expect { described_class.new(prefix: '') }.not_to raise_error
+      end
+
+      it 'accepts integer inputs' do
+        expect { described_class.new(prefix: 5) }.not_to raise_error
+      end
+    end
+
+    context 'with invalid prefixes' do
+      it 'rejects multi-character strings' do
+        expect { described_class.new(prefix: '12') }.to raise_error(/Prefix must be a single digit or empty string/)
+      end
+
+      it 'rejects non-numeric strings' do
+        expect { described_class.new(prefix: 'a') }.to raise_error(/Prefix must be an integer digit/)
+      end
+
+      it 'rejects numbers outside 0-9 range' do
+        expect { described_class.new(prefix: '10') }.to raise_error(/Prefix must be a single digit or empty string/)
+        expect { described_class.new(prefix: '-1') }.to raise_error(/Prefix must be a single digit or empty string/)
+      end
+
+      it 'rejects symbols and special characters' do
+        expect { described_class.new(prefix: '@') }.to raise_error(/Prefix must be an integer digit/)
+        expect { described_class.new(prefix: '#') }.to raise_error(/Prefix must be an integer digit/)
+      end
     end
   end
 end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -4,17 +4,17 @@ require 'spec_helper'
 
 describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
   describe 'derives a build code from an AppVersion object' do
-    context 'with default prefix (backward compatibility)' do
+    context 'with default prefix (nil)' do
       it 'derives the build code from version numbers that are single digits' do
         version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
         build_code_string = described_class.new.build_code(version: version)
-        expect(build_code_string.to_s).to eq('101020304')
+        expect(build_code_string.to_s).to eq('1020304')
       end
 
       it 'derives the build code from version numbers that are two digits' do
         version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
         build_code_string = described_class.new.build_code(version: version)
-        expect(build_code_string.to_s).to eq('112345678')
+        expect(build_code_string.to_s).to eq('12345678')
       end
     end
 


### PR DESCRIPTION
## What does it do?

This PR adds to the class `DerivedBuildCodeFormatter` the possibility to configure a versioning prefix instead of always defaulting to `1`.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
