### PR TITLE
Improve openai_ask tool-use behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- `openai_ask`: improve tool-use handling by validating supported function tools, using `max_completion_tokens`, avoiding secret-bearing debug logs, and refusing to execute additional tool calls after `max_tool_iterations`.
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-- `openai_ask`: improve tool-use handling by requiring named function tools, using `max_completion_tokens`, opting out of OpenAI request storage, omitting sensitive tool diagnostics from logs, and refusing to execute additional tool calls after `max_tool_iterations`.
+- `openai_ask`: improve tool-use handling by requiring named function tools, using `max_completion_tokens`, opting out of OpenAI request storage, omitting sensitive tool diagnostics from logs, and refusing to execute additional tool calls after `max_tool_iterations`. [#719]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-- `openai_ask`: improve tool-use handling by requiring named function tools, using `max_completion_tokens`, omitting sensitive tool diagnostics from normal logs, and refusing to execute additional tool calls after `max_tool_iterations`.
+- `openai_ask`: improve tool-use handling by requiring named function tools, using `max_completion_tokens`, opting out of OpenAI request storage, omitting sensitive tool diagnostics from logs, and refusing to execute additional tool calls after `max_tool_iterations`.
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,11 @@ _None_
 
 ### Bug Fixes
 
-- `openai_ask`: improve tool-use handling by requiring named function tools, using `max_completion_tokens`, opting out of OpenAI request storage, omitting sensitive tool diagnostics from logs, and refusing to execute additional tool calls after `max_tool_iterations`. [#719]
+- `openai_ask`: avoid logging sensitive tool diagnostics and refuse to execute additional tool calls after `max_tool_iterations`. [#719]
 
 ### Internal Changes
 
-_None_
+- `openai_ask`: validate named function tools, use `max_completion_tokens`, and opt out of OpenAI request storage. [#719]
 
 ## 14.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _None_
 
 ### Internal Changes
 
-- `openai_ask`: validate named function tools, use `max_completion_tokens`, and opt out of OpenAI request storage. [#719]
+- `openai_ask`: validate named function tools, default to `gpt-4.1`, use `max_completion_tokens`, and opt out of OpenAI request storage. [#719]
 
 ## 14.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-- `openai_ask`: improve tool-use handling by validating supported function tools, using `max_completion_tokens`, avoiding secret-bearing debug logs, and refusing to execute additional tool calls after `max_tool_iterations`.
+- `openai_ask`: improve tool-use handling by requiring named function tools, using `max_completion_tokens`, omitting sensitive tool diagnostics from normal logs, and refusing to execute additional tool calls after `max_tool_iterations`.
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -8,6 +8,7 @@ module Fastlane
   module Actions
     class OpenaiAskAction < Action
       OPENAI_API_ENDPOINT = URI('https://api.openai.com/v1/chat/completions').freeze
+      # Preserve the previous `max_tokens` ceiling while using the current API field.
       DEFAULT_MAX_COMPLETION_TOKENS = 2048
       DEFAULT_MAX_TOOL_ITERATIONS = 5
       DEFAULT_MODEL = 'gpt-4o'
@@ -49,6 +50,7 @@ module Fastlane
         validate_tools_array!(tools)
         validate_max_tool_iterations!(max_tool_iterations)
         validate_tools!(tools)
+
         run_with_tools(
           prompt: prompt,
           question: question,
@@ -164,7 +166,7 @@ module Fastlane
       def self.validate_tools!(tools)
         invalid_tools = tools.each_with_index.filter_map do |tool, index|
           type = tool_type(tool)
-          next "tools[#{index}] type #{type.empty? ? '<missing>' : type.inspect}" unless type == 'function'
+          next "tools[#{index}] type #{type.nil? ? '<missing>' : type.inspect}" unless type == 'function'
 
           function = tool[:function] || tool['function']
           name = function[:name] || function['name'] if function.is_a?(Hash)
@@ -182,9 +184,9 @@ module Fastlane
       end
 
       def self.tool_type(tool)
-        return '' unless tool.is_a?(Hash)
+        return nil unless tool.is_a?(Hash)
 
-        (tool[:type] || tool['type']).to_s
+        (tool[:type] || tool['type'])&.to_s
       end
 
       def self.valid_tool_name?(name)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -11,7 +11,7 @@ module Fastlane
       # Preserve the previous `max_tokens` ceiling while using the current API field.
       DEFAULT_MAX_COMPLETION_TOKENS = 2048
       DEFAULT_MAX_TOOL_ITERATIONS = 5
-      DEFAULT_MODEL = 'gpt-4o'
+      DEFAULT_MODEL = 'gpt-4.1'
 
       PREDEFINED_PROMPTS = {
         release_notes: <<~PROMPT
@@ -396,7 +396,7 @@ module Fastlane
                                        sensitive: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :model,
-                                       description: 'The OpenAI model to send the request to (e.g. `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`). ' \
+                                       description: 'The OpenAI model to send the request to (e.g. `gpt-4.1`, `gpt-4.1-mini`, `gpt-4o`). ' \
                                                     "Defaults to `#{DEFAULT_MODEL}`",
                                        optional: true,
                                        default_value: DEFAULT_MODEL,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -98,6 +98,7 @@ module Fastlane
       def self.request_body(prompt:, question:, model: DEFAULT_MODEL)
         {
           model: model,
+          store: false,
           response_format: { type: 'text' },
           temperature: 1,
           max_completion_tokens: DEFAULT_MAX_COMPLETION_TOKENS,
@@ -112,6 +113,7 @@ module Fastlane
       def self.request_body_with_messages(messages:, tools:, model: DEFAULT_MODEL)
         {
           model: model,
+          store: false,
           response_format: { type: 'text' },
           temperature: 1,
           max_completion_tokens: DEFAULT_MAX_COMPLETION_TOKENS,
@@ -198,10 +200,8 @@ module Fastlane
           rescue JSON::ParserError
             # Short-circuit: the handler never sees malformed args. Tell the model the
             # tool-call payload was invalid so it can retry with valid JSON, and log the
-            # local failure without recording raw arguments in normal logs. Verbose mode
-            # includes them for explicit debugging.
+            # local failure without recording raw arguments that might contain secrets.
             UI.error("Invalid JSON arguments for tool '#{name}' in tool call '#{tool_call['id']}'. Raw payload omitted because it may contain secrets.")
-            log_verbose_sensitive_diagnostics("Raw arguments for tool '#{name}' in tool call '#{tool_call['id']}': #{raw_args}")
             { error: "Invalid JSON arguments for tool '#{name}' — payload could not be parsed. Retry with valid JSON." }
           end
 
@@ -259,12 +259,7 @@ module Fastlane
         JSON.generate(result)
       rescue StandardError => e
         UI.error("Could not serialize tool result for '#{name}': #{e.class}. Result class: #{result.class}. Error message omitted because it may contain secrets.")
-        log_verbose_sensitive_diagnostics("Tool result serialization error for '#{name}': #{e.class}: #{e.message}")
         JSON.generate({ error: "Tool result for '#{name}' could not be serialized to JSON. Returned class: #{result.class}." })
-      end
-
-      def self.log_verbose_sensitive_diagnostics(message)
-        UI.verbose(message) if FastlaneCore::Globals.verbose?
       end
 
       # Invokes a tool handler safely. Returns a JSON-serializable value that will be
@@ -274,10 +269,9 @@ module Fastlane
       # - Missing or non-callable handler: structured `{ error: ... }` so the model can recover.
       # - Handler raised: structured `{ error:, exception: }` carrying only the exception class
       #   so the model can see the failure category and adjust. The exception message and
-      #   backtrace are omitted from normal local logs and from the model response
+      #   backtrace are intentionally omitted from local logs and from the model response
       #   because tool results and CI logs can expose release secrets
-      #   (tokens, file contents, internal API responses). They are logged only when
-      #   fastlane verbose mode is enabled. The loop keeps going rather than
+      #   (tokens, file contents, internal API responses). The loop keeps going rather than
       #   aborting the lane mid-conversation — the model is the better judge of whether the
       #   failure is recoverable than a global `rescue` here.
       def self.invoke_tool_handler(name:, handler:, args:)
@@ -288,7 +282,6 @@ module Fastlane
           handler.call(args)
         rescue StandardError => e
           UI.error("Handler for tool '#{name}' raised #{e.class}. Error message and backtrace omitted because they may contain secrets.")
-          log_verbose_sensitive_diagnostics("Handler for tool '#{name}' raised #{e.class}: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
           { error: "Handler for tool '#{name}' raised an exception", exception: e.class.name }
         end
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -74,7 +74,7 @@ module Fastlane
           assistant_message = parse_assistant_message(response)
           tool_calls = assistant_message['tool_calls']
 
-          # No tool calls - model produced a final answer.
+          # No tool calls — model produced a final answer.
           return assistant_message['content'] if tool_calls.nil? || tool_calls.empty?
 
           if tool_iterations >= max_tool_iterations
@@ -151,22 +151,27 @@ module Fastlane
       end
 
       def self.validate_max_tool_iterations!(max_tool_iterations)
+        UI.user_error!("Parameter `max_tool_iterations` must be an Integer (got #{max_tool_iterations.class})") unless max_tool_iterations.is_a?(Integer)
         UI.user_error!("Parameter `max_tool_iterations` must be >= 1 (got #{max_tool_iterations})") if max_tool_iterations < 1
       end
 
       def self.validate_tools!(tools)
-        unsupported_tools = tools.each_with_index.filter_map do |tool, index|
+        invalid_tools = tools.each_with_index.filter_map do |tool, index|
           type = tool_type(tool)
-          next if type == 'function'
+          next "tools[#{index}] type #{type.empty? ? '<missing>' : type.inspect}" unless type == 'function'
 
-          "tools[#{index}] type #{type.empty? ? '<missing>' : type.inspect}"
+          function = tool[:function] || tool['function']
+          name = function[:name] || function['name'] if function.is_a?(Hash)
+          next if name.is_a?(String) && !name.empty?
+
+          "tools[#{index}] missing function.name"
         end
 
-        return if unsupported_tools.empty?
+        return if invalid_tools.empty?
 
         UI.user_error!(
-          'Parameter `tools` only supports OpenAI function tools. ' \
-          "Unsupported tool definitions: #{unsupported_tools.join(', ')}"
+          'Parameter `tools` only supports OpenAI function tools with a non-empty `function.name`. ' \
+          "Invalid tool definitions: #{invalid_tools.join(', ')}"
         )
       end
 
@@ -177,7 +182,7 @@ module Fastlane
       end
 
       def self.execute_tool_call(tool_call, tool_handlers)
-        return unsupported_tool_call_result(tool_call) unless tool_call['type'] == 'function' && tool_call['function'].is_a?(Hash)
+        return unsupported_tool_call_result(tool_call) unless function_tool_call?(tool_call)
 
         name = tool_call.dig('function', 'name')
         raw_args = tool_call.dig('function', 'arguments') || '{}'
@@ -191,7 +196,8 @@ module Fastlane
             # tool-call payload was invalid so it can retry with valid JSON, and log the
             # local failure without recording raw arguments that might contain secrets.
             UI.error("Invalid JSON arguments for tool '#{name}' in tool call '#{tool_call['id']}'. Raw payload omitted because it may contain secrets.")
-            { error: "Invalid JSON arguments for tool '#{name}' - payload could not be parsed. Retry with valid JSON." }
+            log_verbose_sensitive_diagnostics("Raw arguments for tool '#{name}' in tool call '#{tool_call['id']}': #{raw_args}")
+            { error: "Invalid JSON arguments for tool '#{name}' — payload could not be parsed. Retry with valid JSON." }
           end
 
         {
@@ -201,6 +207,14 @@ module Fastlane
         }
       end
 
+      def self.function_tool_call?(tool_call)
+        return false unless tool_call['type'] == 'function'
+        return false unless tool_call['function'].is_a?(Hash)
+
+        name = tool_call.dig('function', 'name')
+        name.is_a?(String) && !name.empty?
+      end
+
       def self.unsupported_tool_call_result(tool_call)
         type = tool_call['type'] || '<missing>'
         UI.error("Unsupported OpenAI tool call type '#{type}' in tool call '#{tool_call['id']}'. Only function tool calls are supported.")
@@ -208,29 +222,37 @@ module Fastlane
         {
           role: 'tool',
           tool_call_id: tool_call['id'],
-          content: JSON.generate({ error: "Unsupported tool call type '#{type}'. Only function tool calls are supported." })
+          content: serialize_tool_result(
+            name: type,
+            result: { error: "Unsupported tool call type '#{type}'. Only function tool calls are supported." }
+          )
         }
       end
 
       # Serializes a tool result to a JSON string. Handlers are contracted to return
       # JSON-serializable values, but a buggy handler might return something like a
       # `Pathname`, `Proc`, or a custom object whose `to_json` raises. Failing the
-      # whole conversation over a serialization error is harsh. Instead, log locally
+      # whole conversation over a serialization error is harsh — instead, log locally
       # and send a structured `{ error: ... }` back so the model can recover.
       #
       # The handler's class name is exposed (handler authorship is local, not secret)
-      # but the exception's message is NOT forwarded, using the same reasoning as
+      # but the exception's message is NOT forwarded — same reasoning as
       # `invoke_tool_handler`: handler-returned objects can carry secrets.
       def self.serialize_tool_result(name:, result:)
         JSON.generate(result)
       rescue StandardError => e
         UI.error("Could not serialize tool result for '#{name}': #{e.class}. Result class: #{result.class}. Error message omitted because it may contain secrets.")
+        log_verbose_sensitive_diagnostics("Tool result serialization error for '#{name}': #{e.class}: #{e.message}")
         JSON.generate({ error: "Tool result for '#{name}' could not be serialized to JSON. Returned class: #{result.class}." })
+      end
+
+      def self.log_verbose_sensitive_diagnostics(message)
+        UI.verbose(message) if FastlaneCore::Globals.verbose?
       end
 
       # Invokes a tool handler safely. Returns a JSON-serializable value that will be
       # sent back to the model as the `content` of a `role: tool` message (the value
-      # may be a Hash, Array, scalar, etc. - whatever the handler returns).
+      # may be a Hash, Array, scalar, etc. — whatever the handler returns).
       #
       # - Missing or non-callable handler: structured `{ error: ... }` so the model can recover.
       # - Handler raised: structured `{ error:, exception: }` carrying only the exception class
@@ -238,7 +260,7 @@ module Fastlane
       #   backtrace are intentionally omitted from local logs and from the model response
       #   because tool results and CI logs can expose release secrets
       #   (tokens, file contents, internal API responses). The loop keeps going rather than
-      #   aborting the lane mid-conversation - the model is the better judge of whether the
+      #   aborting the lane mid-conversation — the model is the better judge of whether the
       #   failure is recoverable than a global `rescue` here.
       def self.invoke_tool_handler(name:, handler:, args:)
         return { error: "No handler defined for tool '#{name}'" } if handler.nil?
@@ -248,6 +270,7 @@ module Fastlane
           handler.call(args)
         rescue StandardError => e
           UI.error("Handler for tool '#{name}' raised #{e.class}. Error message and backtrace omitted because they may contain secrets.")
+          log_verbose_sensitive_diagnostics("Handler for tool '#{name}' raised #{e.class}: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
           { error: "Handler for tool '#{name}' raised an exception", exception: e.class.name }
         end
       end
@@ -278,6 +301,7 @@ module Fastlane
           on each turn, if the model calls one or more tools, the corresponding handler is invoked locally
           and its return value is sent back to the model as a `role: tool` message. The loop ends when the
           model returns a plain text response, or before executing tool calls beyond `max_tool_iterations`.
+          The model gets one final API turn to answer after the last permitted local tool execution round.
         DETAILS
       end
 
@@ -361,7 +385,7 @@ module Fastlane
                                        default_value: DEFAULT_MODEL,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :tools,
-                                       description: 'Optional array of OpenAI function tool definitions. ' \
+                                       description: 'Optional array of OpenAI function tool definitions. Each definition must have a non-empty `function.name`. ' \
                                                     'When provided, the action runs a tool-use loop',
                                        optional: true,
                                        default_value: nil,
@@ -383,12 +407,13 @@ module Fastlane
                                        end),
           FastlaneCore::ConfigItem.new(key: :max_tool_iterations,
                                        description: 'Maximum number of local tool execution rounds before the action fails. ' \
+                                                    'The model can receive one final API turn to answer after the last permitted tool result. ' \
                                                     'Only used when `tools` are provided',
                                        optional: true,
                                        default_value: DEFAULT_MAX_TOOL_ITERATIONS,
                                        type: Integer,
                                        verify_block: proc do |value|
-                                         UI.user_error!("Parameter `max_tool_iterations` must be >= 1 (got #{value})") if value < 1
+                                         validate_max_tool_iterations!(value)
                                        end),
         ]
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -47,7 +47,7 @@ module Fastlane
           return parse_text_response(response)
         end
 
-        UI.user_error!('Parameter `tools` must be a non-empty Array when provided') if tools.empty?
+        validate_tools_array!(tools)
         validate_tools!(tools)
         run_with_tools(
           prompt: prompt,
@@ -155,6 +155,10 @@ module Fastlane
       def self.validate_max_tool_iterations!(max_tool_iterations)
         UI.user_error!("Parameter `max_tool_iterations` must be an Integer (got #{max_tool_iterations.class})") unless max_tool_iterations.is_a?(Integer)
         UI.user_error!("Parameter `max_tool_iterations` must be >= 1 (got #{max_tool_iterations})") if max_tool_iterations < 1
+      end
+
+      def self.validate_tools_array!(tools)
+        UI.user_error!('Parameter `tools` must be a non-empty Array when provided') unless tools.is_a?(Array) && !tools.empty?
       end
 
       def self.validate_tools!(tools)
@@ -402,7 +406,7 @@ module Fastlane
                                        default_value: nil,
                                        type: Array,
                                        verify_block: proc do |value|
-                                         UI.user_error!('Parameter `tools` must be a non-empty Array when provided') if value.empty?
+                                         validate_tools_array!(value)
                                          validate_tools!(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :tool_handlers,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -224,7 +224,7 @@ module Fastlane
         type = tool_call['type'] || '<missing>'
         error =
           if type == 'function'
-            "Function tool call is missing a non-empty function.name."
+            'Function tool call is missing a non-empty function.name.'
           else
             "Unsupported tool call type '#{type}'. Only function tool calls are supported."
           end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -8,6 +8,7 @@ module Fastlane
   module Actions
     class OpenaiAskAction < Action
       OPENAI_API_ENDPOINT = URI('https://api.openai.com/v1/chat/completions').freeze
+      DEFAULT_MAX_COMPLETION_TOKENS = 2048
       DEFAULT_MAX_TOOL_ITERATIONS = 5
       DEFAULT_MODEL = 'gpt-4o'
 
@@ -32,6 +33,7 @@ module Fastlane
         # callers can register handlers with either string or symbol keys without surprises.
         tool_handlers = (params[:tool_handlers] || {}).transform_keys(&:to_s)
         max_tool_iterations = params[:max_tool_iterations] || DEFAULT_MAX_TOOL_ITERATIONS
+        validate_max_tool_iterations!(max_tool_iterations)
 
         headers = {
           'Content-Type': 'application/json',
@@ -39,12 +41,14 @@ module Fastlane
         }
 
         # Backwards-compatible single-shot path when no tools are provided.
-        if tools.nil? || tools.empty?
+        if tools.nil?
           body = request_body(prompt: prompt, question: question, model: model)
           response = Net::HTTP.post(OPENAI_API_ENDPOINT, body, headers)
           return parse_text_response(response)
         end
 
+        UI.user_error!('Parameter `tools` must be a non-empty Array when provided') if tools.empty?
+        validate_tools!(tools)
         run_with_tools(
           prompt: prompt,
           question: question,
@@ -62,14 +66,23 @@ module Fastlane
           format_message(role: 'user', text: question),
         ].compact
 
-        max_tool_iterations.times do
+        tool_iterations = 0
+
+        loop do
           body = request_body_with_messages(messages: messages, tools: tools, model: model)
           response = Net::HTTP.post(OPENAI_API_ENDPOINT, body, headers)
           assistant_message = parse_assistant_message(response)
           tool_calls = assistant_message['tool_calls']
 
-          # No tool calls — model produced a final answer.
+          # No tool calls - model produced a final answer.
           return assistant_message['content'] if tool_calls.nil? || tool_calls.empty?
+
+          if tool_iterations >= max_tool_iterations
+            UI.user_error!(
+              "OpenAI tool-use loop did not produce a final answer after #{max_tool_iterations} tool iterations. " \
+              'Refusing to execute additional tool calls. Increase `max_tool_iterations` or check that your prompt instructs the model to stop calling tools.'
+            )
+          end
 
           # Append the assistant's tool-call message verbatim, then run each handler
           # and append the corresponding `role: tool` results.
@@ -77,12 +90,9 @@ module Fastlane
           tool_calls.each do |tool_call|
             messages << execute_tool_call(tool_call, tool_handlers)
           end
-        end
 
-        UI.user_error!(
-          "OpenAI tool-use loop did not terminate after #{max_tool_iterations} iterations. " \
-          'Increase `max_tool_iterations` or check that your prompt instructs the model to stop calling tools.'
-        )
+          tool_iterations += 1
+        end
       end
 
       def self.request_body(prompt:, question:, model: DEFAULT_MODEL)
@@ -90,7 +100,7 @@ module Fastlane
           model: model,
           response_format: { type: 'text' },
           temperature: 1,
-          max_tokens: 2048,
+          max_completion_tokens: DEFAULT_MAX_COMPLETION_TOKENS,
           top_p: 1,
           messages: [
             format_message(role: 'system', text: prompt),
@@ -104,7 +114,7 @@ module Fastlane
           model: model,
           response_format: { type: 'text' },
           temperature: 1,
-          max_tokens: 2048,
+          max_completion_tokens: DEFAULT_MAX_COMPLETION_TOKENS,
           top_p: 1,
           messages: messages,
           tools: tools
@@ -140,7 +150,35 @@ module Fastlane
         end
       end
 
+      def self.validate_max_tool_iterations!(max_tool_iterations)
+        UI.user_error!("Parameter `max_tool_iterations` must be >= 1 (got #{max_tool_iterations})") if max_tool_iterations < 1
+      end
+
+      def self.validate_tools!(tools)
+        unsupported_tools = tools.each_with_index.filter_map do |tool, index|
+          type = tool_type(tool)
+          next if type == 'function'
+
+          "tools[#{index}] type #{type.empty? ? '<missing>' : type.inspect}"
+        end
+
+        return if unsupported_tools.empty?
+
+        UI.user_error!(
+          'Parameter `tools` only supports OpenAI function tools. ' \
+          "Unsupported tool definitions: #{unsupported_tools.join(', ')}"
+        )
+      end
+
+      def self.tool_type(tool)
+        return '' unless tool.is_a?(Hash)
+
+        (tool[:type] || tool['type']).to_s
+      end
+
       def self.execute_tool_call(tool_call, tool_handlers)
+        return unsupported_tool_call_result(tool_call) unless tool_call['type'] == 'function' && tool_call['function'].is_a?(Hash)
+
         name = tool_call.dig('function', 'name')
         raw_args = tool_call.dig('function', 'arguments') || '{}'
 
@@ -151,9 +189,9 @@ module Fastlane
           rescue JSON::ParserError
             # Short-circuit: the handler never sees malformed args. Tell the model the
             # tool-call payload was invalid so it can retry with valid JSON, and log the
-            # raw arguments locally for debugging without forwarding them to the API.
-            UI.error("Invalid JSON arguments for tool '#{name}'. Raw payload: #{raw_args}")
-            { error: "Invalid JSON arguments for tool '#{name}' — payload could not be parsed. Retry with valid JSON." }
+            # local failure without recording raw arguments that might contain secrets.
+            UI.error("Invalid JSON arguments for tool '#{name}' in tool call '#{tool_call['id']}'. Raw payload omitted because it may contain secrets.")
+            { error: "Invalid JSON arguments for tool '#{name}' - payload could not be parsed. Retry with valid JSON." }
           end
 
         {
@@ -163,33 +201,44 @@ module Fastlane
         }
       end
 
+      def self.unsupported_tool_call_result(tool_call)
+        type = tool_call['type'] || '<missing>'
+        UI.error("Unsupported OpenAI tool call type '#{type}' in tool call '#{tool_call['id']}'. Only function tool calls are supported.")
+
+        {
+          role: 'tool',
+          tool_call_id: tool_call['id'],
+          content: JSON.generate({ error: "Unsupported tool call type '#{type}'. Only function tool calls are supported." })
+        }
+      end
+
       # Serializes a tool result to a JSON string. Handlers are contracted to return
       # JSON-serializable values, but a buggy handler might return something like a
       # `Pathname`, `Proc`, or a custom object whose `to_json` raises. Failing the
-      # whole conversation over a serialization error is harsh — instead, log locally
+      # whole conversation over a serialization error is harsh. Instead, log locally
       # and send a structured `{ error: ... }` back so the model can recover.
       #
       # The handler's class name is exposed (handler authorship is local, not secret)
-      # but the exception's message is NOT forwarded — same reasoning as
+      # but the exception's message is NOT forwarded, using the same reasoning as
       # `invoke_tool_handler`: handler-returned objects can carry secrets.
       def self.serialize_tool_result(name:, result:)
         JSON.generate(result)
       rescue StandardError => e
-        UI.error("Could not serialize tool result for '#{name}': #{e.class}: #{e.message}. Result class: #{result.class}")
+        UI.error("Could not serialize tool result for '#{name}': #{e.class}. Result class: #{result.class}. Error message omitted because it may contain secrets.")
         JSON.generate({ error: "Tool result for '#{name}' could not be serialized to JSON. Returned class: #{result.class}." })
       end
 
       # Invokes a tool handler safely. Returns a JSON-serializable value that will be
       # sent back to the model as the `content` of a `role: tool` message (the value
-      # may be a Hash, Array, scalar, etc. — whatever the handler returns).
+      # may be a Hash, Array, scalar, etc. - whatever the handler returns).
       #
       # - Missing or non-callable handler: structured `{ error: ... }` so the model can recover.
       # - Handler raised: structured `{ error:, exception: }` carrying only the exception class
-      #   so the model can see the failure category and adjust. The full message and backtrace
-      #   are logged locally via `UI.error` but NOT forwarded to the model, because tool
-      #   results are sent to OpenAI and handler exception messages can contain secrets
+      #   so the model can see the failure category and adjust. The exception message and
+      #   backtrace are intentionally omitted from local logs and from the model response
+      #   because tool results and CI logs can expose release secrets
       #   (tokens, file contents, internal API responses). The loop keeps going rather than
-      #   aborting the lane mid-conversation — the model is the better judge of whether the
+      #   aborting the lane mid-conversation - the model is the better judge of whether the
       #   failure is recoverable than a global `rescue` here.
       def self.invoke_tool_handler(name:, handler:, args:)
         return { error: "No handler defined for tool '#{name}'" } if handler.nil?
@@ -198,7 +247,7 @@ module Fastlane
         begin
           handler.call(args)
         rescue StandardError => e
-          UI.error("Handler for tool '#{name}' raised #{e.class}: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
+          UI.error("Handler for tool '#{name}' raised #{e.class}. Error message and backtrace omitted because they may contain secrets.")
           { error: "Handler for tool '#{name}' raised an exception", exception: e.class.name }
         end
       end
@@ -228,7 +277,7 @@ module Fastlane
           When `tools` and `tool_handlers` are provided, the action runs a tool-use (function-calling) loop:
           on each turn, if the model calls one or more tools, the corresponding handler is invoked locally
           and its return value is sent back to the model as a `role: tool` message. The loop ends when the
-          model returns a plain text response, or when `max_tool_iterations` is reached.
+          model returns a plain text response, or before executing tool calls beyond `max_tool_iterations`.
         DETAILS
       end
 
@@ -312,13 +361,14 @@ module Fastlane
                                        default_value: DEFAULT_MODEL,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :tools,
-                                       description: 'Optional array of tool (function-calling) definitions in OpenAI format. ' \
+                                       description: 'Optional array of OpenAI function tool definitions. ' \
                                                     'When provided, the action runs a tool-use loop',
                                        optional: true,
                                        default_value: nil,
                                        type: Array,
                                        verify_block: proc do |value|
                                          UI.user_error!('Parameter `tools` must be a non-empty Array when provided') if value.empty?
+                                         validate_tools!(value)
                                        end),
           FastlaneCore::ConfigItem.new(key: :tool_handlers,
                                        description: 'Hash of tool name to a callable (e.g. a Proc) invoked when the model calls that tool. ' \
@@ -332,7 +382,7 @@ module Fastlane
                                          UI.user_error!("Parameter `tool_handlers` values must respond to :call. Non-callable handlers: #{non_callable.keys}") if non_callable.any?
                                        end),
           FastlaneCore::ConfigItem.new(key: :max_tool_iterations,
-                                       description: 'Maximum number of tool-use loop iterations before the action fails. ' \
+                                       description: 'Maximum number of local tool execution rounds before the action fails. ' \
                                                     'Only used when `tools` are provided',
                                        optional: true,
                                        default_value: DEFAULT_MAX_TOOL_ITERATIONS,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -33,7 +33,6 @@ module Fastlane
         # callers can register handlers with either string or symbol keys without surprises.
         tool_handlers = (params[:tool_handlers] || {}).transform_keys(&:to_s)
         max_tool_iterations = params[:max_tool_iterations] || DEFAULT_MAX_TOOL_ITERATIONS
-        validate_max_tool_iterations!(max_tool_iterations)
 
         headers = {
           'Content-Type': 'application/json',
@@ -48,6 +47,7 @@ module Fastlane
         end
 
         validate_tools_array!(tools)
+        validate_max_tool_iterations!(max_tool_iterations)
         validate_tools!(tools)
         run_with_tools(
           prompt: prompt,

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/openai_ask_action.rb
@@ -162,7 +162,7 @@ module Fastlane
 
           function = tool[:function] || tool['function']
           name = function[:name] || function['name'] if function.is_a?(Hash)
-          next if name.is_a?(String) && !name.empty?
+          next if valid_tool_name?(name)
 
           "tools[#{index}] missing function.name"
         end
@@ -181,10 +181,14 @@ module Fastlane
         (tool[:type] || tool['type']).to_s
       end
 
+      def self.valid_tool_name?(name)
+        (name.is_a?(String) || name.is_a?(Symbol)) && !name.to_s.empty?
+      end
+
       def self.execute_tool_call(tool_call, tool_handlers)
         return unsupported_tool_call_result(tool_call) unless function_tool_call?(tool_call)
 
-        name = tool_call.dig('function', 'name')
+        name = tool_call.dig('function', 'name').to_s
         raw_args = tool_call.dig('function', 'arguments') || '{}'
 
         result =
@@ -194,7 +198,8 @@ module Fastlane
           rescue JSON::ParserError
             # Short-circuit: the handler never sees malformed args. Tell the model the
             # tool-call payload was invalid so it can retry with valid JSON, and log the
-            # local failure without recording raw arguments that might contain secrets.
+            # local failure without recording raw arguments in normal logs. Verbose mode
+            # includes them for explicit debugging.
             UI.error("Invalid JSON arguments for tool '#{name}' in tool call '#{tool_call['id']}'. Raw payload omitted because it may contain secrets.")
             log_verbose_sensitive_diagnostics("Raw arguments for tool '#{name}' in tool call '#{tool_call['id']}': #{raw_args}")
             { error: "Invalid JSON arguments for tool '#{name}' — payload could not be parsed. Retry with valid JSON." }
@@ -212,19 +217,31 @@ module Fastlane
         return false unless tool_call['function'].is_a?(Hash)
 
         name = tool_call.dig('function', 'name')
-        name.is_a?(String) && !name.empty?
+        valid_tool_name?(name)
       end
 
       def self.unsupported_tool_call_result(tool_call)
         type = tool_call['type'] || '<missing>'
-        UI.error("Unsupported OpenAI tool call type '#{type}' in tool call '#{tool_call['id']}'. Only function tool calls are supported.")
+        error =
+          if type == 'function'
+            "Function tool call is missing a non-empty function.name."
+          else
+            "Unsupported tool call type '#{type}'. Only function tool calls are supported."
+          end
+        log_message =
+          if type == 'function'
+            "Invalid OpenAI function tool call '#{tool_call['id']}': missing a non-empty function.name."
+          else
+            "Unsupported OpenAI tool call type '#{type}' in tool call '#{tool_call['id']}'. Only function tool calls are supported."
+          end
+        UI.error(log_message)
 
         {
           role: 'tool',
           tool_call_id: tool_call['id'],
           content: serialize_tool_result(
             name: type,
-            result: { error: "Unsupported tool call type '#{type}'. Only function tool calls are supported." }
+            result: { error: error }
           )
         }
       end
@@ -257,9 +274,10 @@ module Fastlane
       # - Missing or non-callable handler: structured `{ error: ... }` so the model can recover.
       # - Handler raised: structured `{ error:, exception: }` carrying only the exception class
       #   so the model can see the failure category and adjust. The exception message and
-      #   backtrace are intentionally omitted from local logs and from the model response
+      #   backtrace are omitted from normal local logs and from the model response
       #   because tool results and CI logs can expose release secrets
-      #   (tokens, file contents, internal API responses). The loop keeps going rather than
+      #   (tokens, file contents, internal API responses). They are logged only when
+      #   fastlane verbose mode is enabled. The loop keeps going rather than
       #   aborting the lane mid-conversation — the model is the better judge of whether the
       #   failure is recoverable than a global `rescue` here.
       def self.invoke_tool_handler(name:, handler:, args:)

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -12,7 +12,7 @@ describe Fastlane::Actions::OpenaiAskAction do
         "id": "chatcmpl-Aa2NPY4sSWF5eKoW1aFBJmfc78y9p",
         "object": "chat.completion",
         "created": 1733152307,
-        "model": "gpt-4o-2024-08-06",
+        "model": "gpt-4.1-2025-04-14",
         "choices": [
           {
             "index": 0,
@@ -51,7 +51,7 @@ describe Fastlane::Actions::OpenaiAskAction do
       id: 'chatcmpl-toolcall',
       object: 'chat.completion',
       created: 1_733_152_308,
-      model: 'gpt-4o-2024-08-06',
+      model: 'gpt-4.1-2025-04-14',
       choices: [
         {
           index: 0,
@@ -157,6 +157,12 @@ describe Fastlane::Actions::OpenaiAskAction do
 
     expect(body['max_completion_tokens']).to eq(described_class.const_get(:DEFAULT_MAX_COMPLETION_TOKENS))
     expect(body).not_to have_key('max_tokens')
+  end
+
+  it 'uses gpt-4.1 as the default model' do
+    body = JSON.parse(described_class.request_body(prompt: 'sys', question: 'q'))
+
+    expect(body['model']).to eq('gpt-4.1')
   end
 
   it 'opts out of storing Chat Completions by default' do

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -141,6 +141,12 @@ describe Fastlane::Actions::OpenaiAskAction do
     expect(body).not_to have_key('max_tokens')
   end
 
+  it 'opts out of storing Chat Completions by default' do
+    body = JSON.parse(described_class.request_body(prompt: 'sys', question: 'q'))
+
+    expect(body['store']).to eq(false)
+  end
+
   it 'calls the API with :release_notes prompt' do
     changelog = <<~CHANGELOG
       - [Internal] Fetch remote FF on site change [https://github.com/woocommerce/woocommerce-android/pull/12751]
@@ -271,6 +277,7 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(tool_result_msg['tool_call_id']).to eq('call_xyz')
       expect(JSON.parse(tool_result_msg['content'])).to eq({ 'ok' => false, 'message' => 'too long' })
       expect(body['tools']).to eq(JSON.parse(tools.to_json))
+      expect(body['store']).to eq(false)
       expect(body['max_completion_tokens']).to eq(described_class.const_get(:DEFAULT_MAX_COMPLETION_TOKENS))
       expect(body).not_to have_key('max_tokens')
     end
@@ -447,6 +454,9 @@ describe Fastlane::Actions::OpenaiAskAction do
     end
 
     it 'returns a structured error tool result when the handler raises' do
+      allow(FastlaneCore::Globals).to receive(:verbose?).and_return(true)
+      expect(UI).not_to receive(:verbose)
+
       tool_handlers = {
         'check_length' => ->(_args) { raise ArgumentError, 'bad args' }
       }
@@ -591,10 +601,10 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(tool_result_msg['content']).not_to include('secret_token=abc123')
     end
 
-    it 'logs sensitive diagnostics only when verbose mode is enabled' do
+    it 'does not log raw tool arguments even when verbose mode is enabled' do
       allow(FastlaneCore::Globals).to receive(:verbose?).and_return(true)
       expect(UI).to receive(:error).with(/Raw payload omitted/)
-      expect(UI).to receive(:verbose).with(/secret_token=abc123/)
+      expect(UI).not_to receive(:verbose)
 
       result = described_class.execute_tool_call(
         {

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -144,7 +144,7 @@ describe Fastlane::Actions::OpenaiAskAction do
   it 'opts out of storing Chat Completions by default' do
     body = JSON.parse(described_class.request_body(prompt: 'sys', question: 'q'))
 
-    expect(body['store']).to eq(false)
+    expect(body['store']).to be(false)
   end
 
   it 'calls the API with :release_notes prompt' do
@@ -277,7 +277,7 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(tool_result_msg['tool_call_id']).to eq('call_xyz')
       expect(JSON.parse(tool_result_msg['content'])).to eq({ 'ok' => false, 'message' => 'too long' })
       expect(body['tools']).to eq(JSON.parse(tools.to_json))
-      expect(body['store']).to eq(false)
+      expect(body['store']).to be(false)
       expect(body['max_completion_tokens']).to eq(described_class.const_get(:DEFAULT_MAX_COMPLETION_TOKENS))
       expect(body).not_to have_key('max_tokens')
     end
@@ -610,11 +610,11 @@ describe Fastlane::Actions::OpenaiAskAction do
           'type' => 'function',
           'function' => {
             'name' => 'check_length',
-            'arguments' => 'this is not valid JSON with secret_token=abc123 {',
-          },
+            'arguments' => 'this is not valid JSON with secret_token=abc123 {'
+          }
         },
         {
-          'check_length' => ->(_args) { raise 'should not be called' },
+          'check_length' => ->(_args) { raise 'should not be called' }
         }
       )
 
@@ -631,11 +631,11 @@ describe Fastlane::Actions::OpenaiAskAction do
           'type' => 'custom',
           'custom' => {
             'name' => 'custom_tool',
-            'input' => 'payload',
-          },
+            'input' => 'payload'
+          }
         },
         {
-          'custom_tool' => ->(_args) { raise 'should not be called' },
+          'custom_tool' => ->(_args) { raise 'should not be called' }
         }
       )
 
@@ -654,11 +654,11 @@ describe Fastlane::Actions::OpenaiAskAction do
           'id' => 'call_missing_name',
           'type' => 'function',
           'function' => {
-            'arguments' => '{}',
-          },
+            'arguments' => '{}'
+          }
         },
         {
-          'validate_length' => ->(_args) { raise 'should not be called' },
+          'validate_length' => ->(_args) { raise 'should not be called' }
         }
       )
 
@@ -721,8 +721,8 @@ describe Fastlane::Actions::OpenaiAskAction do
             {
               type: 'custom',
               custom: {
-                name: 'custom_tool',
-              },
+                name: 'custom_tool'
+              }
             },
           ]
         )
@@ -739,8 +739,8 @@ describe Fastlane::Actions::OpenaiAskAction do
             {
               type: 'function',
               function: {
-                parameters: {},
-              },
+                parameters: {}
+              }
             },
           ]
         )

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -134,6 +134,13 @@ describe Fastlane::Actions::OpenaiAskAction do
     expect(JSON.parse(expected_req_body)['model']).to eq('gpt-4o-mini')
   end
 
+  it 'uses max_completion_tokens instead of deprecated max_tokens' do
+    body = JSON.parse(described_class.request_body(prompt: 'sys', question: 'q'))
+
+    expect(body['max_completion_tokens']).to eq(described_class.const_get(:DEFAULT_MAX_COMPLETION_TOKENS))
+    expect(body).not_to have_key('max_tokens')
+  end
+
   it 'calls the API with :release_notes prompt' do
     changelog = <<~CHANGELOG
       - [Internal] Fetch remote FF on site change [https://github.com/woocommerce/woocommerce-android/pull/12751]
@@ -165,7 +172,7 @@ describe Fastlane::Actions::OpenaiAskAction do
   describe 'with tool-use' do
     # Tool-use specs invoke `described_class.run` directly rather than
     # `run_described_fastlane_action`, because the latter inspects parameters
-    # into an eval'd Fastlane lane — and `Proc#inspect` is not valid Ruby.
+    # into an eval'd Fastlane lane - and `Proc#inspect` is not valid Ruby.
     let(:tools) do
       [
         {
@@ -264,21 +271,41 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(tool_result_msg['tool_call_id']).to eq('call_xyz')
       expect(JSON.parse(tool_result_msg['content'])).to eq({ 'ok' => false, 'message' => 'too long' })
       expect(body['tools']).to eq(JSON.parse(tools.to_json))
+      expect(body['max_completion_tokens']).to eq(described_class.const_get(:DEFAULT_MAX_COMPLETION_TOKENS))
+      expect(body).not_to have_key('max_tokens')
     end
 
     it 'fails when the loop exceeds max_tool_iterations' do
+      handler_calls = []
       tool_handlers = {
-        'check_length' => ->(_args) { { ok: false } }
+        'check_length' => lambda do |args|
+          handler_calls << args
+          { ok: false }
+        end
       }
 
-      # Always return a tool call — the loop should never terminate naturally.
-      perpetual_tool_call = stubbed_tool_call_response(
-        tool_call_id: 'call_loop',
+      # Always return tool calls; the third one must not be executed when the cap is 2.
+      first_tool_call = stubbed_tool_call_response(
+        tool_call_id: 'call_loop_1',
         name: 'check_length',
-        arguments_json: { text: 'x' }.to_json
+        arguments_json: { text: 'first' }.to_json
       )
-      stub_request(:post, endpoint)
-        .to_return(status: 200, body: perpetual_tool_call)
+      second_tool_call = stubbed_tool_call_response(
+        tool_call_id: 'call_loop_2',
+        name: 'check_length',
+        arguments_json: { text: 'second' }.to_json
+      )
+      third_tool_call = stubbed_tool_call_response(
+        tool_call_id: 'call_loop_3',
+        name: 'check_length',
+        arguments_json: { text: 'third' }.to_json
+      )
+      stub = stub_request(:post, endpoint)
+             .to_return(
+               { status: 200, body: first_tool_call },
+               { status: 200, body: second_tool_call },
+               { status: 200, body: third_tool_call }
+             )
 
       expect do
         described_class.run(
@@ -289,7 +316,45 @@ describe Fastlane::Actions::OpenaiAskAction do
           tool_handlers: tool_handlers,
           max_tool_iterations: 2
         )
-      end.to raise_error(FastlaneCore::Interface::FastlaneError, /did not terminate after 2 iterations/)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /did not produce a final answer after 2 tool iterations/)
+
+      expect(stub).to have_been_requested.times(3)
+      expect(handler_calls).to eq([{ 'text' => 'first' }, { 'text' => 'second' }])
+    end
+
+    it 'allows one final model response after the last permitted tool iteration' do
+      handler_calls = []
+      tool_handlers = {
+        'check_length' => lambda do |args|
+          handler_calls << args
+          { ok: true }
+        end
+      }
+      first_response = stubbed_tool_call_response(
+        tool_call_id: 'call_once',
+        name: 'check_length',
+        arguments_json: { text: 'draft' }.to_json
+      )
+      second_response = stubbed_response('Final answer.')
+
+      stub = stub_request(:post, endpoint)
+             .to_return(
+               { status: 200, body: first_response },
+               { status: 200, body: second_response }
+             )
+
+      result = described_class.run(
+        api_token: fake_token,
+        prompt: 'sys',
+        question: 'q',
+        tools: tools,
+        tool_handlers: tool_handlers,
+        max_tool_iterations: 1
+      )
+
+      expect(result).to eq('Final answer.')
+      expect(stub).to have_been_requested.twice
+      expect(handler_calls).to eq([{ 'text' => 'draft' }])
     end
 
     it 'sends the configured model on the wire when overridden' do
@@ -401,6 +466,14 @@ describe Fastlane::Actions::OpenaiAskAction do
           { status: 200, body: second_response }
         )
 
+      expect(UI).to receive(:error).with(
+        satisfy do |message|
+          message.include?("Handler for tool 'check_length' raised ArgumentError") &&
+            !message.include?('bad args') &&
+            !message.include?("\n")
+        end
+      )
+
       result = described_class.run(
         api_token: fake_token,
         prompt: 'sys',
@@ -415,9 +488,9 @@ describe Fastlane::Actions::OpenaiAskAction do
       content = JSON.parse(tool_result_msg['content'])
       expect(content['error']).to eq("Handler for tool 'check_length' raised an exception")
       expect(content['exception']).to eq('ArgumentError')
-      # Exception message must NOT be forwarded to the model — it can carry secrets
+      # Exception message must NOT be forwarded to the model - it can carry secrets
       # from the surrounding lane (tokens, file contents, etc.). Only the class name
-      # is sent; the full message is logged locally via `UI.error`.
+      # is sent; the full message is also omitted from local logs.
       expect(content).not_to have_key('message')
       expect(tool_result_msg['content']).not_to include('bad args')
     end
@@ -450,6 +523,13 @@ describe Fastlane::Actions::OpenaiAskAction do
           { status: 200, body: second_response }
         )
 
+      expect(UI).to receive(:error).with(
+        satisfy do |message|
+          message.include?("Could not serialize tool result for 'check_length': RuntimeError") &&
+            !message.include?('cannot serialize')
+        end
+      )
+
       result = described_class.run(
         api_token: fake_token,
         prompt: 'sys',
@@ -461,7 +541,7 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(result).to eq('Recovered.')
       tool_result_msg = JSON.parse(recorded_bodies.last)['messages'].find { |m| m['role'] == 'tool' }
       expect(JSON.parse(tool_result_msg['content'])['error']).to match(/could not be serialized to JSON/)
-      # Exception message must NOT leak — only the class is acceptable in the structured payload.
+      # Exception message must NOT leak - only the class is acceptable in the structured payload.
       expect(tool_result_msg['content']).not_to include('cannot serialize')
     end
 
@@ -477,7 +557,7 @@ describe Fastlane::Actions::OpenaiAskAction do
       first_response = stubbed_tool_call_response(
         tool_call_id: 'call_bad_json',
         name: 'check_length',
-        arguments_json: 'this is not valid JSON {'
+        arguments_json: 'this is not valid JSON with secret_token=abc123 {'
       )
       second_response = stubbed_response('Recovered.')
 
@@ -488,6 +568,13 @@ describe Fastlane::Actions::OpenaiAskAction do
           { status: 200, body: first_response },
           { status: 200, body: second_response }
         )
+
+      expect(UI).to receive(:error).with(
+        satisfy do |message|
+          message.include?("Invalid JSON arguments for tool 'check_length'") &&
+            !message.include?('secret_token=abc123')
+        end
+      )
 
       result = described_class.run(
         api_token: fake_token,
@@ -501,15 +588,40 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(handler_calls).to be_empty
       tool_result_msg = JSON.parse(recorded_bodies.last)['messages'].find { |m| m['role'] == 'tool' }
       expect(JSON.parse(tool_result_msg['content'])['error']).to match(/Invalid JSON arguments.*check_length/)
+      expect(tool_result_msg['content']).not_to include('secret_token=abc123')
+    end
+
+    it 'returns a structured error tool result for unsupported returned tool call types' do
+      expect(UI).to receive(:error).with(/Unsupported OpenAI tool call type 'custom'/)
+
+      result = described_class.execute_tool_call(
+        {
+          'id' => 'call_custom',
+          'type' => 'custom',
+          'custom' => {
+            'name' => 'custom_tool',
+            'input' => 'payload',
+          },
+        },
+        {
+          'custom_tool' => ->(_args) { raise 'should not be called' },
+        }
+      )
+
+      expect(result[:role]).to eq('tool')
+      expect(result[:tool_call_id]).to eq('call_custom')
+      expect(JSON.parse(result[:content])).to eq(
+        { 'error' => "Unsupported tool call type 'custom'. Only function tool calls are supported." }
+      )
     end
   end
 
   describe 'parameter validation' do
     it 'rejects max_tool_iterations < 1' do
-      # No `tool_handlers` here — `run_described_fastlane_action` inspects args into an
+      # No `tool_handlers` here - `run_described_fastlane_action` inspects args into an
       # eval'd lane, and `Proc#inspect` is not valid Ruby. The other tool-use specs that
       # need a handler invoke `described_class.run` directly to avoid this. We don't need
-      # a handler to exercise the `max_tool_iterations` `verify_block` — it fires before
+      # a handler to exercise the `max_tool_iterations` `verify_block` - it fires before
       # the action body runs.
       expect do
         run_described_fastlane_action(
@@ -531,6 +643,24 @@ describe Fastlane::Actions::OpenaiAskAction do
           tools: []
         )
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /tools.*non-empty Array/)
+    end
+
+    it 'rejects unsupported tool definition types' do
+      expect do
+        described_class.run(
+          api_token: fake_token,
+          prompt: 'sys',
+          question: 'q',
+          tools: [
+            {
+              type: 'custom',
+              custom: {
+                name: 'custom_tool',
+              },
+            },
+          ]
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /only supports OpenAI function tools/)
     end
 
     it 'rejects tool_handlers with non-callable values' do

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -637,6 +637,29 @@ describe Fastlane::Actions::OpenaiAskAction do
         { 'error' => "Unsupported tool call type 'custom'. Only function tool calls are supported." }
       )
     end
+
+    it 'returns a clear structured error when a returned function tool call has no name' do
+      expect(UI).to receive(:error).with(/missing a non-empty function.name/)
+
+      result = described_class.execute_tool_call(
+        {
+          'id' => 'call_missing_name',
+          'type' => 'function',
+          'function' => {
+            'arguments' => '{}',
+          },
+        },
+        {
+          'validate_length' => ->(_args) { raise 'should not be called' },
+        }
+      )
+
+      expect(result[:role]).to eq('tool')
+      expect(result[:tool_call_id]).to eq('call_missing_name')
+      expect(JSON.parse(result[:content])).to eq(
+        { 'error' => 'Function tool call is missing a non-empty function.name.' }
+      )
+    end
   end
 
   describe 'parameter validation' do
@@ -714,6 +737,12 @@ describe Fastlane::Actions::OpenaiAskAction do
           ]
         )
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /missing function.name/)
+    end
+
+    it 'accepts symbol function names in tool definitions' do
+      expect do
+        described_class.validate_tools!([{ type: 'function', function: { name: :noop, parameters: {} } }])
+      end.not_to raise_error
     end
 
     it 'rejects tool_handlers with non-callable values' do

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -454,7 +454,7 @@ describe Fastlane::Actions::OpenaiAskAction do
     end
 
     it 'returns a structured error tool result when the handler raises' do
-      expect(UI).not_to receive(:verbose)
+      expect(FastlaneCore::UI).not_to receive(:verbose)
 
       tool_handlers = {
         'check_length' => ->(_args) { raise ArgumentError, 'bad args' }
@@ -475,7 +475,7 @@ describe Fastlane::Actions::OpenaiAskAction do
           { status: 200, body: second_response }
         )
 
-      expect(UI).to receive(:error).with(
+      expect(FastlaneCore::UI).to receive(:error).with(
         satisfy do |message|
           message.include?("Handler for tool 'check_length' raised ArgumentError") &&
             !message.include?('bad args') &&
@@ -532,7 +532,7 @@ describe Fastlane::Actions::OpenaiAskAction do
           { status: 200, body: second_response }
         )
 
-      expect(UI).to receive(:error).with(
+      expect(FastlaneCore::UI).to receive(:error).with(
         satisfy do |message|
           message.include?("Could not serialize tool result for 'check_length': RuntimeError") &&
             !message.include?('cannot serialize')
@@ -578,7 +578,7 @@ describe Fastlane::Actions::OpenaiAskAction do
           { status: 200, body: second_response }
         )
 
-      expect(UI).to receive(:error).with(
+      expect(FastlaneCore::UI).to receive(:error).with(
         satisfy do |message|
           message.include?("Invalid JSON arguments for tool 'check_length'") &&
             !message.include?('secret_token=abc123')
@@ -601,8 +601,8 @@ describe Fastlane::Actions::OpenaiAskAction do
     end
 
     it 'does not log raw tool arguments even when verbose mode is enabled' do
-      expect(UI).to receive(:error).with(/Raw payload omitted/)
-      expect(UI).not_to receive(:verbose)
+      expect(FastlaneCore::UI).to receive(:error).with(/Raw payload omitted/)
+      expect(FastlaneCore::UI).not_to receive(:verbose)
 
       result = described_class.execute_tool_call(
         {
@@ -623,7 +623,7 @@ describe Fastlane::Actions::OpenaiAskAction do
     end
 
     it 'returns a structured error tool result for unsupported returned tool call types' do
-      expect(UI).to receive(:error).with(/Unsupported OpenAI tool call type 'custom'/)
+      expect(FastlaneCore::UI).to receive(:error).with(/Unsupported OpenAI tool call type 'custom'/)
 
       result = described_class.execute_tool_call(
         {
@@ -647,7 +647,7 @@ describe Fastlane::Actions::OpenaiAskAction do
     end
 
     it 'returns a clear structured error when a returned function tool call has no name' do
-      expect(UI).to receive(:error).with(/missing a non-empty function.name/)
+      expect(FastlaneCore::UI).to receive(:error).with(/missing a non-empty function.name/)
 
       result = described_class.execute_tool_call(
         {
@@ -707,6 +707,17 @@ describe Fastlane::Actions::OpenaiAskAction do
           prompt: 'sys',
           question: 'q',
           tools: []
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /tools.*non-empty Array/)
+    end
+
+    it 'rejects non-array tools when run directly' do
+      expect do
+        described_class.run(
+          api_token: fake_token,
+          prompt: 'sys',
+          question: 'q',
+          tools: 'not a tools array'
         )
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /tools.*non-empty Array/)
     end

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -454,7 +454,6 @@ describe Fastlane::Actions::OpenaiAskAction do
     end
 
     it 'returns a structured error tool result when the handler raises' do
-      allow(FastlaneCore::Globals).to receive(:verbose?).and_return(true)
       expect(UI).not_to receive(:verbose)
 
       tool_handlers = {
@@ -602,7 +601,6 @@ describe Fastlane::Actions::OpenaiAskAction do
     end
 
     it 'does not log raw tool arguments even when verbose mode is enabled' do
-      allow(FastlaneCore::Globals).to receive(:verbose?).and_return(true)
       expect(UI).to receive(:error).with(/Raw payload omitted/)
       expect(UI).not_to receive(:verbose)
 

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -172,7 +172,7 @@ describe Fastlane::Actions::OpenaiAskAction do
   describe 'with tool-use' do
     # Tool-use specs invoke `described_class.run` directly rather than
     # `run_described_fastlane_action`, because the latter inspects parameters
-    # into an eval'd Fastlane lane - and `Proc#inspect` is not valid Ruby.
+    # into an eval'd Fastlane lane — and `Proc#inspect` is not valid Ruby.
     let(:tools) do
       [
         {
@@ -488,7 +488,7 @@ describe Fastlane::Actions::OpenaiAskAction do
       content = JSON.parse(tool_result_msg['content'])
       expect(content['error']).to eq("Handler for tool 'check_length' raised an exception")
       expect(content['exception']).to eq('ArgumentError')
-      # Exception message must NOT be forwarded to the model - it can carry secrets
+      # Exception message must NOT be forwarded to the model — it can carry secrets
       # from the surrounding lane (tokens, file contents, etc.). Only the class name
       # is sent; the full message is also omitted from local logs.
       expect(content).not_to have_key('message')
@@ -541,7 +541,7 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(result).to eq('Recovered.')
       tool_result_msg = JSON.parse(recorded_bodies.last)['messages'].find { |m| m['role'] == 'tool' }
       expect(JSON.parse(tool_result_msg['content'])['error']).to match(/could not be serialized to JSON/)
-      # Exception message must NOT leak - only the class is acceptable in the structured payload.
+      # Exception message must NOT leak — only the class is acceptable in the structured payload.
       expect(tool_result_msg['content']).not_to include('cannot serialize')
     end
 
@@ -591,6 +591,29 @@ describe Fastlane::Actions::OpenaiAskAction do
       expect(tool_result_msg['content']).not_to include('secret_token=abc123')
     end
 
+    it 'logs sensitive diagnostics only when verbose mode is enabled' do
+      allow(FastlaneCore::Globals).to receive(:verbose?).and_return(true)
+      expect(UI).to receive(:error).with(/Raw payload omitted/)
+      expect(UI).to receive(:verbose).with(/secret_token=abc123/)
+
+      result = described_class.execute_tool_call(
+        {
+          'id' => 'call_bad_json',
+          'type' => 'function',
+          'function' => {
+            'name' => 'check_length',
+            'arguments' => 'this is not valid JSON with secret_token=abc123 {',
+          },
+        },
+        {
+          'check_length' => ->(_args) { raise 'should not be called' },
+        }
+      )
+
+      expect(JSON.parse(result[:content])['error']).to match(/Invalid JSON arguments.*check_length/)
+      expect(result[:content]).not_to include('secret_token=abc123')
+    end
+
     it 'returns a structured error tool result for unsupported returned tool call types' do
       expect(UI).to receive(:error).with(/Unsupported OpenAI tool call type 'custom'/)
 
@@ -618,10 +641,10 @@ describe Fastlane::Actions::OpenaiAskAction do
 
   describe 'parameter validation' do
     it 'rejects max_tool_iterations < 1' do
-      # No `tool_handlers` here - `run_described_fastlane_action` inspects args into an
+      # No `tool_handlers` here — `run_described_fastlane_action` inspects args into an
       # eval'd lane, and `Proc#inspect` is not valid Ruby. The other tool-use specs that
       # need a handler invoke `described_class.run` directly to avoid this. We don't need
-      # a handler to exercise the `max_tool_iterations` `verify_block` - it fires before
+      # a handler to exercise the `max_tool_iterations` `verify_block` — it fires before
       # the action body runs.
       expect do
         run_described_fastlane_action(
@@ -632,6 +655,18 @@ describe Fastlane::Actions::OpenaiAskAction do
           max_tool_iterations: 0
         )
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /max_tool_iterations.*must be >= 1/)
+    end
+
+    it 'rejects non-integer max_tool_iterations when run directly' do
+      expect do
+        described_class.run(
+          api_token: fake_token,
+          prompt: 'sys',
+          question: 'q',
+          tools: [{ type: 'function', function: { name: 'noop', parameters: {} } }],
+          max_tool_iterations: '2'
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /max_tool_iterations.*must be an Integer/)
     end
 
     it 'rejects empty tools array' do
@@ -661,6 +696,24 @@ describe Fastlane::Actions::OpenaiAskAction do
           ]
         )
       end.to raise_error(FastlaneCore::Interface::FastlaneError, /only supports OpenAI function tools/)
+    end
+
+    it 'rejects function tool definitions without a function name' do
+      expect do
+        described_class.run(
+          api_token: fake_token,
+          prompt: 'sys',
+          question: 'q',
+          tools: [
+            {
+              type: 'function',
+              function: {
+                parameters: {},
+              },
+            },
+          ]
+        )
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, /missing function.name/)
     end
 
     it 'rejects tool_handlers with non-callable values' do

--- a/spec/openai_ask_action_spec.rb
+++ b/spec/openai_ask_action_spec.rb
@@ -134,6 +134,24 @@ describe Fastlane::Actions::OpenaiAskAction do
     expect(JSON.parse(expected_req_body)['model']).to eq('gpt-4o-mini')
   end
 
+  it 'ignores max_tool_iterations on the single-shot path' do
+    expected_req_body = described_class.request_body(prompt: 'sys', question: 'q')
+
+    stub = stub_request(:post, endpoint)
+           .with(body: expected_req_body)
+           .to_return(status: 200, body: stubbed_response('Hi.'))
+
+    result = described_class.run(
+      api_token: fake_token,
+      prompt: 'sys',
+      question: 'q',
+      max_tool_iterations: 'not used without tools'
+    )
+
+    expect(result).to eq('Hi.')
+    expect(stub).to have_been_requested
+  end
+
   it 'uses max_completion_tokens instead of deprecated max_tokens' do
     body = JSON.parse(described_class.request_body(prompt: 'sys', question: 'q'))
 


### PR DESCRIPTION
## What does it do?

Improves `openai_ask` follow-up behavior after the initial tool-use support:

- Uses `max_completion_tokens` for Chat Completions requests.
- Adds `store: false` to opt out of OpenAI request storage.
- Validates function tool definitions before sending them to OpenAI.
- Keeps malformed or unsupported tool calls from invoking local handlers.
- Caps local tool execution without dropping the final allowed model response.
- Avoids logging raw tool arguments, handler exception messages, or backtraces.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.