### PR TITLE
Release 14.4.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- Add `Fastlane::Wpmreleasetoolkit::EnvManager` for loading `.env` files and accessing required environment variables with user-friendly error messages. Repos that maintain their own `EnvManager` can switch to this centralized implementation. [#578]
+_None_
 
 ### Bug Fixes
 
@@ -19,6 +19,12 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 14.4.0
+
+### New Features
+
+- Add `Fastlane::Wpmreleasetoolkit::EnvManager` for loading `.env` files and accessing required environment variables with user-friendly error messages. Repos that maintain their own `EnvManager` can switch to this centralized implementation. [#578]
 
 ## 14.3.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.3.1)
+    fastlane-plugin-wpmreleasetoolkit (14.4.0)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.3.1'
+    VERSION = '14.4.0'
   end
 end


### PR DESCRIPTION
Releasing new version 14.4.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:

```
### New Features

- Add `Fastlane::Wpmreleasetoolkit::EnvManager` for loading `.env` files and accessing required environment variables with user-friendly error messages. Repos that maintain their own `EnvManager` can switch to this centralized implementation. [#578]


```
