### PR TITLE
Release 14.3.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ _None_
 
 ### Internal Changes
 
+_None_
+
+## 14.3.1
+
+### Internal Changes
+
 - Remove `activesupport` as a runtime dependency — replace the only production usage (`deep_dup`) with `Marshal` deep copy — and move it to a dev-only dependency for specs. [#709]
 - Update RuboCop configuration: fix obsolete `Naming/PredicateName` cop rename, move permanent style choices from `.rubocop_todo.yml` to `.rubocop.yml`, and fix a `Style/FileOpen` violation. [#709]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.3.0)
+    fastlane-plugin-wpmreleasetoolkit (14.3.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.3.0'
+    VERSION = '14.3.1'
   end
 end


### PR DESCRIPTION
Releasing new version 14.3.1.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Internal Changes

- Remove `activesupport` as a runtime dependency — replace the only production usage (`deep_dup`) with `Marshal` deep copy — and move it to a dev-only dependency for specs. [#709]
- Update RuboCop configuration: fix obsolete `Naming/PredicateName` cop rename, move permanent style choices from `.rubocop_todo.yml` to `.rubocop.yml`, and fix a `Style/FileOpen` violation. [#709]


```
