### PR TITLE
Release 13.5.3 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ _None_
 
 ### Internal Changes
 
+_None_
+
+## 13.5.3
+
+### Internal Changes
+
 - Extract GlotPress download and retry logic into a shared `GlotPressDownloader` helper class. [#667]
 
 ## 13.5.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.5.2)
+    fastlane-plugin-wpmreleasetoolkit (13.5.3)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.5.2'
+    VERSION = '13.5.3'
   end
 end


### PR DESCRIPTION
Releasing new version 13.5.3.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Internal Changes

- Extract GlotPress download and retry logic into a shared `GlotPressDownloader` helper class. [#667]


```
