### PR TITLE
Add Claude Code deny rules for agent safety

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "permissions": {
+    "allow": [
+      "Bash(git tag list)"
+    ],
     "deny": [
       "Bash(gem push*)",
       "Bash(gem signin*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(gem push*)",
+      "Bash(gem signin*)",
+      "Bash(git tag*)",
+      "Bash(git push --tags*)",
+      "Bash(git push origin --tags*)",
+      "Bash(git push -f*)",
+      "Bash(git push --force*)",
+      "Bash(git push origin -f*)",
+      "Bash(git push origin --force*)",
+      "Bash(git push origin --delete*)",
+      "Bash(git push origin :*)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean*)",
+      "Bash(git checkout -- .)",
+      "Bash(git restore .)",
+      "Bash(rake new_release*)",
+      "Bash(bundle exec rake new_release*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.claude/settings.json` with deny rules that block destructive and production-impacting commands from agent execution.
- Denied operations: gem publishing, tag creation (triggers CI gem publish), force push, remote branch/tag deletion, hard reset, `git clean`, and the interactive release task.
- Plain `git push` stays allowed to support PR workflows.

## Context

When an AI agent works in this repo, the deny list acts as a guardrail against accidental production impact — even if the agent is given broad permissions otherwise.

See also: the [agent isolation recommendations](https://github.com/wordpress-mobile/release-toolkit/blob/agent-isolation-deny-rules/agent-isolation-recommendations.md) document for further improvements.

## Test plan

- [x] Verify CI passes (no functional code changes — config only)
- [ ] Verify an agent session in this repo cannot run denied commands (e.g., `gem push`, `git tag`)

---

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*