### PR TITLE
Release 13.6.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,25 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 13.6.0
+
+### New Features
+
 - `upload_build_to_apps_cdn`: Update the list of valid values for `platform` to now support _both_ `x86` and `ARM64` for the `Microsoft Store` and `Windows` platforms. [#669]
 
 ### Bug Fixes
 
 - Fix `NoMethodError` (`undefined method 'trigger_action_by_name' for nil:NilClass`) when running `configure_setup`. [#670]
-
-### Internal Changes
-
-_None_
 
 ## 13.5.3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.5.3)
+    fastlane-plugin-wpmreleasetoolkit (13.6.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Wpmreleasetoolkit
-    VERSION = '13.5.3'
+    VERSION = '13.6.0'
   end
 end


### PR DESCRIPTION
Releasing new version 13.6.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- `upload_build_to_apps_cdn`: Update the list of valid values for `platform` to now support _both_ `x86` and `ARM64` for the `Microsoft Store` and `Windows` platforms. [#669]

### Bug Fixes

- Fix `NoMethodError` (`undefined method 'trigger_action_by_name' for nil:NilClass`) when running `configure_setup`. [#670]


```
