### PR TITLE
Replace other_action.sh with Actions.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix NoMethodError (`undefined method 'trigger_action_by_name' for nil:NilClass`) when running `configure_setup` by replacing `other_action.sh` calls with `Actions.sh` in `configure_apply_action`. [#670]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-- Fix NoMethodError (`undefined method 'trigger_action_by_name' for nil:NilClass`) when running `configure_setup` by replacing `other_action.sh` calls with `Actions.sh` in `configure_apply_action`. [#670]
+- Fix `NoMethodError` (`undefined method 'trigger_action_by_name' for nil:NilClass`) when running `configure_setup`. [#670]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb
@@ -42,14 +42,14 @@ module Fastlane
         original_repo_ref = Fastlane::Helper::ConfigureHelper.repo_branch_name
         original_repo_ref = repo_hash if original_repo_ref.nil?
 
-        other_action.sh(command: "cd #{repository_path} && git fetch && git checkout #{file_hash}", log: false) unless repo_hash == file_hash
+        Actions.sh("cd #{repository_path} && git fetch && git checkout #{file_hash}", log: false) unless repo_hash == file_hash
 
         # Run the provided block
         yield
 
         ### Restore secrets repo to original branch.  If it was originally in a
         ### detached HEAD state, we need to use the hash since there's no branch name.
-        other_action.sh(command: "cd #{repository_path} && git checkout #{original_repo_ref}", log: false)
+        Actions.sh("cd #{repository_path} && git checkout #{original_repo_ref}", log: false)
       end
 
       ### Check with the user whether we should overwrite the file, if it exists


### PR DESCRIPTION
## What does it do?

Discussion: p1761917945519239-slack-C02KLTL3MKM

Fixes a minor issue when running `configure_setup`:

<details><summary>Stacktrace</summary>

```cmd

/Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/other_action.rb:23:in `method_missing': [!] undefined method `trigger_action_by_name' for nil:NilClass (NoMethodError)
      self.runner.trigger_action_by_name(method_sym,
                 ^^^^^^^^^^^^^^^^^^^^^^^
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-plugin-wpmreleasetoolkit-13.5.3/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb:52:in `prepare_repository'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-plugin-wpmreleasetoolkit-13.5.3/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_apply_action.rb:16:in `run'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-plugin-wpmreleasetoolkit-13.5.3/lib/fastlane/plugin/wpmreleasetoolkit/actions/configure/configure_setup_action.rb:37:in `run'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:263:in `block (2 levels) in execute_action'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/actions/actions_helper.rb:69:in `execute_action'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:255:in `block in execute_action'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:229:in `chdir'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/runner.rb:229:in `execute_action'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/one_off.rb:42:in `run'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/one_off.rb:22:in `execute'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:226:in `block (2 levels) in run'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/commander-4.6.0/lib/commander/command.rb:187:in `call'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/commander-4.6.0/lib/commander/command.rb:157:in `run'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/commander-4.6.0/lib/commander/runner.rb:444:in `run_active_command'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane_core/lib/fastlane_core/ui/fastlane_runner.rb:124:in `run!'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/commander-4.6.0/lib/commander/delegates.rb:18:in `run!'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:363:in `run'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/commands_generator.rb:43:in `start'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/cli_tools_distributor.rb:123:in `take_off'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/bin/fastlane:23:in `<top (required)>'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/bin/fastlane:25:in `load'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/bin/fastlane:25:in `<main>'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `eval'
    from /Users/wzieba/.rvm/gems/ruby-3.2.2/bin/ruby_executable_hooks:22:in `<main>'
/Users/wzieba/.rvm/gems/ruby-3.2.2/gems/fastlane-2.228.0/fastlane/lib/fastlane/other_action.rb:23:in `method_missing': undefined method `trigger_action_by_name' for nil:NilClass (NoMethodError)


```

</details> 

## Checklist before requesting a review

- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.