### PR TITLE
`buildkite_pipeline_upload`: use `.` for sourcing env files for POSIX compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- `buildkite_pipeline_upload`: Fix compatibility issues by using POSIX-compliant `.` instead of bash-specific `source` command. [#681]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/buildkite_pipeline_upload_action.rb
@@ -21,7 +21,9 @@ module Fastlane
         if env_file && File.exist?(env_file)
           UI.message(" - Sourcing environment file beforehand: #{env_file}")
 
-          sh(environment, "source #{env_file.shellescape} && buildkite-agent pipeline upload #{pipeline_file.shellescape}")
+          # Use `.` instead of `source` for POSIX compliance - works across all shells (sh/dash/bash/zsh)
+          # while `source` isn't always present
+          sh(environment, ". #{env_file.shellescape} && buildkite-agent pipeline upload #{pipeline_file.shellescape}")
         else
           sh(environment, 'buildkite-agent', 'pipeline', 'upload', pipeline_file)
         end

--- a/spec/buildkite_pipeline_upload_action_spec.rb
+++ b/spec/buildkite_pipeline_upload_action_spec.rb
@@ -60,7 +60,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
       allow(File).to receive(:exist?).with(env_file).and_return(true)
       expect(Fastlane::Action).to receive(:sh).with(
         environment,
-        "source #{env_file.shellescape} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
+        ". #{env_file.shellescape} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
       )
       expect_upload_pipeline_message
       expect_sourcing_env_file_message(env_file)
@@ -92,7 +92,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
       allow(File).to receive(:exist?).with(env_file).and_return(true)
       expect(Fastlane::Action).to receive(:sh).with(
         environment_default,
-        "source #{env_file.shellescape} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
+        ". #{env_file.shellescape} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
       )
       expect_upload_pipeline_message
       expect_sourcing_env_file_message(env_file)
@@ -122,7 +122,7 @@ describe Fastlane::Actions::BuildkitePipelineUploadAction do
       allow(File).to receive(:exist?).with(env_file_default).and_return(true)
       expect(Fastlane::Action).to receive(:sh).with(
         environment_default,
-        "source #{env_file_default} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
+        ". #{env_file_default} && buildkite-agent pipeline upload #{loaded_pipeline_file.shellescape}"
       )
       expect_upload_pipeline_message
       expect_sourcing_env_file_message(env_file_default)


### PR DESCRIPTION
## What does it do?

Closes AINFRA-1649.

See p1765809510712929-slack-C02KLTL3MKM.

We've noticed the following error in [CI](https://buildkite.com/automattic/woocommerce-android/builds/34481#019b22c5-c297-4e99-9e03-82fbb3f91bba/239-264):
```
sh: 1: source: not found
```
When running in CI. This PR replaces the `source` command with `.`, which is POSIX compliant and should be more portable.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
