### PR TITLE
Release 13.4.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ _None_
 
 ### New Features
 
-- Add the possibility to configure in `DerivedBuildCodeFormatter` a versioning prefix instead of always defaulting to 1. [#656]
-- Add configurable number of digits in version components in `DerivedBuildCodeFormatter`. [#657]
+_None_
 
 ### Bug Fixes
 
@@ -20,6 +19,13 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 13.4.0
+
+### New Features
+
+- Add the possibility to configure in `DerivedBuildCodeFormatter` a versioning prefix instead of always defaulting to 1. [#656]
+- Add configurable number of digits in version components in `DerivedBuildCodeFormatter`. [#657]
 
 ## 13.3.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.3.1)
+    fastlane-plugin-wpmreleasetoolkit (13.4.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.3.1'
+    VERSION = '13.4.0'
   end
 end


### PR DESCRIPTION
Releasing new version `13.4.0`.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- Add the possibility to configure in `DerivedBuildCodeFormatter` a versioning prefix instead of always defaulting to 1. [#656]
- Add configurable number of digits in version components in `DerivedBuildCodeFormatter`. [#657]


```
