### PR TITLE
Fix a gem spec warning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ bundle exec rubocop                     # Run linter
 bundle exec rubocop -a                  # Auto-fix lint issues
 bundle exec yard doc                    # Generate docs, open in browser
 bundle exec yard stats --list-undoc     # Show undocumented methods
+gem build                               # Build the gem (no arguments — auto-picks the gemspec)
 rake new_release                        # Start a new release (interactive)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Overview
 
-Release Toolkit is a Fastlane plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, Day One, Pocket Casts, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
+Release Toolkit is a _fastlane_ plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, Day One, Pocket Casts, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
 
 - **Language**: Ruby (version in `.ruby-version`, minimum in `fastlane-plugin-wpmreleasetoolkit.gemspec`)
 - **Framework**: Fastlane plugin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Overview
 
-Release Toolkit is a fastlane plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, DayOne, PocketCats, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
+Release Toolkit is a Fastlane plugin  implemented as a Ruby gem (`fastlane-plugin-wpmreleasetoolkit`) providing actions and helper utilities for release automation of Automattic's mobile apps. It standardizes the release process across multiple products (WordPress, Jetpack, WooCommerce, Day One, Pocket Casts, Tumblr, Studio, …), repositories, and platforms (iOS, Android, macOS).
 
 - **Language**: Ruby (version in `.ruby-version`, minimum in `fastlane-plugin-wpmreleasetoolkit.gemspec`)
 - **Framework**: Fastlane plugin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fastlane-plugin-wpmreleasetoolkit (14.1.0)
-      activesupport (>= 6.1.7.1)
+      activesupport (>= 6.1.7.1, < 8)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/fastlane-plugin-wpmreleasetoolkit.gemspec
+++ b/fastlane-plugin-wpmreleasetoolkit.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   # since this would cause a circular dependency
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
-  spec.add_dependency 'activesupport', '>= 6.1.7.1' # Required for fastlane to not crash when importing this plugin
+  spec.add_dependency 'activesupport', '>= 6.1.7.1', '< 8' # Required for fastlane to not crash when importing this plugin
   spec.add_dependency 'buildkit', '~> 1.5'
   spec.add_dependency 'chroma', '0.2.0'
   spec.add_dependency 'diffy', '~> 3.3'


### PR DESCRIPTION
This is a cherry-pick from https://github.com/wordpress-mobile/release-toolkit/pull/694 with only the useful bits:

- Naming tweaks
- Add `gem build` instruction to `AGENTS.md`
- Fix a warning discovered when running `gem build`