### PR TITLE
Fix milestone search queries to support fine-grained GitHub tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix GitHub API search queries to support fine-grained tokens in addition to classic tokens. Fine-grained tokens require explicit `is:issue` or `is:pull-request` qualifiers in search queries. [#TBD]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-- Fix GitHub API search queries to support fine-grained tokens in addition to classic tokens. Fine-grained tokens require explicit `is:issue` or `is:pull-request` qualifiers in search queries. [#TBD]
+- Fix GitHub API search queries to support fine-grained tokens in addition to classic tokens. Fine-grained tokens require explicit `is:issue` or `is:pull-request` qualifiers in search queries. [#663]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -44,14 +44,42 @@ module Fastlane
       # @param [String] repository The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)
       # @param [Sawyer::Resource, String] milestone The milestone object, or title of the milestone, we want to fetch the list of PRs for (e.g.: `16.9`)
       # @param [Boolean] include_closed If set to true, will include both opened and closed PRs. Otherwise, will only include opened PRs.
-      # @return [Array<Sawyer::Resource>] A list of the PRs for the given milestone, sorted by number
+      # @return [Array<Sawyer::Resource>] A list of the PRs and issues for the given milestone, sorted by number
       #
       def get_prs_and_issues_for_milestone(repository:, milestone:, include_closed: false)
+        # While the `/search` API used with a classic tokens returns both issues and PRs, using a fine-grained tokens always require either 'is:issue' or 'is:pull-request',
+        # therefore we need to make two separate calls to cover both cases
+        issues = search_milestone_items(repository: repository, milestone: milestone, type: :issue, include_closed: include_closed)
+        prs = search_milestone_items(repository: repository, milestone: milestone, type: :pr, include_closed: include_closed)
+
+        (issues + prs).sort_by(&:number)
+      end
+
+      # Search for issues or PRs for a given milestone
+      #
+      # @param [String] repository The repository name, including the organization (e.g. `wordpress-mobile/wordpress-ios`)
+      # @param [Sawyer::Resource, String] milestone The milestone object, or title of the milestone
+      # @param [Symbol] type The type of items to search for (:issue or :pr/:pull_request)
+      # @param [Boolean] include_closed If set to true, will include both opened and closed items. Otherwise, will only include opened items.
+      # @return [Array<Sawyer::Resource>] A list of issues or PRs for the given milestone
+      #
+      def search_milestone_items(repository:, milestone:, type:, include_closed: false)
         milestone_title = milestone.is_a?(Sawyer::Resource) ? milestone.title : milestone
-        query = %(repo:#{repository} milestone:"#{milestone_title}")
+
+        # Map type symbol to GitHub search qualifier
+        type_qualifier = case type
+                         when :issue
+                           'is:issue'
+                         when :pr, :pull_request
+                           'is:pull-request'
+                         else
+                           raise ArgumentError, "Invalid type: #{type}. Must be :issue or :pr"
+                         end
+
+        query = %(repo:#{repository} milestone:"#{milestone_title}" #{type_qualifier})
         query += ' is:open' unless include_closed
 
-        client.search_issues(query)[:items].sort_by(&:number)
+        client.search_issues(query)[:items]
       end
 
       # Set/Update the milestone assigned to a given PR or issue

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -220,33 +220,51 @@ describe Fastlane::Helper::GithubHelper do
     end
 
     it 'returns only opened PRs for a given milestone by default' do
-      search_results = [101, 103].map { |num| sawyer_resource_stub(number: num) }
+      issue_results = [101].map { |num| sawyer_resource_stub(number: num) }
+      pr_results = [103].map { |num| sawyer_resource_stub(number: num) }
+
       allow(client).to receive(:search_issues)
-        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:open))
-        .and_return({ items: search_results })
+        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:issue is:open))
+        .and_return({ items: issue_results })
+
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:pull-request is:open))
+        .and_return({ items: pr_results })
 
       result = helper.get_prs_and_issues_for_milestone(repository: test_repo, milestone: '12.3 New Version')
-      expect(result).to eq(search_results)
+      expect(result.map(&:number)).to eq([101, 103])
     end
 
     it 'returns only opened PRs for a given milestone if include_closed is false' do
-      search_results = [101, 103].map { |num| sawyer_resource_stub(number: num) }
+      issue_results = [101].map { |num| sawyer_resource_stub(number: num) }
+      pr_results = [103].map { |num| sawyer_resource_stub(number: num) }
+
       allow(client).to receive(:search_issues)
-        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:open))
-        .and_return({ items: search_results })
+        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:issue is:open))
+        .and_return({ items: issue_results })
+
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:pull-request is:open))
+        .and_return({ items: pr_results })
 
       result = helper.get_prs_and_issues_for_milestone(repository: test_repo, milestone: '12.3 New Version', include_closed: false)
-      expect(result).to eq(search_results)
+      expect(result.map(&:number)).to eq([101, 103])
     end
 
     it 'returns both opened and closed PRs of a milestone if include_closed is true' do
