### PR TITLE
Add version components digits configuration to DerivedBuildCodeFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ _None_
 
 ### New Features
 
-- Add the possibility to configure in DerivedBuildCodeFormatter a versioning prefix instead of always defaulting to 1. [#656]
-- Add configurable number of digits in version components in DerivedBuildCodeFormatter. [#657]
+- Add the possibility to configure in `DerivedBuildCodeFormatter` a versioning prefix instead of always defaulting to 1. [#656]
+- Add configurable number of digits in version components in `DerivedBuildCodeFormatter`. [#657]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _None_
 ### New Features
 
 - Add the possibility to configure in DerivedBuildCodeFormatter a versioning prefix instead of always defaulting to 1. [#656]
+- Add configurable number of digits in version components in DerivedBuildCodeFormatter. [#657]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/app_version.rb
@@ -33,6 +33,14 @@ module Fastlane
       def to_s
         "#{@major}.#{@minor}.#{@patch}.#{@build_number}"
       end
+
+      # Returns an array of the version components.
+      #
+      # @return [Array<Integer>] an array of the version components.
+      #
+      def components
+        [@major, @minor, @patch, @build_number]
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -45,6 +45,12 @@ module Fastlane
         # @return [String] The formatted build code string.
         #
         def build_code(build_code = nil, version:)
+          # Validate that version components fit within their configured digit limits
+          validate_version_component_fits!(component_value: version.major, digit_limit: @major_digits)
+          validate_version_component_fits!(component_value: version.minor, digit_limit: @minor_digits)
+          validate_version_component_fits!(component_value: version.patch, digit_limit: @patch_digits)
+          validate_version_component_fits!(component_value: version.build_number, digit_limit: @build_digits)
+
           result = [
             @prefix,
             version.major.to_s.rjust(@major_digits, '0'),
@@ -108,6 +114,23 @@ module Fastlane
 
           UI.user_error!("Total digit count (#{total_digits}) exceeds maximum allowed (#{MAX_TOTAL_DIGITS}). " \
                          "Current config: major(#{major_digits}) + minor(#{minor_digits}) + patch(#{patch_digits}) + build(#{build_digits}) digits")
+        end
+
+        # Validates that a version component value fits within its configured digit limit.
+        #
+        # @param [Integer] component_value The version component value to validate
+        # @param [Integer] digit_limit The maximum number of digits allowed for this component
+        #
+        # @raise [StandardError] If the component value exceeds the digit limit
+        #
+        def validate_version_component_fits!(component_value:, digit_limit:)
+          # Calculate the maximum value that fits in the digit limit
+          max_value = (10**digit_limit) - 1
+
+          return if component_value <= max_value
+
+          UI.user_error!("Version component value (#{component_value}) exceeds maximum allowed " \
+                         "for #{digit_limit} digit(s) (max: #{max_value}). Consider increasing the corresponding _digits parameter.")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -45,17 +45,14 @@ module Fastlane
         # @return [String] The formatted build code string.
         #
         def build_code(build_code = nil, version:)
-          # Build dynamic format string based on configured digit counts
-          format_string = "%<prefix>s%<major>.#{@major_digits}i%<minor>.#{@minor_digits}i%<patch>.#{@patch_digits}i%<build_number>.#{@build_digits}i"
-
-          result = format(
-            format_string,
-            prefix: @prefix,
-            major: version.major,
-            minor: version.minor,
-            patch: version.patch,
-            build_number: version.build_number
-          )
+          # Use manual padding to avoid security risks with dynamic format strings
+          result = [
+            @prefix,
+            version.major.to_s.rjust(@major_digits, '0'),
+            version.minor.to_s.rjust(@minor_digits, '0'),
+            version.patch.to_s.rjust(@patch_digits, '0'),
+            version.build_number.to_s.rjust(@build_digits, '0'),
+          ].join
 
           result.gsub(/^0+/, '')
         end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -19,9 +19,8 @@ module Fastlane
         # @param [Integer] build_digits Number of digits for build number. Must be between 1–3. Defaults to 2.
         #
         def initialize(prefix: nil, major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
-          prefix ||= ''
           validate_prefix!(prefix)
-          @prefix = prefix.to_s
+          @prefix = (prefix || '').to_s
 
           @digit_counts = [major_digits, minor_digits, patch_digits, build_digits]
           @digit_counts.each { |d| validate_digit_count!(d) }
@@ -61,6 +60,10 @@ module Fastlane
         # @raise [StandardError] If the prefix is invalid
         #
         def validate_prefix!(prefix)
+          unless prefix.nil? || prefix.is_a?(String) || prefix.is_a?(Integer)
+            UI.user_error!("Prefix must be a string or integer, got: #{prefix.class}")
+          end
+
           prefix_str = prefix.to_s
 
           # Allow empty string

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -45,7 +45,6 @@ module Fastlane
         # @return [String] The formatted build code string.
         #
         def build_code(build_code = nil, version:)
-          # Use manual padding to avoid security risks with dynamic format strings
           result = [
             @prefix,
             version.major.to_s.rjust(@major_digits, '0'),

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -11,10 +11,10 @@ module Fastlane
         # Initialize the formatter with configurable prefix and digit counts.
         #
         # @param [String] prefix The prefix to use for the build code. Must be a single digit (0-9), or empty string / nil.
-        # @param [Integer] major_digits Number of digits for major version. Defaults to 2.
-        # @param [Integer] minor_digits Number of digits for minor version. Defaults to 2.
-        # @param [Integer] patch_digits Number of digits for patch version. Defaults to 2.
-        # @param [Integer] build_digits Number of digits for build number. Defaults to 2.
+        # @param [Integer] major_digits Number of digits for major version. Must be between 1–3. Defaults to 2.
+        # @param [Integer] minor_digits Number of digits for minor version. Must be between 1–3. Defaults to 2.
+        # @param [Integer] patch_digits Number of digits for patch version. Must be between 1–3. Defaults to 2.
+        # @param [Integer] build_digits Number of digits for build number. Must be between 1–3. Defaults to 2.
         #
         def initialize(prefix: nil, major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
           prefix ||= ''

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -20,7 +20,7 @@ module Fastlane
         #
         def initialize(prefix: nil, major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
           validate_prefix!(prefix)
-          @prefix = (prefix || '').to_s
+          @prefix = prefix.to_s
 
           @digit_counts = [major_digits, minor_digits, patch_digits, build_digits]
           @digit_counts.each { |d| validate_digit_count!(d) }

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -19,17 +19,12 @@ module Fastlane
         def initialize(prefix: nil, major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
           prefix ||= ''
           validate_prefix!(prefix)
-          validate_digit_count!(major_digits)
-          validate_digit_count!(minor_digits)
-          validate_digit_count!(patch_digits)
-          validate_digit_count!(build_digits)
-          validate_total_digits!(major_digits, minor_digits, patch_digits, build_digits)
+
+          @digit_counts = [major_digits, minor_digits, patch_digits, build_digits]
+          @digit_counts.each { |d| validate_digit_count!(d) }
+          validate_total_digits!(@digit_counts)
 
           @prefix = prefix.to_s
-          @major_digits = major_digits
-          @minor_digits = minor_digits
-          @patch_digits = patch_digits
-          @build_digits = build_digits
         end
 
         # Calculate the next derived build code.
@@ -44,22 +39,16 @@ module Fastlane
         #
         # @return [String] The formatted build code string.
         #
-        def build_code(build_code = nil, version:)
-          # Validate that version components fit within their configured digit limits
-          validate_version_component_fits!(component_value: version.major, digit_limit: @major_digits)
-          validate_version_component_fits!(component_value: version.minor, digit_limit: @minor_digits)
-          validate_version_component_fits!(component_value: version.patch, digit_limit: @patch_digits)
-          validate_version_component_fits!(component_value: version.build_number, digit_limit: @build_digits)
-
-          result = [
-            @prefix,
-            version.major.to_s.rjust(@major_digits, '0'),
-            version.minor.to_s.rjust(@minor_digits, '0'),
-            version.patch.to_s.rjust(@patch_digits, '0'),
-            version.build_number.to_s.rjust(@build_digits, '0'),
-          ].join
-
-          result.gsub(/^0+/, '')
+        def build_code(_build_code = nil, version:)
+          formatted_components = version.components.zip(@digit_counts).map do |value, width|
+            comp = value.to_s.rjust(width, '0')
+            if comp.length > width
+              UI.user_error!("Version component value (#{value}) exceeds maximum allowed width of #{width} characters. " \
+                             "Consider increasing the corresponding `*_digits` parameter of your `#{self.class.name}`")
+            end
+            comp
+          end
+          [@prefix, *formatted_components].join.gsub(/^0+/, '')
         end
 
         private
@@ -106,31 +95,14 @@ module Fastlane
 
         # Validates that the total number of digits (excluding prefix) doesn't exceed the maximum for multiplatform compatibility.
         #
-        def validate_total_digits!(major_digits, minor_digits, patch_digits, build_digits)
-          total_digits = major_digits + minor_digits + patch_digits + build_digits
+        def validate_total_digits!(digits_list)
+          total_digits = digits_list.sum
 
           # Limit total digits to 8 (excluding prefix)
           return if total_digits <= MAX_TOTAL_DIGITS
 
           UI.user_error!("Total digit count (#{total_digits}) exceeds maximum allowed (#{MAX_TOTAL_DIGITS}). " \
-                         "Current config: major(#{major_digits}) + minor(#{minor_digits}) + patch(#{patch_digits}) + build(#{build_digits}) digits")
-        end
-
-        # Validates that a version component value fits within its configured digit limit.
-        #
-        # @param [Integer] component_value The version component value to validate
-        # @param [Integer] digit_limit The maximum number of digits allowed for this component
-        #
-        # @raise [StandardError] If the component value exceeds the digit limit
-        #
-        def validate_version_component_fits!(component_value:, digit_limit:)
-          # Calculate the maximum value that fits in the digit limit
-          max_value = (10**digit_limit) - 1
-
-          return if component_value <= max_value
-
-          UI.user_error!("Version component value (#{component_value}) exceeds maximum allowed " \
-                         "for #{digit_limit} digit(s) (max: #{max_value}). Consider increasing the corresponding _digits parameter.")
+                         "Current config: major(#{digits_list[0]}) + minor(#{digits_list[1]}) + patch(#{digits_list[2]}) + build(#{digits_list[3]}) digits")
         end
       end
     end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -4,6 +4,8 @@ module Fastlane
   module Wpmreleasetoolkit
     module Versioning
       MAX_TOTAL_DIGITS = 8
+      MIN_DIGIT_COUNT = 1
+      MAX_DIGIT_COUNT = 3
 
       # The `DerivedBuildCodeFormatter` class is a specialized build code formatter for derived build codes.
       # It takes in an AppVersion object and derives a build code from it.
@@ -87,9 +89,9 @@ module Fastlane
             UI.user_error!("Digit count must be an integer, got: #{digit_count.class}")
           end
 
-          return if digit_count.between?(1, 3)
+          return if digit_count.between?(MIN_DIGIT_COUNT, MAX_DIGIT_COUNT)
 
-          UI.user_error!("Digit count must be between 1 and 3 digits, got: #{digit_count}")
+          UI.user_error!("Digit count must be between #{MIN_DIGIT_COUNT} and #{MAX_DIGIT_COUNT} digits, got: #{digit_count}")
         end
 
         # Validates that the total number of digits (excluding prefix) doesn't exceed the maximum for multiplatform compatibility.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -19,12 +19,11 @@ module Fastlane
         def initialize(prefix: nil, major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
           prefix ||= ''
           validate_prefix!(prefix)
+          @prefix = prefix.to_s
 
           @digit_counts = [major_digits, minor_digits, patch_digits, build_digits]
           @digit_counts.each { |d| validate_digit_count!(d) }
           validate_total_digits!(@digit_counts)
-
-          @prefix = prefix.to_s
         end
 
         # Calculate the next derived build code.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -3,7 +3,7 @@
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning
-      MAX_TOTAL_DIGITS = 9
+      MAX_TOTAL_DIGITS = 8
 
       # The `DerivedBuildCodeFormatter` class is a specialized build code formatter for derived build codes.
       # It takes in an AppVersion object and derives a build code from it.
@@ -107,7 +107,7 @@ module Fastlane
         def validate_total_digits!(major_digits, minor_digits, patch_digits, build_digits)
           total_digits = major_digits + minor_digits + patch_digits + build_digits
 
-          # Limit total digits to 9 (excluding prefix)
+          # Limit total digits to 8 (excluding prefix)
           return if total_digits <= MAX_TOTAL_DIGITS
 
           UI.user_error!("Total digit count (#{total_digits}) exceeds maximum allowed (#{MAX_TOTAL_DIGITS}). " \

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -3,6 +3,7 @@
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning
+       # Max total for `*_digits` params, not counting prefix
       MAX_TOTAL_DIGITS = 8
       MIN_DIGIT_COUNT = 1
       MAX_DIGIT_COUNT = 3
@@ -99,6 +100,8 @@ module Fastlane
 
         # Validates that the total number of digits (excluding prefix) doesn't exceed the maximum for multiplatform compatibility.
         #
+        # Since Google Play's max versionCode is ≈ 2_000_000_000, we want to avoid being too close to the limit
+        # as this would then block us from submitting any updates for that app if we reached it.
         def validate_total_digits!(digits_list)
           total_digits = digits_list.sum
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -3,7 +3,7 @@
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning
-       # Max total for `*_digits` params, not counting prefix
+      # Max total for `*_digits` params, not counting prefix
       MAX_TOTAL_DIGITS = 8
       MIN_DIGIT_COUNT = 1
       MAX_DIGIT_COUNT = 3

--- a/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/versioning/formatters/derived_build_code_formatter.rb
@@ -3,23 +3,39 @@
 module Fastlane
   module Wpmreleasetoolkit
     module Versioning
+      MAX_TOTAL_DIGITS = 9
+
       # The `DerivedBuildCodeFormatter` class is a specialized build code formatter for derived build codes.
       # It takes in an AppVersion object and derives a build code from it.
       class DerivedBuildCodeFormatter
-        # Initialize the formatter with a configurable prefix.
+        # Initialize the formatter with configurable prefix and digit counts.
         #
         # @param [String] prefix The prefix to use for the build code. Must be a single digit (0-9), or the empty string. Defaults to '1' for backward compatibility.
+        # @param [Integer] major_digits Number of digits for major version. Defaults to 2.
+        # @param [Integer] minor_digits Number of digits for minor version. Defaults to 2.
+        # @param [Integer] patch_digits Number of digits for patch version. Defaults to 2.
+        # @param [Integer] build_digits Number of digits for build number. Defaults to 2.
         #
-        def initialize(prefix: '1')
+        def initialize(prefix: '1', major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
           prefix ||= ''
           validate_prefix!(prefix)
+          validate_digit_count!(major_digits)
+          validate_digit_count!(minor_digits)
+          validate_digit_count!(patch_digits)
+          validate_digit_count!(build_digits)
+          validate_total_digits!(major_digits, minor_digits, patch_digits, build_digits)
+
           @prefix = prefix.to_s
+          @major_digits = major_digits
+          @minor_digits = minor_digits
+          @patch_digits = patch_digits
+          @build_digits = build_digits
         end
 
         # Calculate the next derived build code.
         #
         # This method derives a new build code from the given AppVersion object by concatenating the configured prefix,
-        # the major version, the minor version, the patch version, and the build number.
+        # the major version, the minor version, the patch version, and the build number with configurable digit counts.
         #
         # @param [AppVersion] version The AppVersion object to derive the next build code from.
         #
@@ -29,10 +45,11 @@ module Fastlane
         # @return [String] The formatted build code string.
         #
         def build_code(build_code = nil, version:)
+          # Build dynamic format string based on configured digit counts
+          format_string = "%<prefix>s%<major>.#{@major_digits}i%<minor>.#{@minor_digits}i%<patch>.#{@patch_digits}i%<build_number>.#{@build_digits}i"
+
           result = format(
-            # The prefix is configurable to allow for additional platforms or
-            # extensions that could use a different digit prefix such as 2, etc.
-            '%<prefix>s%<major>.2i%<minor>.2i%<patch>.2i%<build_number>.2i',
+            format_string,
             prefix: @prefix,
             major: version.major,
             minor: version.minor,
@@ -66,6 +83,35 @@ module Fastlane
           return if ('0'..'9').include?(prefix_str)
 
           UI.user_error!("Prefix must be an integer digit (0-9) or empty string, got: '#{prefix_str}'")
+        end
+
+        # Validates that the digit count is a valid positive integer within reasonable limits.
+        #
+        # @param [Integer] digit_count The digit count to validate
+        #
+        # @raise [StandardError] If the digit count is invalid
+        #
+        def validate_digit_count!(digit_count)
+          # Check if it's an integer
+          unless digit_count.is_a?(Integer)
+            UI.user_error!("Digit count must be an integer, got: #{digit_count.class}")
+          end
+
+          return if digit_count.between?(1, 3)
+
+          UI.user_error!("Digit count must be between 1 and 3 digits, got: #{digit_count}")
+        end
+
+        # Validates that the total number of digits (excluding prefix) doesn't exceed the maximum for multiplatform compatibility.
+        #
+        def validate_total_digits!(major_digits, minor_digits, patch_digits, build_digits)
+          total_digits = major_digits + minor_digits + patch_digits + build_digits
+
+          # Limit total digits to 9 (excluding prefix)
+          return if total_digits <= MAX_TOTAL_DIGITS
+
+          UI.user_error!("Total digit count (#{total_digits}) exceeds maximum allowed (#{MAX_TOTAL_DIGITS}). " \
+                         "Current config: major(#{major_digits}) + minor(#{minor_digits}) + patch(#{patch_digits}) + build(#{build_digits}) digits")
         end
       end
     end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -223,4 +223,80 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
       end
     end
   end
+
+  describe 'version component validation' do
+    context 'with valid version components within digit limits' do
+      it 'accepts version components that fit within their digit limits' do
+        formatter = described_class.new(major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 3)
+
+        # Valid cases: major=9 (1 digit), minor=99 (2 digits), patch=99 (2 digits), build=999 (3 digits)
+        version = Fastlane::Models::AppVersion.new(9, 99, 99, 999)
+        expect { formatter.build_code(version: version) }.not_to raise_error
+      end
+
+      it 'accepts version components at exactly the digit limit' do
+        formatter = described_class.new(major_digits: 2, minor_digits: 1, patch_digits: 3, build_digits: 2)
+
+        # Edge cases: exactly at limits
+        version = Fastlane::Models::AppVersion.new(99, 9, 999, 99)
+        expect { formatter.build_code(version: version) }.not_to raise_error
+      end
+    end
+
+    context 'with invalid version components exceeding digit limits' do
+      it 'rejects major version exceeding digit limit' do
+        formatter = described_class.new(major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 2)
+        version = Fastlane::Models::AppVersion.new(10, 1, 1, 1) # major=10 > max(9) for 1 digit
+
+        expect { formatter.build_code(version: version) }.to raise_error(
+          /Version component value \(10\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+        )
+      end
+
+      it 'rejects minor version exceeding digit limit' do
+        formatter = described_class.new(major_digits: 2, minor_digits: 1, patch_digits: 2, build_digits: 2)
+        version = Fastlane::Models::AppVersion.new(1, 23, 4, 5) # minor=23 > max(9) for 1 digit
+
+        expect { formatter.build_code(version: version) }.to raise_error(
+          /Version component value \(23\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+        )
+      end
+
+      it 'rejects patch version exceeding digit limit' do
+        formatter = described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 1, build_digits: 2)
+        version = Fastlane::Models::AppVersion.new(1, 2, 34, 5) # patch=34 > max(9) for 1 digit
+
+        expect { formatter.build_code(version: version) }.to raise_error(
+          /Version component value \(34\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+        )
+      end
+
+      it 'rejects build number exceeding digit limit' do
+        formatter = described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 1)
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 46) # build_number=46 > max(9) for 1 digit
+
+        expect { formatter.build_code(version: version) }.to raise_error(
+          /Version component value \(46\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+        )
+      end
+
+      it 'provides helpful error messages with different digit limits' do
+        formatter = described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
+        version = Fastlane::Models::AppVersion.new(123, 4, 5, 6) # major=123 > max(99) for 2 digits
+
+        expect { formatter.build_code(version: version) }.to raise_error(
+          /Version component value \(123\) exceeds maximum allowed for 2 digit\(s\) \(max: 99\).*Consider increasing the corresponding _digits parameter/
+        )
+      end
+
+      it 'validates the first component that exceeds limits' do
+        formatter = described_class.new(major_digits: 1, minor_digits: 1, patch_digits: 1, build_digits: 1)
+        version = Fastlane::Models::AppVersion.new(12, 34, 56, 78) # All exceed 1 digit limit, but major is checked first
+
+        expect { formatter.build_code(version: version) }.to raise_error(
+          /Version component value \(12\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+        )
+      end
+    end
+  end
 end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -149,16 +149,16 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
     context 'with valid digit counts' do
       it 'accepts digit counts from 1 to 3 individually' do
         (1..3).each do |count|
-          # Test each parameter individually with safe defaults for others
-          expect { described_class.new(major_digits: count) }.not_to raise_error
-          expect { described_class.new(minor_digits: count) }.not_to raise_error
-          expect { described_class.new(patch_digits: count) }.not_to raise_error
-          expect { described_class.new(build_digits: count) }.not_to raise_error
+          # Test each parameter individually with safe defaults for others that stay within 8 digit limit
+          expect { described_class.new(major_digits: count, minor_digits: 1, patch_digits: 1, build_digits: 1) }.not_to raise_error
+          expect { described_class.new(major_digits: 1, minor_digits: count, patch_digits: 1, build_digits: 1) }.not_to raise_error
+          expect { described_class.new(major_digits: 1, minor_digits: 1, patch_digits: count, build_digits: 1) }.not_to raise_error
+          expect { described_class.new(major_digits: 1, minor_digits: 1, patch_digits: 1, build_digits: count) }.not_to raise_error
         end
       end
 
-      it 'accepts mixed valid digit counts within 9 total digits' do
-        # 1 + 2 + 2 + 3 = 8 digits <= 9
+      it 'accepts mixed valid digit counts within 8 total digits' do
+        # 1 + 2 + 2 + 3 = 8 digits <= 8
         expect { described_class.new(major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 3) }.not_to raise_error
       end
     end
@@ -177,16 +177,18 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         expect { described_class.new(patch_digits: nil) }.to raise_error(/Digit count must be an integer, got: NilClass/)
       end
 
-      it 'rejects configurations exceeding 9 total digits' do
-        # 3 + 3 + 3 + 3 = 12 digits > 9
-        expect { described_class.new(major_digits: 3, minor_digits: 3, patch_digits: 3, build_digits: 3) }.to raise_error(/Total digit count \(12\) exceeds maximum allowed \(9\)/)
+      it 'rejects configurations exceeding 8 total digits' do
+        # 3 + 3 + 3 + 3 = 12 digits > 8
+        expect { described_class.new(major_digits: 3, minor_digits: 3, patch_digits: 3, build_digits: 3) }.to raise_error(/Total digit count \(12\) exceeds maximum allowed \(8\)/)
+        # 2 + 2 + 2 + 3 = 9 digits > 8
+        expect { described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 3) }.to raise_error(/Total digit count \(9\) exceeds maximum allowed \(8\)/)
       end
 
-      it 'accepts configurations within and at 9 total digit limit' do
-        # 2 + 2 + 2 + 2 = 8 digits <= 9 (default config)
+      it 'accepts configurations within and at 8 total digit limit' do
+        # 2 + 2 + 2 + 2 = 8 digits <= 8 (default config)
         expect { described_class.new }.not_to raise_error
-        # 2 + 2 + 2 + 3 = 9 digits = 9 (at limit)
-        expect { described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 3) }.not_to raise_error
+        # 2 + 2 + 2 + 2 = 8 digits = 8 (at limit)
+        expect { described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2) }.not_to raise_error
       end
     end
   end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -19,13 +19,6 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
     end
 
     context 'with explicit prefix' do
-      it 'derives the build code with prefix "1"' do
-        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
-        formatter = described_class.new(prefix: '1')
-        build_code_string = formatter.build_code(version: version)
-        expect(build_code_string.to_s).to eq('101020304')
-      end
-
       it 'derives the build code with prefix "2"' do
         version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
         formatter = described_class.new(prefix: '2')
@@ -33,7 +26,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         expect(build_code_string.to_s).to eq('201020304')
       end
 
-      it 'derives the build code with prefix "0"' do
+      it 'derives the build code with prefix "0" and trims leading zeros' do
         version = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
         formatter = described_class.new(prefix: '0')
         build_code_string = formatter.build_code(version: version)
@@ -81,6 +74,123 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
     end
   end
 
+  describe 'configurable digit counts' do
+    context 'with custom digit counts' do
+      it 'uses 1 digit for each component' do
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        formatter = described_class.new(prefix: '1', major_digits: 1, minor_digits: 1, patch_digits: 1, build_digits: 1)
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('11234')
+      end
+
+      it 'uses 2 digits for each component and pads with zeros' do
+        # Test both large numbers and zero-padding in one test
+        version_large = Fastlane::Models::AppVersion.new(12, 34, 56, 78)
+        formatter = described_class.new(prefix: '2', major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
+        expect(formatter.build_code(version: version_large).to_s).to eq('212345678')
+
+        # Test zero-padding with smaller numbers
+        version_small = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        expect(formatter.build_code(version: version_small).to_s).to eq('201020304')
+      end
+
+      it 'uses mixed digit counts' do
+        version = Fastlane::Models::AppVersion.new(1, 23, 45, 678)
+        formatter = described_class.new(prefix: '', major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 3)
+        build_code_string = formatter.build_code(version: version)
+        # 1(1 digit) + 23(2 digits) + 45(2 digits) + 678(3 digits) = "12345678"
+        expect(build_code_string.to_s).to eq('12345678')
+      end
+
+      it 'handles maximum values within digit limits' do
+        version = Fastlane::Models::AppVersion.new(99, 99, 99, 99)
+        formatter = described_class.new(prefix: '1', major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('199999999')
+      end
+    end
+
+    context 'with empty prefix and custom digits' do
+      it 'trims leading zeros correctly with 1-digit major' do
+        version = Fastlane::Models::AppVersion.new(5, 12, 34, 56)
+        formatter = described_class.new(prefix: '', major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 2)
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('5123456')
+      end
+
+      it 'trims leading zeros correctly with larger major' do
+        version = Fastlane::Models::AppVersion.new(7, 8, 9, 10)
+        formatter = described_class.new(prefix: '', major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
+        build_code_string = formatter.build_code(version: version)
+        expect(build_code_string.to_s).to eq('7080910')
+      end
+
+      it 'handles edge case where all components start with zeros' do
+        version = Fastlane::Models::AppVersion.new(0, 1, 2, 3)
+        formatter = described_class.new(prefix: '', major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
+        build_code_string = formatter.build_code(version: version)
+        # ''(empty prefix) + '00'(2 digits) + '01'(2 digits) + '02'(2 digits) + '03'(2 digits) = "00010203", trimmed to "10203"
+        expect(build_code_string.to_s).to eq('10203')
+      end
+    end
+
+    context 'with backward compatibility (default 2 digits)' do
+      it 'maintains existing behavior when no digit parameters specified' do
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 4)
+        formatter_old = described_class.new(prefix: '1')
+        formatter_new = described_class.new(prefix: '1', major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
+
+        expect(formatter_old.build_code(version: version)).to eq(formatter_new.build_code(version: version))
+      end
+    end
+  end
+
+  describe 'digit count validation' do
+    context 'with valid digit counts' do
+      it 'accepts digit counts from 1 to 3 individually' do
+        (1..3).each do |count|
+          # Test each parameter individually with safe defaults for others
+          expect { described_class.new(major_digits: count) }.not_to raise_error
+          expect { described_class.new(minor_digits: count) }.not_to raise_error
+          expect { described_class.new(patch_digits: count) }.not_to raise_error
+          expect { described_class.new(build_digits: count) }.not_to raise_error
+        end
+      end
+
+      it 'accepts mixed valid digit counts within 9 total digits' do
+        # 1 + 2 + 2 + 3 = 8 digits <= 9
+        expect { described_class.new(major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 3) }.not_to raise_error
+      end
+    end
+
+    context 'with invalid digit counts' do
+      it 'rejects digit counts outside valid range (1-3)' do
+        expect { described_class.new(major_digits: 0) }.to raise_error(/Digit count must be between 1 and 3/)
+        expect { described_class.new(minor_digits: -1) }.to raise_error(/Digit count must be between 1 and 3/)
+        expect { described_class.new(patch_digits: 4) }.to raise_error(/Digit count must be between 1 and 3/)
+      end
+
+      it 'rejects non-integer digit counts' do
+        expect { described_class.new(build_digits: '3') }.to raise_error(/Digit count must be an integer, got: String/)
+        expect { described_class.new(major_digits: 2.5) }.to raise_error(/Digit count must be an integer, got: Float/)
+        expect { described_class.new(minor_digits: 1.0) }.to raise_error(/Digit count must be an integer, got: Float/)
+        expect { described_class.new(patch_digits: nil) }.to raise_error(/Digit count must be an integer, got: NilClass/)
+      end
+
+      it 'rejects configurations exceeding 9 total digits' do
+        # 3 + 3 + 3 + 3 = 12 digits > 9
+        expect { described_class.new(major_digits: 3, minor_digits: 3, patch_digits: 3, build_digits: 3) }.to raise_error(/Total digit count \(12\) exceeds maximum allowed \(9\)/)
+      end
+
+      it 'accepts configurations within and at 9 total digit limit' do
+        # 2 + 2 + 2 + 2 = 8 digits <= 9 (default config)
+        expect { described_class.new }.not_to raise_error
+        # 2 + 2 + 2 + 3 = 9 digits = 9 (at limit)
+        expect { described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 3) }.not_to raise_error
+      end
+    end
+  end
+
   describe 'prefix validation' do
     context 'with valid prefixes' do
       it 'accepts single digits 0-9' do
@@ -99,22 +209,15 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
     end
 
     context 'with invalid prefixes' do
-      it 'rejects multi-character strings' do
+      it 'rejects invalid prefix formats' do
+        # Multi-character strings and out-of-range numbers
         expect { described_class.new(prefix: '12') }.to raise_error(/Prefix must be a single digit or empty string/)
-      end
-
-      it 'rejects non-numeric strings' do
-        expect { described_class.new(prefix: 'a') }.to raise_error(/Prefix must be an integer digit/)
-      end
-
-      it 'rejects numbers outside 0-9 range' do
         expect { described_class.new(prefix: '10') }.to raise_error(/Prefix must be a single digit or empty string/)
         expect { described_class.new(prefix: '-1') }.to raise_error(/Prefix must be a single digit or empty string/)
-      end
 
-      it 'rejects symbols and special characters' do
+        # Non-numeric characters
+        expect { described_class.new(prefix: 'a') }.to raise_error(/Prefix must be an integer digit/)
         expect { described_class.new(prefix: '@') }.to raise_error(/Prefix must be an integer digit/)
-        expect { described_class.new(prefix: '#') }.to raise_error(/Prefix must be an integer digit/)
       end
     end
   end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -249,7 +249,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         version = Fastlane::Models::AppVersion.new(10, 1, 1, 1) # major=10 > max(9) for 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
-          /Version component value \(10\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+          /Version component value \(10\) exceeds maximum allowed width of 1 characters/
         )
       end
 
@@ -258,7 +258,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         version = Fastlane::Models::AppVersion.new(1, 23, 4, 5) # minor=23 > max(9) for 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
-          /Version component value \(23\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+          /Version component value \(23\) exceeds maximum allowed width of 1 characters/
         )
       end
 
@@ -267,7 +267,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         version = Fastlane::Models::AppVersion.new(1, 2, 34, 5) # patch=34 > max(9) for 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
-          /Version component value \(34\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+          /Version component value \(34\) exceeds maximum allowed width of 1 characters/
         )
       end
 
@@ -276,7 +276,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         version = Fastlane::Models::AppVersion.new(1, 2, 3, 46) # build_number=46 > max(9) for 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
-          /Version component value \(46\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+          /Version component value \(46\) exceeds maximum allowed width of 1 characters/
         )
       end
 
@@ -285,7 +285,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         version = Fastlane::Models::AppVersion.new(123, 4, 5, 6) # major=123 > max(99) for 2 digits
 
         expect { formatter.build_code(version: version) }.to raise_error(
-          /Version component value \(123\) exceeds maximum allowed for 2 digit\(s\) \(max: 99\).*Consider increasing the corresponding _digits parameter/
+          /Version component value \(123\) exceeds maximum allowed width of 2 characters.*Consider increasing the corresponding `\*_digits` parameter/
         )
       end
 
@@ -294,7 +294,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         version = Fastlane::Models::AppVersion.new(12, 34, 56, 78) # All exceed 1 digit limit, but major is checked first
 
         expect { formatter.build_code(version: version) }.to raise_error(
-          /Version component value \(12\) exceeds maximum allowed for 1 digit\(s\) \(max: 9\)/
+          /Version component value \(12\) exceeds maximum allowed width of 1 characters/
         )
       end
     end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -269,7 +269,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
 
       it 'rejects minor version exceeding digit limit' do
         formatter = described_class.new(major_digits: 2, minor_digits: 1, patch_digits: 2, build_digits: 2)
-        version = Fastlane::Models::AppVersion.new(1, 23, 4, 5) # minor=23 > max(9) for 1 digit
+        version = Fastlane::Models::AppVersion.new(1, 23, 4, 5) # minor=23 is longer than 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
           /Version component value \(23\) exceeds maximum allowed width of 1 characters/
@@ -278,7 +278,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
 
       it 'rejects patch version exceeding digit limit' do
         formatter = described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 1, build_digits: 2)
-        version = Fastlane::Models::AppVersion.new(1, 2, 34, 5) # patch=34 > max(9) for 1 digit
+        version = Fastlane::Models::AppVersion.new(1, 2, 34, 5) # patch=34 is longer than 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
           /Version component value \(34\) exceeds maximum allowed width of 1 characters/
@@ -287,7 +287,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
 
       it 'rejects build number exceeding digit limit' do
         formatter = described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 1)
-        version = Fastlane::Models::AppVersion.new(1, 2, 3, 46) # build_number=46 > max(9) for 1 digit
+        version = Fastlane::Models::AppVersion.new(1, 2, 3, 46) # build_number=46 is longer than 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
           /Version component value \(46\) exceeds maximum allowed width of 1 characters/
@@ -296,7 +296,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
 
       it 'provides helpful error messages with different digit limits' do
         formatter = described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
-        version = Fastlane::Models::AppVersion.new(123, 4, 5, 6) # major=123 > max(99) for 2 digits
+        version = Fastlane::Models::AppVersion.new(123, 4, 5, 6) # major=123 is longer than 2 digits
 
         expect { formatter.build_code(version: version) }.to raise_error(
           /Version component value \(123\) exceeds maximum allowed width of 2 characters.*Consider increasing the corresponding `\*_digits` parameter/

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -146,6 +146,9 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
   end
 
   describe 'digit count validation' do
+    # Generate all combinations of [1,2,3] for each of the 4 digit count parameters
+    all_digit_combinations = Array.new(4, [1, 2, 3]).reduce(&:product).map(&:flatten)
+
     context 'with valid digit counts' do
       it 'accepts digit counts from 1 to 3 individually' do
         (1..3).each do |count|
@@ -157,9 +160,12 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         end
       end
 
-      it 'accepts mixed valid digit counts within 8 total digits' do
-        # 1 + 2 + 2 + 3 = 8 digits <= 8
-        expect { described_class.new(major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 3) }.not_to raise_error
+      context 'with mixed valid digit counts within 8 total digits' do
+        all_digit_combinations.select { |combination| combination.sum <= 8 }.each do |major, minor, patch, build|
+          it "accepts #{major},#{minor},#{patch},#{build} digit combination" do
+            expect { described_class.new(major_digits: major, minor_digits: minor, patch_digits: patch, build_digits: build) }.not_to raise_error
+          end
+        end
       end
     end
 
@@ -177,18 +183,12 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         expect { described_class.new(patch_digits: nil) }.to raise_error(/Digit count must be an integer, got: NilClass/)
       end
 
-      it 'rejects configurations exceeding 8 total digits' do
-        # 3 + 3 + 3 + 3 = 12 digits > 8
-        expect { described_class.new(major_digits: 3, minor_digits: 3, patch_digits: 3, build_digits: 3) }.to raise_error(/Total digit count \(12\) exceeds maximum allowed \(8\)/)
-        # 2 + 2 + 2 + 3 = 9 digits > 8
-        expect { described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 3) }.to raise_error(/Total digit count \(9\) exceeds maximum allowed \(8\)/)
-      end
-
-      it 'accepts configurations within and at 8 total digit limit' do
-        # 2 + 2 + 2 + 2 = 8 digits <= 8 (default config)
-        expect { described_class.new }.not_to raise_error
-        # 2 + 2 + 2 + 2 = 8 digits = 8 (at limit)
-        expect { described_class.new(major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2) }.not_to raise_error
+      context 'with configurations exceeding 8 total digits' do
+        all_digit_combinations.select { |combination| combination.sum > 8 }.each do |major, minor, patch, build|
+          it "rejects #{major},#{minor},#{patch},#{build} digit combination (total: #{major + minor + patch + build})" do
+            expect { described_class.new(major_digits: major, minor_digits: minor, patch_digits: patch, build_digits: build) }.to raise_error(/Total digit count \(#{major + minor + patch + build}\) exceeds maximum allowed \(8\)/)
+          end
+        end
       end
     end
   end
@@ -208,6 +208,10 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
       it 'accepts integer inputs' do
         expect { described_class.new(prefix: 5) }.not_to raise_error
       end
+
+      it 'accepts nil prefix' do
+        expect { described_class.new(prefix: nil) }.not_to raise_error
+      end
     end
 
     context 'with invalid prefixes' do
@@ -220,6 +224,16 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         # Non-numeric characters
         expect { described_class.new(prefix: 'a') }.to raise_error(/Prefix must be an integer digit/)
         expect { described_class.new(prefix: '@') }.to raise_error(/Prefix must be an integer digit/)
+      end
+
+      it 'rejects non-string and non-integer prefix types' do
+        # Arrays, hashes, and other objects
+        expect { described_class.new(prefix: []) }.to raise_error(/Prefix must be a string or integer/)
+        expect { described_class.new(prefix: {}) }.to raise_error(/Prefix must be a string or integer/)
+        expect { described_class.new(prefix: Object.new) }.to raise_error(/Prefix must be a string or integer/)
+        expect { described_class.new(prefix: true) }.to raise_error(/Prefix must be a string or integer/)
+        expect { described_class.new(prefix: false) }.to raise_error(/Prefix must be a string or integer/)
+        expect { described_class.new(prefix: 3.14) }.to raise_error(/Prefix must be a string or integer/)
       end
     end
   end

--- a/spec/derived_build_code_formatter_spec.rb
+++ b/spec/derived_build_code_formatter_spec.rb
@@ -118,7 +118,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
         expect(build_code_string.to_s).to eq('5123456')
       end
 
-      it 'trims leading zeros correctly with larger major' do
+      it 'trims leading zeros correctly with larger number of major digits' do
         version = Fastlane::Models::AppVersion.new(7, 8, 9, 10)
         formatter = described_class.new(prefix: '', major_digits: 2, minor_digits: 2, patch_digits: 2, build_digits: 2)
         build_code_string = formatter.build_code(version: version)
@@ -225,7 +225,7 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
   end
 
   describe 'version component validation' do
-    context 'with valid version components within digit limits' do
+    context 'with version components within digit limits' do
       it 'accepts version components that fit within their digit limits' do
         formatter = described_class.new(major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 3)
 
@@ -243,10 +243,10 @@ describe Fastlane::Wpmreleasetoolkit::Versioning::DerivedBuildCodeFormatter do
       end
     end
 
-    context 'with invalid version components exceeding digit limits' do
+    context 'with version components exceeding digit limits' do
       it 'rejects major version exceeding digit limit' do
         formatter = described_class.new(major_digits: 1, minor_digits: 2, patch_digits: 2, build_digits: 2)
-        version = Fastlane::Models::AppVersion.new(10, 1, 1, 1) # major=10 > max(9) for 1 digit
+        version = Fastlane::Models::AppVersion.new(10, 1, 1, 1) # major=10 is longer than 1 digit
 
         expect { formatter.build_code(version: version) }.to raise_error(
           /Version component value \(10\) exceeds maximum allowed width of 1 characters/


### PR DESCRIPTION
## What does it do?

This PR adds to the `DerivedBuildCodeFormatter` class the possibility to configure a variable number of digits per version components, so that we have more flexibility to increase the maximum number of builds per a specific major / minor version, for example.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
