### PR TITLE
Add `exclude` parameter to `find_previous_tag` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- Added optional `exclude` parameter to `find_previous_tag` action, mapping to git's `--exclude` flag. This allows skipping beta/pre-release tags when searching for the previous stable release tag [#PR]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- Added optional `exclude` parameter to `find_previous_tag` action, mapping to git's `--exclude` flag. This allows skipping beta/pre-release tags when searching for the previous stable release tag [#PR]
+- Added optional `exclude` parameter to `find_previous_tag` action, mapping to git's `--exclude` flag. This allows skipping beta/pre-release tags when searching for the previous stable release tag [#696]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
@@ -8,7 +8,7 @@ module Fastlane
     class FindPreviousTagAction < Action
       def self.run(params)
         tag_pattern = params[:pattern]
-        exclude_patterns = Array(params[:exclude])
+        exclude_patterns = params[:exclude] || []
 
         # Make sure we have all the latest tags fetched locally
         Actions.sh('git', 'fetch', '--tags', '--force') { nil }
@@ -41,7 +41,7 @@ module Fastlane
           reachable from the current commit and that matches a specific naming pattern
 
           e.g. `find_previous_tag(pattern: '12.3.*.*')`, `find_previous_tag(pattern: '12.3-rc-*')`,
-          `find_previous_tag(pattern: 'v*', exclude: '*beta*')`,
+          `find_previous_tag(pattern: 'v*', exclude: ['*beta*'])`,
           `find_previous_tag(pattern: 'v*', exclude: ['*alpha*', '*beta*'])`
         DETAILS
       end
@@ -54,11 +54,10 @@ module Fastlane
                                        default_value: nil,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :exclude,
-                                       description: 'One or more _fnmatch_-style patterns of tags to exclude from the search (maps to `git describe --exclude`). ' \
-                                                    'Can be a single string or an array of strings',
+                                       description: 'An array of _fnmatch_-style patterns of tags to exclude from the search (maps to `git describe --exclude`)',
                                        optional: true,
                                        default_value: nil,
-                                       is_string: false),
+                                       type: Array),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
@@ -8,7 +8,7 @@ module Fastlane
     class FindPreviousTagAction < Action
       def self.run(params)
         tag_pattern = params[:pattern]
-        exclude_pattern = params[:exclude]
+        exclude_patterns = Array(params[:exclude])
 
         # Make sure we have all the latest tags fetched locally
         Actions.sh('git', 'fetch', '--tags', '--force') { nil }
@@ -18,7 +18,7 @@ module Fastlane
         # Finally find the previous tag matching the provided pattern, and that is not the current commit
         git_cmd = %w[git describe --tags --abbrev=0]
         git_cmd += ['--match', tag_pattern] unless tag_pattern.nil?
-        git_cmd += ['--exclude', exclude_pattern] unless exclude_pattern.nil?
+        exclude_patterns.each { |p| git_cmd += ['--exclude', p] }
         git_cmd += ['--exclude', current_commit_tag] unless current_commit_tag.empty?
         Actions.sh(*git_cmd) { |exit_status, stdout, _| exit_status.success? ? stdout.chomp : nil }
       end
@@ -41,7 +41,8 @@ module Fastlane
           reachable from the current commit and that matches a specific naming pattern
 
           e.g. `find_previous_tag(pattern: '12.3.*.*')`, `find_previous_tag(pattern: '12.3-rc-*')`,
-          `find_previous_tag(pattern: 'v*', exclude: '*beta*')`
+          `find_previous_tag(pattern: 'v*', exclude: '*beta*')`,
+          `find_previous_tag(pattern: 'v*', exclude: ['*alpha*', '*beta*'])`
         DETAILS
       end
 
@@ -53,10 +54,11 @@ module Fastlane
                                        default_value: nil,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :exclude,
-                                       description: 'An _fnmatch_-style pattern of tags to exclude from the search (maps to `git describe --exclude`)',
+                                       description: 'One or more _fnmatch_-style patterns of tags to exclude from the search (maps to `git describe --exclude`). ' \
+                                                    'Can be a single string or an array of strings',
                                        optional: true,
                                        default_value: nil,
-                                       type: String),
+                                       is_string: false),
         ]
       end
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/find_previous_tag.rb
@@ -8,6 +8,7 @@ module Fastlane
     class FindPreviousTagAction < Action
       def self.run(params)
         tag_pattern = params[:pattern]
+        exclude_pattern = params[:exclude]
 
         # Make sure we have all the latest tags fetched locally
         Actions.sh('git', 'fetch', '--tags', '--force') { nil }
@@ -17,6 +18,7 @@ module Fastlane
         # Finally find the previous tag matching the provided pattern, and that is not the current commit
         git_cmd = %w[git describe --tags --abbrev=0]
         git_cmd += ['--match', tag_pattern] unless tag_pattern.nil?
+        git_cmd += ['--exclude', exclude_pattern] unless exclude_pattern.nil?
         git_cmd += ['--exclude', current_commit_tag] unless current_commit_tag.empty?
         Actions.sh(*git_cmd) { |exit_status, stdout, _| exit_status.success? ? stdout.chomp : nil }
       end
