### PR TITLE
[AINFRA-1462] Add x64 architecture to Windows platforms for AppsCDN action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- `upload_build_to_apps_cdn`: Update the list of valid values for `platform` to add support for `Microsoft Store - x64` and `Windows - x64`. [#672]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
@@ -35,8 +35,10 @@ module Fastlane
         'Mac - Intel',
         'Mac - Any',
         'Windows - x86',
+        'Windows - x64',
         'Windows - ARM64',
         'Microsoft Store - x86',
+        'Microsoft Store - x64',
         'Microsoft Store - ARM64',
       ].freeze
       # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-install-type.php


### PR DESCRIPTION
Closes [AINFRA-1462](https://linear.app/a8c/issue/AINFRA-1462) (again)

## What does it do?

Add `Windows - x64` and `Microsoft Store - x64` platforms to the `upload_build_to_apps_cdn` action.
(Follow-up on #669)

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
