### PR TITLE
Add stub AGENTS.md with CLAUDE.md pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## Overview
+
+Release Toolkit is a Ruby gem providing shared tools used in release automation for WordPress mobile apps.
+It is a collection of `fastlane` actions and helper utilities that standardize the release process across multiple repositories.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Add stub `AGENTS.md` with project overview as the source of truth for agent instructions
- Add `CLAUDE.md` containing only `@AGENTS.md` pointer

See also:
- bloom/DayOne-Apple#28097
- wordpress-mobile/WordPress-iOS#25252
- wordpress-mobile/GutenbergKit#321
- Automattic/dangermattic#109

---

This PR was created autonomously by Claude Code (Opus 4.6) on behalf of @mokagio with approval.