### PR TITLE
Track experiments in agenting build-test loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ bundle exec rubocop                     # Run linter
 bundle exec rubocop -a                  # Auto-fix lint issues
 bundle exec yard doc                    # Generate docs, open in browser
 bundle exec yard stats --list-undoc     # Show undocumented methods
+gem build                               # Build the gem (no arguments — auto-picks the gemspec)
 rake new_release                        # Start a new release (interactive)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Overview
 
-Release Toolkit is a Fastlane plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, Day One, Pocket Casts, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
+Release Toolkit is a _fastlane_ plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, Day One, Pocket Casts, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
 
 - **Language**: Ruby (version in `.ruby-version`, minimum in `fastlane-plugin-wpmreleasetoolkit.gemspec`)
 - **Framework**: Fastlane plugin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Overview
 
-Release Toolkit is a fastlane plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, DayOne, PocketCats, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
+Release Toolkit is a Fastlane plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, Day One, Pocket Casts, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
 
 - **Language**: Ruby (version in `.ruby-version`, minimum in `fastlane-plugin-wpmreleasetoolkit.gemspec`)
 - **Framework**: Fastlane plugin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fastlane-plugin-wpmreleasetoolkit (14.0.0)
-      activesupport (>= 6.1.7.1)
+      activesupport (>= 6.1.7.1, < 8)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
-  spec.add_dependency 'activesupport', '>= 6.1.7.1' # Required for fastlane to not crash when importing this plugin
+  spec.add_dependency 'activesupport', '>= 6.1.7.1', '< 8' # Required for fastlane to not crash when importing this plugin
   spec.add_dependency 'buildkit', '~> 1.5'
   spec.add_dependency 'chroma', '0.2.0'
   spec.add_dependency 'diffy', '~> 3.3'

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/app_version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/app_version.rb
@@ -24,6 +24,14 @@ module Fastlane
         @build_number = build_number
       end
 
+      # Returns whether this version is a patch (hotfix) release.
+      #
+      # @return [Boolean] true if the patch component is greater than zero.
+      #
+      def patch?
+        @patch.positive?
+      end
+
       # Converts the AppVersion object to a string representation.
       # This should only be used for internal debugging/testing purposes, not to write versions in version files
       # In order to format an `AppVersion` into a `String`, you should use the appropriate `VersionFormatter` for your project instead.

--- a/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/models/configuration.rb
@@ -29,6 +29,11 @@ module Fastlane
       files_to_copy << file
     end
 
+    def valid?
+      !project_name.nil? && !project_name.empty? &&
+        !branch.nil? && !branch.empty?
+    end
+
     def to_hash
       {
         project_name: project_name,

--- a/spec/app_version_spec.rb
+++ b/spec/app_version_spec.rb
@@ -25,6 +25,18 @@ describe Fastlane::Models::AppVersion do
     end
   end
 
+  describe '#patch?' do
+    it 'returns true when patch is greater than zero' do
+      app_version = described_class.new(1, 2, 3)
+      expect(app_version.patch?).to be true
+    end
+
+    it 'returns false when patch is zero' do
+      app_version = described_class.new(1, 2, 0)
+      expect(app_version.patch?).to be false
+    end
+  end
+
   describe '#to_s' do
     it 'returns the version as a formatted string' do
       app_version = described_class.new(2, 3, 4, 5)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -52,6 +52,35 @@ describe Fastlane::Configuration do
     end
   end
 
+  describe '#valid?' do
+    it 'returns true when project_name and branch are present' do
+      config = described_class.new(project_name: 'MyProject', branch: 'trunk')
+      expect(config.valid?).to be true
+    end
+
+    it 'returns false when project_name is empty' do
+      config = described_class.new(project_name: '', branch: 'trunk')
+      expect(config.valid?).to be false
+    end
+
+    it 'returns false when project_name is nil' do
+      config = described_class.new(branch: 'trunk')
+      config.project_name = nil
+      expect(config.valid?).to be false
+    end
+
+    it 'returns false when branch is empty' do
+      config = described_class.new(project_name: 'MyProject', branch: '')
+      expect(config.valid?).to be false
+    end
+
+    it 'returns false when branch is nil' do
+      config = described_class.new(project_name: 'MyProject')
+      config.branch = nil
+      expect(config.valid?).to be false
+    end
+  end
+
   describe '#add_file_to_copy' do
     it 'adds files to copy' do
       expect(subject.files_to_copy).to eq([])


### PR DESCRIPTION
The changes in this PR could be three distinct PRs, but I've pushed them in a single one for convenience.

- Update `AGENTS.md` with `gem build` instructions
- Fix a gem version constraint warning
- Add two helper methods

The fix and new methods were done by Claude Opus 4.6 as experiments in agentic build-test loop.

If something feels unnecessary, I'll close this PR and cherry pick only the useful bits.

Attached are exports of the conversations that implemented the above, to showcase the autonomous workflow:

- [autonomous-build-test-example-1.txt](https://github.com/user-attachments/files/25507588/autonomous-build-test-example-1.txt)
- [autonomous-build-test-example-2.txt](https://github.com/user-attachments/files/25507589/autonomous-build-test-example-2.txt)
- [autonomous-build-test-example-3.txt](https://github.com/user-attachments/files/25507590/autonomous-build-test-example-3.txt)