-      search_results = [101, 102, 103, 104].map { |num| sawyer_resource_stub(number: num) }
+      issue_results = [101, 102].map { |num| sawyer_resource_stub(number: num) }
+      pr_results = [103, 104].map { |num| sawyer_resource_stub(number: num) }
+
       allow(client).to receive(:search_issues)
-        .with(%(repo:#{test_repo} milestone:"12.3 New Version"))
-        .and_return({ items: search_results })
+        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:issue))
+        .and_return({ items: issue_results })
+
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} milestone:"12.3 New Version" is:pull-request))
+        .and_return({ items: pr_results })
 
       result = helper.get_prs_and_issues_for_milestone(repository: test_repo, milestone: '12.3 New Version', include_closed: true)
-      expect(result).to eq(search_results)
+      expect(result.map(&:number)).to eq([101, 102, 103, 104])
     end
   end
 

--- a/spec/update_assigned_milestone_spec.rb
+++ b/spec/update_assigned_milestone_spec.rb
@@ -72,8 +72,12 @@ describe Fastlane::Actions::UpdateAssignedMilestoneAction do
   context 'when providing a source milestone' do
     it 'updates the milestone of all matching and still-opened PRs' do
       allow(client).to receive(:search_issues)
-        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:open))
-        .and_return({ items: [101, 103].map { |n| mock_pr(n) } })
+        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:issue is:open))
+        .and_return({ items: [101].map { |n| mock_pr(n) } })
+
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:pull-request is:open))
+        .and_return({ items: [103].map { |n| mock_pr(n) } })
 
       expect(client).to receive(:update_issue).with(test_repo, 101, { milestone: 123 })
       expect(client).to receive(:update_issue).with(test_repo, 103, { milestone: 123 })
@@ -91,8 +95,13 @@ describe Fastlane::Actions::UpdateAssignedMilestoneAction do
     it 'adds a PR comment if one is provided' do
       comment = 'Updated milestone from `12.2` to `12.3`'
       allow(client).to receive(:search_issues)
-        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:open))
-        .and_return({ items: [101, 103].map { |n| mock_pr(n) } })
+        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:issue is:open))
+        .and_return({ items: [101].map { |n| mock_pr(n) } })
+
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:pull-request is:open))
+        .and_return({ items: [103].map { |n| mock_pr(n) } })
+
       allow(client).to receive(:issue_comments).and_return([])
 
       expect(client).to receive(:update_issue).with(test_repo, 101, { milestone: 123 })
@@ -113,8 +122,12 @@ describe Fastlane::Actions::UpdateAssignedMilestoneAction do
 
     it 'does not add a PR comment if comment is empty' do
       allow(client).to receive(:search_issues)
-        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:open))
-        .and_return({ items: [101, 103].map { |n| mock_pr(n) } })
+        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:issue is:open))
+        .and_return({ items: [101].map { |n| mock_pr(n) } })
+
+      allow(client).to receive(:search_issues)
+        .with(%(repo:#{test_repo} milestone:"#{mock_milestone(12.2)[:title]}" is:pull-request is:open))
+        .and_return({ items: [103].map { |n| mock_pr(n) } })
 
       expect(client).to receive(:update_issue).with(test_repo, 101, { milestone: 123 })
       expect(client).to receive(:update_issue).with(test_repo, 103, { milestone: 123 })


### PR DESCRIPTION
Fixes AINFRA-1359

## What does it do?

Fixes GitHub API search queries to support fine-grained tokens in addition to classic tokens.

GitHub's fine-grained tokens enforce stricter search query requirements than classic tokens. This seems to be a bug in the API as it worked fine without parameters with classic tokens, but when searching for issues and PRs in a milestone, fine-grained tokens require explicit `is:issue` or `is:pull-request` qualifiers -- it seems you cannot search for both simultaneously in a single query.

This change should maintain backward compatibility with classic tokens while adding support for fine-grained tokens. The public API remains unchanged.

## Testing

I've created a simple test lane locally on WooAndroid to test the updated action:
<details>
<summary> See test lane ⬇️ </summary>

```ruby
  lane :test_milestone do
      # Move PRs to next milestone
      moved_issues = update_assigned_milestone(
        github_token: ENV['WOO_TOKEN'],
        repository: GITHUB_REPO,
        from_milestone: '0.1',
        to_milestone: '0.2',
        comment: "Test moving milestones."
      )

      UI.message("Items moved: #{moved_issues}")
  end
```

</details>

I created the test milestones `0.1` and `0.2`, assigned `0.1` to [this issue](https://github.com/woocommerce/woocommerce-android/issues/14701) and [this PR](https://github.com/woocommerce/woocommerce-android/pull/14669) and ran the lane twice: first with the fine-grained token, moving issues from `0.1` to `0.2` and then with a classic token performing the same operation again.

<details>
<summary>PR activity ⬇️</summary>
<img width="800" alt="Screenshot 2025-10-06 at 17 42 34" src="https://github.com/user-attachments/assets/8c0a5087-4f8f-48eb-971e-d3226343e894" />

</details>

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
