### PR TITLE
Release 14.0.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@
 
 ### Breaking Changes
 
+_None_
+
+### New Features
+
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 14.0.0
+
+### Breaking Changes
+
 - Generated PO files now have entries sorted **alphabetically by `msgctxt`** for deterministic output. This may affect tests or tooling that depend on a specific entry order. [#684]
 - Existing translator comments (`#.` lines) in PO files will be **lost** when regenerating unless explicitly added to the `source_files` parameter. See `MIGRATION.md` for instructions on preserving comments. [#684]
 
@@ -13,10 +31,6 @@
 
 - Add `commit_changes` option to `gp_update_metadata_source` to optionally commit changes after updating the PO file. [#684]
 - Add support for translator comments in `gp_update_metadata_source` via a new hash format for `source_files` entries: `{ path: 'file.txt', comment: 'translators: ...' }`. Simple string paths are still supported for entries without comments. [#684]
-
-### Bug Fixes
-
-_None_
 
 ### Internal Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (13.8.1)
+    fastlane-plugin-wpmreleasetoolkit (14.0.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '13.8.1'
+    VERSION = '14.0.0'
   end
 end


### PR DESCRIPTION
Releasing new version 14.0.0.

## What's Next

Once merged, a GitHub Release will be created which will trigger the CI job to push the gem to RubyGems.

---

Generated with the help of [Claude Code](https://claude.ai/code)

---

<!-- blue -->
> [!NOTE]  
> Gio here. This PR was entirely generated by Claude. I am working on a skill for releases.