### PR TITLE
[AINFRA-1406] Fix deletion of intermediate branch if nothing to backmerge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix a bug in `create_release_backmerge_pull_request` when you pass a `intermediate_branch_created_callback` callback but there's ultimately nothing to merge. [#665]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_release_backmerge_pull_request_action.rb
@@ -124,6 +124,7 @@ module Fastlane
           # When a callback was provided, do the pre-check about valid PR _only_ at that point, in case the callback added new commits
           unless can_merge?(intermediate_branch, into: base_branch)
             UI.error("Nothing to merge from #{intermediate_branch} into #{base_branch}. Skipping PR creation.")
+            Action.sh('git', 'checkout', head_branch) # Switch to original branch so we can delete the intermediate branch
             Fastlane::Helper::GitHelper.delete_local_branch_if_exists!(intermediate_branch)
             return nil
           end


### PR DESCRIPTION
## What does it do?

Fixes the issue during `create_release_backmerge_pull_request` when there is nothing to backmerge but the automation already created the intermediate `merge/…` backmerge branch and is now trying to delete that branch to cancel the process and clean things up.

So far in that specific case we were still checked out on the `merge/…` intermediate when we were trying to delete that branch, but `git` doesn't allow to delete the current branch:
```

[!]     Error creating backmerge pull request:
--
  |  
  | ```
  | git '--git-dir=/opt/ci/builds/builder/automattic/day-one-ios/.git' '--work-tree=/opt/ci/builds/builder/automattic/day-one-ios' '-c' 'core.quotePath=true' '-c' 'color.ui=false' 'branch' '-D' 'merge/release-2025.21-into-trunk'  2>&1
  | status: pid 2243 exit 1
  | output: "error: cannot delete branch 'merge/release-2025.21-into-trunk' used by worktree at '/opt/ci/builds/builder/automattic/day-one-ios'\n"
```

The fix is to `git checkout` the previous branch (the head branch we were potentially trying to backmerge) before deleting the intermediate branch, so that we're sure we're not in the branch we're deleting.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [ ] ~~Add Unit Tests (aka `specs/*_spec.rb`) if applicable.~~
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] ~~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~~
