### PR TITLE
Release 13.5.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- `upload_build_to_apps_cdn`: Add support for `Microsoft Store` as an allowed value for the `platform` parameter. [#661]
+_None_
 
 ### Bug Fixes
 
@@ -19,6 +19,12 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 13.5.0
+
+### New Features
+
+- `upload_build_to_apps_cdn`: Add support for `Microsoft Store` as an allowed value for the `platform` parameter. [#661]
 
 ## 13.4.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.4.0)
+    fastlane-plugin-wpmreleasetoolkit (13.5.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.4.0'
+    VERSION = '13.5.0'
   end
 end


### PR DESCRIPTION
Releasing new version 13.5.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- `upload_build_to_apps_cdn`: Add support for `Microsoft Store` as an allowed value for the `platform` parameter. [#661]


```
