### PR TITLE
Release 14.2.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Added optional `next_version` parameter to `android_update_release_notes` and `ios_update_release_notes` actions, allowing callers to provide the next version directly instead of relying on the built-in calculator that assumes minor version caps at 9. This fixes incorrect version bumps (e.g., 8.9 → 9.0 instead of 8.10) for apps using semantic versioning. [#706]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 14.2.1
+
+### Bug Fixes
+
+- Added optional `next_version` parameter to `android_update_release_notes` and `ios_update_release_notes` actions, allowing callers to provide the next version directly instead of relying on the built-in calculator that assumes minor version caps at 9. This fixes incorrect version bumps (e.g., 8.9 → 9.0 instead of 8.10) for apps using semantic versioning. [#706]
 
 ## 14.2.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.2.0)
+    fastlane-plugin-wpmreleasetoolkit (14.2.1)
       activesupport (>= 6.1.7.1, < 8)
       buildkit (~> 1.5)
       chroma (= 0.2.0)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.2.0'
+    VERSION = '14.2.1'
   end
 end


### PR DESCRIPTION
Releasing new version 14.2.1.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Added optional `next_version` parameter to `android_update_release_notes` and `ios_update_release_notes` actions, allowing callers to provide the next version directly instead of relying on the built-in calculator that assumes minor version caps at 9. This fixes incorrect version bumps (e.g., 8.9 → 9.0 instead of 8.10) for apps using semantic versioning. [#706]


```
