### PR TITLE
Adds new Sparkle options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,7 +77,7 @@ Metrics/BlockLength:
    - spec/**/shared_examples_*.rb
 
 Metrics/ClassLength:
-  Max: 300
+  Max: 350
 
 Metrics/MethodLength:
   Max: 150

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- `upload_build_to_apps_cdn`: Add additional Sparkle meta fields `critical_update` and `phased_rollout_interval` [#673]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
@@ -69,6 +69,8 @@ module Fastlane
           version: params[:version],
           build_number: params[:build_number], # Optional: may be nil
           minimum_system_version: params[:minimum_system_version], # Optional: may be nil
+          critical_update: params[:critical_update], # Optional: may be nil
+          phased_rollout_interval: params[:phased_rollout_interval], # Optional: may be nil
           post_status: params[:post_status], # Optional: may be nil
           release_notes: params[:release_notes], # Optional: may be nil
           sha: params[:sha], # Optional: may be nil
@@ -291,6 +293,18 @@ module Fastlane
             description: 'The minimum version for the provided platform (e.g. \'13.0\' for macOS Ventura)',
             optional: true,
             type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :critical_update,
+            description: 'Whether the build is a critical update',
+            optional: true,
+            type: Boolean
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :phased_rollout_interval,
+            description: 'The interval for the phased rollout (in seconds)',
+            optional: true,
+            type: Integer
           ),
           FastlaneCore::ConfigItem.new(
             key: :release_notes,


### PR DESCRIPTION
## What does it do?

Makes 2 new Sparkle meta fields available via the wpmreleasetoolkit. See https://sparkle-project.org/documentation/publishing/#publishing-an-update and https://github.a8c.com/Automattic/wpcom/pull/195377.

https://linear.app/a8c/issue/PROXY-66

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] ~~Add Unit Tests (aka `specs/*_spec.rb`) if applicable.~~
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] ~~If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.~~
