### PR TITLE
Release 14.1.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,21 @@ _None_
 
 ### New Features
 
-- Added optional `exclude` parameter to `find_previous_tag` action, mapping to git's `--exclude` flag. This allows skipping beta/pre-release tags when searching for the previous stable release tag [#696]
+_None_
 
 ### Bug Fixes
 
 _None_
+
+### Internal Changes
+
+_None_
+
+## 14.1.0
+
+### New Features
+
+- Added optional `exclude` parameter to `find_previous_tag` action, mapping to git's `--exclude` flag. This allows skipping beta/pre-release tags when searching for the previous stable release tag [#696]
 
 ### Internal Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.0.0)
+    fastlane-plugin-wpmreleasetoolkit (14.1.0)
       activesupport (>= 6.1.7.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.0.0'
+    VERSION = '14.1.0'
   end
 end


### PR DESCRIPTION
Releasing new version `14.1.0`.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- Added optional `exclude` parameter to `find_previous_tag` action, mapping to git's `--exclude` flag. This allows skipping beta/pre-release tags when searching for the previous stable release tag [#696]

### Internal Changes

- Enhance `AGENTS.md` with project guidance for AI agents. [#692]
- Bumped `faraday` to address security vulnerability. [#689]
- Bumped `nokogiri` to address security vulnerability. [#693]


```