@@ -38,7 +40,8 @@ module Fastlane
           Uses `git describe --tags --abbrev=0 --match … --exclude …` to find the previous git tag
           reachable from the current commit and that matches a specific naming pattern
 
-          e.g. `find_previous_tag(pattern: '12.3.*.*')`, `find_previous_tag(pattern: '12.3-rc-*')`
+          e.g. `find_previous_tag(pattern: '12.3.*.*')`, `find_previous_tag(pattern: '12.3-rc-*')`,
+          `find_previous_tag(pattern: 'v*', exclude: '*beta*')`
         DETAILS
       end
 
@@ -46,6 +49,11 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :pattern,
                                        description: 'The _fnmatch_-style pattern to use when searching for the previous tag',
+                                       optional: true,
+                                       default_value: nil,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :exclude,
+                                       description: 'An _fnmatch_-style pattern of tags to exclude from the search (maps to `git describe --exclude`)',
                                        optional: true,
                                        default_value: nil,
                                        type: String),

--- a/spec/find_previous_tag_spec.rb
+++ b/spec/find_previous_tag_spec.rb
@@ -97,6 +97,22 @@ describe Fastlane::Actions::FindPreviousTagAction do
     expect(tag).to eq('v1.7.3')
   end
 
+  it 'excludes tags matching multiple exclude patterns' do
+    # Arrange
+    stub_current_commit_tag(nil)
+    stub_main_command(
+      %w[git describe --tags --abbrev=0 --match v* --exclude *alpha* --exclude *beta*],
+      stdout: 'v1.7.3'
+    )
+    # Act
+    tag = run_described_fastlane_action(
+      pattern: 'v*',
+      exclude: %w[*alpha* *beta*]
+    )
+    # Assert
+    expect(tag).to eq('v1.7.3')
+  end
+
   it 'returns nil if no previous commit could be found' do
     # Arrange
     stub_current_commit_tag(nil)

--- a/spec/find_previous_tag_spec.rb
+++ b/spec/find_previous_tag_spec.rb
@@ -97,6 +97,22 @@ describe Fastlane::Actions::FindPreviousTagAction do
     expect(tag).to eq('v1.7.3')
   end
 
+  it 'auto-converts a single exclude string into an array' do
+    # Arrange
+    stub_current_commit_tag(nil)
+    stub_main_command(
+      %w[git describe --tags --abbrev=0 --match v* --exclude *beta*],
+      stdout: 'v1.7.3'
+    )
+    # Act — Fastlane's ConfigItem auto-converts a String to Array when type is Array
+    tag = run_described_fastlane_action(
+      pattern: 'v*',
+      exclude: '*beta*'
+    )
+    # Assert
+    expect(tag).to eq('v1.7.3')
+  end
+
   it 'excludes tags matching multiple exclude patterns' do
     # Arrange
     stub_current_commit_tag(nil)

--- a/spec/find_previous_tag_spec.rb
+++ b/spec/find_previous_tag_spec.rb
@@ -65,6 +65,38 @@ describe Fastlane::Actions::FindPreviousTagAction do
     expect(tag).to eq('12.2')
   end
 
+  it 'excludes tags matching the exclude pattern' do
+    # Arrange
+    stub_current_commit_tag(nil)
+    stub_main_command(
+      %w[git describe --tags --abbrev=0 --match v* --exclude *beta*],
+      stdout: 'v1.7.3'
+    )
+    # Act
+    tag = run_described_fastlane_action(
+      pattern: 'v*',
+      exclude: '*beta*'
+    )
+    # Assert
+    expect(tag).to eq('v1.7.3')
+  end
+
+  it 'excludes both the exclude pattern and the current commit tag' do
+    # Arrange
+    stub_current_commit_tag('v1.8.0')
+    stub_main_command(
+      %w[git describe --tags --abbrev=0 --match v* --exclude *beta* --exclude v1.8.0],
+      stdout: 'v1.7.3'
+    )
+    # Act
+    tag = run_described_fastlane_action(
+      pattern: 'v*',
+      exclude: '*beta*'
+    )
+    # Assert
+    expect(tag).to eq('v1.7.3')
+  end
+
   it 'returns nil if no previous commit could be found' do
     # Arrange
     stub_current_commit_tag(nil)

--- a/spec/find_previous_tag_spec.rb
+++ b/spec/find_previous_tag_spec.rb
@@ -75,7 +75,7 @@ describe Fastlane::Actions::FindPreviousTagAction do
     # Act
     tag = run_described_fastlane_action(
       pattern: 'v*',
-      exclude: '*beta*'
+      exclude: ['*beta*']
     )
     # Assert
     expect(tag).to eq('v1.7.3')
@@ -91,7 +91,7 @@ describe Fastlane::Actions::FindPreviousTagAction do
     # Act
     tag = run_described_fastlane_action(
       pattern: 'v*',
-      exclude: '*beta*'
+      exclude: ['*beta*']
     )
     # Assert
     expect(tag).to eq('v1.7.3')


### PR DESCRIPTION
Fixes AINFRA-2056

## What does it do?

Adds an optional `exclude` parameter to the `find_previous_tag` action that maps to git's `--exclude` flag, allowing callers to skip beta/pre-release tags when searching for the previous stable release tag — e.g. `find_previous_tag(pattern: 'v*', exclude: '*beta*')`.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.