### PR TITLE
Release 14.2.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- Added optional `name` parameter to `create_github_release` action, allowing a custom release title independent of the git tag. Defaults to `version` for backward compatibility. [#703]
+_None_
 
 ### Bug Fixes
 
@@ -19,6 +19,12 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 14.2.0
+
+### New Features
+
+- Added optional `name` parameter to `create_github_release` action, allowing a custom release title independent of the git tag. Defaults to `version` for backward compatibility. [#703]
 
 ## 14.1.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.1.0)
+    fastlane-plugin-wpmreleasetoolkit (14.2.0)
       activesupport (>= 6.1.7.1, < 8)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.1.0'
+    VERSION = '14.2.0'
   end
 end


### PR DESCRIPTION
Releasing new version `14.2.0`.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- Added optional `name` parameter to `create_github_release` action, allowing a custom release title independent of the git tag. Defaults to `version` for backward compatibility. [#703]


```
