### PR TITLE
Add common pitfalls and quick start to `AGENTS.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ Release Toolkit is a _fastlane_ plugin  implemented as a Ruby gem (`fastlane-plu
 - **Main branch**: `trunk`
 - **Gem version**: defined in `lib/fastlane/plugin/wpmreleasetoolkit/version.rb`
 
+## Quick Start
+
+```sh
+bundle install && gem build && bundle exec rubocop && bundle exec rspec
+```
+
 ## Build and Development Commands
 
 ```sh
@@ -215,3 +221,7 @@ Runtime and development dependencies with version constraints are defined in `fa
 - **gettext** — i18n/PO files
 - **google-cloud-storage** — GCS uploads
 - **buildkit** — Buildkite API
+
+## Common Pitfalls
+
+- **Don't inspect or edit `vendor/bundle/` unless necessary** — The bundled gems live there and are managed by Bundler.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Release Toolkit is a _fastlane_ plugin  implemented as a Ruby gem (`fastlane-plu
 ## Quick Start
 
 ```sh
-bundle install && gem build && bundle exec rubocop && bundle exec rspec
+bundle install && bundle exec rubocop && bundle exec rspec
 ```
 
 ## Build and Development Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,4 +224,4 @@ Runtime and development dependencies with version constraints are defined in `fa
 
 ## Common Pitfalls
 
-- **Don't inspect or edit `vendor/bundle/` unless necessary** — The bundled gems live there and are managed by Bundler.
+- **Don't inspect or edit `vendor/` unless necessary** — The bundled gems and SwiftGen binaries live there.


### PR DESCRIPTION
## What does it do?

Documents the bootstrap sequence and instructs the agent to not inspect `vendor/` unless necessary.