### PR TITLE
[AINFRA-1149] `upload_build_to_apps_cdn`: Add `Microsoft Store` as allowed platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- `upload_build_to_apps_cdn`: Add support for `Microsoft Store` as an allowed value for the `platform` parameter. [#661]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
@@ -15,11 +15,35 @@ module Fastlane
     end
 
     class UploadBuildToAppsCdnAction < Action
+      # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-resource-type.php
       RESOURCE_TYPE = 'Build'
+      # These are from the WordPress.com API, not the Apps CDN plugin
       VALID_POST_STATUS = %w[publish draft].freeze
-      VALID_BUILD_TYPES = %w[Alpha Beta Nightly Production Prototype].freeze
-      VALID_PLATFORMS = ['Android', 'iOS', 'Mac - Silicon', 'Mac - Intel', 'Mac - Any', 'Windows'].freeze
-      VALID_INSTALL_TYPES = ['Full Install', 'Update'].freeze
+      # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-build-type.php
+      VALID_BUILD_TYPES = %w[
+        Alpha
+        Beta
+        Nightly
+        Production
+        Prototype
+      ].freeze
+      # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-platform.php
+      VALID_PLATFORMS = [
+        'Android',
+        'iOS',
+        'Mac - Silicon',
+        'Mac - Intel',
+        'Mac - Any',
+        'Windows',
+        'Microsoft Store',
+      ].freeze
+      # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-install-type.php
+      VALID_INSTALL_TYPES = [
+        'Full Install',
+        'Update',
+      ].freeze
+      # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-visibility.php
+      VALID_VISIBILITIES = %i[internal external].freeze
 
       def self.run(params)
         UI.message('Uploading build to Apps CDN...')
@@ -179,6 +203,8 @@ module Fastlane
             type: String,
             verify_block: proc do |value|
               UI.user_error!('Product cannot be empty') if value.to_s.empty?
+              # Unlike for other parameters, we don't validate the product value against a list of valid values because we expect this list of
+              # supported products to be updated on the backend from time to time and we don't want to have to update the toolkit every time for it.
             end
           ),
           FastlaneCore::ConfigItem.new(
@@ -228,7 +254,7 @@ module Fastlane
             optional: false,
             type: Symbol,
             verify_block: proc do |value|
-              UI.user_error!('Visibility must be either :internal or :external') unless %i[internal external].include?(value)
+              UI.user_error!("Visibility must be one of: #{VALID_VISIBILITIES.map { "`:#{_1}`" }.join(', ')}") unless VALID_VISIBILITIES.include?(value.to_s.downcase.to_sym)
             end
           ),
           FastlaneCore::ConfigItem.new(

--- a/spec/upload_build_to_apps_cdn_spec.rb
+++ b/spec/upload_build_to_apps_cdn_spec.rb
@@ -387,7 +387,7 @@ describe Fastlane::Actions::UploadBuildToAppsCdnAction do
             version: test_version,
             file_path: file_path
           )
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Visibility must be either :internal or :external')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Visibility must be one of: `:internal`, `:external`')
       end
     end
 
@@ -421,7 +421,7 @@ describe Fastlane::Actions::UploadBuildToAppsCdnAction do
             version: test_version,
             file_path: file_path
           )
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Platform must be one of: Android, iOS, Mac - Silicon, Mac - Intel, Mac - Any, Windows')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Platform must be one of: Android, iOS, Mac - Silicon, Mac - Intel, Mac - Any, Windows, Microsoft Store')
       end
     end
 


### PR DESCRIPTION
Closes [AINFRA-1149](https://linear.app/a8c/issue/AINFRA-1149)

## What does it do?

 - Adds `Microsoft Store` as allowed platforms for the `upload_build_to_apps_cdn` action
 - Add comments pointing to the source of those allowed enum values in the backend code
 - Update Unit tests accordingly

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~