### PR TITLE
Release 14.4.2 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- `openai_ask`: support OpenAI tool-use (function calling) and model overrides. New optional parameters: `tools`, `tool_handlers`, and `max_tool_iterations` enable a multi-turn loop where the model invokes locally-defined tools and receives `role: tool` results until it produces a plain text response or hits the iteration cap; `model` overrides the previously hardcoded `gpt-4o`. Tool-handler keys may be strings or symbols (normalized internally), exceptions raised inside a handler are surfaced back to the model as structured `{ error:, exception: }` tool results (carrying only the exception class — the message and backtrace are logged locally but not forwarded, since handler errors can contain secrets) rather than crashing the lane, and the new parameters validate their inputs (non-empty Array, callable handlers, iteration cap >= 1). Backwards-compatible — when `tools` is omitted, behavior is unchanged. Also fixes a long-standing `NameError` when generating action documentation (documented examples are now non-interpolated heredocs) and a `EXEMPLE` typo in the example HEREDOC tags. [#716]
+_None_
 
 ### Bug Fixes
 
@@ -19,6 +19,12 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 14.4.2
+
+### New Features
+
+- `openai_ask`: support OpenAI tool-use (function calling) and model overrides. New optional parameters: `tools`, `tool_handlers`, and `max_tool_iterations` enable a multi-turn loop where the model invokes locally-defined tools and receives `role: tool` results until it produces a plain text response or hits the iteration cap; `model` overrides the previously hardcoded `gpt-4o`. Tool-handler keys may be strings or symbols (normalized internally), exceptions raised inside a handler are surfaced back to the model as structured `{ error:, exception: }` tool results (carrying only the exception class — the message and backtrace are logged locally but not forwarded, since handler errors can contain secrets) rather than crashing the lane, and the new parameters validate their inputs (non-empty Array, callable handlers, iteration cap >= 1). Backwards-compatible — when `tools` is omitted, behavior is unchanged. Also fixes a long-standing `NameError` when generating action documentation (documented examples are now non-interpolated heredocs) and a `EXEMPLE` typo in the example HEREDOC tags. [#716]
 
 ## 14.4.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.4.1)
+    fastlane-plugin-wpmreleasetoolkit (14.4.2)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.4.1'
+    VERSION = '14.4.2'
   end
 end


### PR DESCRIPTION
Releasing new version 14.4.2.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- `openai_ask`: support OpenAI tool-use (function calling) and model overrides. New optional parameters: `tools`, `tool_handlers`, and `max_tool_iterations` enable a multi-turn loop where the model invokes locally-defined tools and receives `role: tool` results until it produces a plain text response or hits the iteration cap; `model` overrides the previously hardcoded `gpt-4o`. Tool-handler keys may be strings or symbols (normalized internally), exceptions raised inside a handler are surfaced back to the model as structured `{ error:, exception: }` tool results (carrying only the exception class — the message and backtrace are logged locally but not forwarded, since handler errors can contain secrets) rather than crashing the lane, and the new parameters validate their inputs (non-empty Array, callable handlers, iteration cap >= 1). Backwards-compatible — when `tools` is omitted, behavior is unchanged. Also fixes a long-standing `NameError` when generating action documentation (documented examples are now non-interpolated heredocs) and a `EXEMPLE` typo in the example HEREDOC tags. [#716]


```
