### PR TITLE
Release 13.5.2 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Fix a bug in `create_release_backmerge_pull_request` when you pass a `intermediate_branch_created_callback` callback but there's ultimately nothing to merge. [#665]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 13.5.2
+
+### Bug Fixes
+
+- Fix a bug in `create_release_backmerge_pull_request` when you pass a `intermediate_branch_created_callback` callback but there's ultimately nothing to merge. [#665]
 
 ## 13.5.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.5.1)
+    fastlane-plugin-wpmreleasetoolkit (13.5.2)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.5.1'
+    VERSION = '13.5.2'
   end
 end


### PR DESCRIPTION
Releasing new version 13.5.2.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Fix a bug in `create_release_backmerge_pull_request` when you pass a `intermediate_branch_created_callback` callback but there's ultimately nothing to merge. [#665]


```
