### PR TITLE
[AINFRA-1462] Add new platforms to `upload_build_to_apps_cdn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- `upload_build_to_apps_cdn`: Update the list of valid values for `platform` to now support _both_ `x86` and `ARM64` for the `Microsoft Store` and `Windows` platforms. [#669]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
@@ -34,8 +34,10 @@ module Fastlane
         'Mac - Silicon',
         'Mac - Intel',
         'Mac - Any',
-        'Windows',
-        'Microsoft Store',
+        'Windows - x86',
+        'Windows - ARM64',
+        'Microsoft Store - x86',
+        'Microsoft Store - ARM64',
       ].freeze
       # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-install-type.php
       VALID_INSTALL_TYPES = [

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/promo_screenshots_helper.rb
@@ -4,7 +4,7 @@ require 'tmpdir'
 begin
   $skip_magick = false
   require 'RMagick'
-rescue LoadError
+rescue LoadError, RuntimeError
   $skip_magick = true
 end
 require 'json'

--- a/spec/upload_build_to_apps_cdn_spec.rb
+++ b/spec/upload_build_to_apps_cdn_spec.rb
@@ -421,7 +421,7 @@ describe Fastlane::Actions::UploadBuildToAppsCdnAction do
             version: test_version,
             file_path: file_path
           )
-        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'Platform must be one of: Android, iOS, Mac - Silicon, Mac - Intel, Mac - Any, Windows, Microsoft Store')
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, "Platform must be one of: #{described_class::VALID_PLATFORMS.join(', ')}")
       end
     end
 


### PR DESCRIPTION
Closes [AINFRA-1462](https://linear.app/a8c/issue/AINFRA-1462)

## What does it do?

Add new `Windows - ARM64` and `Microsoft Store - ARM64` platforms to `upload_build_to_apps_cdn`

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~~