### PR TITLE
Update yard to 0.9.43 (GHSA-3jfp-46x4-xgfj)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,7 +424,7 @@ GEM
       rouge (~> 3.28.0)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    yard (0.9.38)
+    yard (0.9.43)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
## Summary
- Bump `yard` from 0.9.38 to 0.9.43 in `Gemfile.lock` to address [GHSA-3jfp-46x4-xgfj](https://github.com/advisories/GHSA-3jfp-46x4-xgfj), a path traversal vulnerability in `yard server` (< 0.9.42).
- Resolves https://github.com/wordpress-mobile/release-toolkit/security/dependabot/52.

## Test plan
- [ ] CI passes on the updated `Gemfile.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)