### PR TITLE
Release 14.4.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- Bump the floor of the `nokogiri` dependency to `>= 1.19.3` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) (CSS selector ReDoS). [#714]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 14.4.1
+
+### Bug Fixes
+
+- Bump the floor of the `nokogiri` dependency to `>= 1.19.3` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) (CSS selector ReDoS). [#714]
 
 ## 14.4.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.4.0)
+    fastlane-plugin-wpmreleasetoolkit (14.4.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.4.0'
+    VERSION = '14.4.1'
   end
 end


### PR DESCRIPTION
Releasing new version 14.4.1.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- Bump the floor of the `nokogiri` dependency to `>= 1.19.3` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) (CSS selector ReDoS). [#714]


```
