### PR TITLE
Add Linux platforms to upload_build_to_apps_cdn allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-- `upload_build_to_apps_cdn`: Update the list of valid values for `platform` to add support for `Linux - x64` and `Linux - ARM64`.
+- `upload_build_to_apps_cdn`: Update the list of valid values for `platform` to add support for `Linux - x64` and `Linux - ARM64`. [#720]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-_None_
+- `upload_build_to_apps_cdn`: Update the list of valid values for `platform` to add support for `Linux - x64` and `Linux - ARM64`.
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb
@@ -40,6 +40,8 @@ module Fastlane
         'Microsoft Store - x86',
         'Microsoft Store - x64',
         'Microsoft Store - ARM64',
+        'Linux - x64',
+        'Linux - ARM64',
       ].freeze
       # See https://github.a8c.com/Automattic/wpcom/blob/trunk/wp-content/lib/a8c/cdn/src/enums/enum-install-type.php
       VALID_INSTALL_TYPES = [


### PR DESCRIPTION
## Description

Resolves RSM-3058

Adds `'Linux - x64'` and `'Linux - ARM64'` to the `VALID_PLATFORMS` array in the `upload_build_to_apps_cdn` action.

WordPress.com Studio is wiring up Linux distribution to AppsCDN. The WPCOM-side `Platform` enum and the extension allowlist were updated in the WPCOM repo to accept these two platform values, but uploads still fail in CI because this fastlane action's **client-side** platform validation rejects them before the HTTP request reaches the server:

```
Error setting value 'Linux - x64' for option 'platform'
Platform must be one of: Android, iOS, Mac - Silicon, Mac - Intel, Mac - Any,
Windows - x86, Windows - x64, Windows - ARM64,
Microsoft Store - x86, Microsoft Store - x64, Microsoft Store - ARM64
```

This PR closes that gap. Precedent: #672 added `'Microsoft Store - x64'` and `'Windows - x64'` to the same array.

## Changes

- `lib/fastlane/plugin/wpmreleasetoolkit/actions/common/upload_build_to_apps_cdn.rb`: appends `'Linux - x64'` and `'Linux - ARM64'` to `VALID_PLATFORMS`.
- `CHANGELOG.md`: New Features entry under `## Trunk`, mirroring the wording in #672's entry.

No spec changes needed — `spec/upload_build_to_apps_cdn_spec.rb` already references `described_class::VALID_PLATFORMS.join(', ')` dynamically, so the existing tests automatically pick up the new entries.

## How AI was used in this PR

AI-assisted: identified the gap by tracing the failure in a Studio CI build, located the file/lines to edit, and drafted this PR. Author reviewed.

## Context

- Studio's distribution PR that surfaced the issue: [Automattic/studio#3363](https://github.com/Automattic/studio/pull/3363) (now reverted in [Automattic/studio#3462](https://github.com/Automattic/studio/pull/3462) until this lands and a new gem version is released).
- Failing CI build: [Studio Buildkite #16073](https://buildkite.com/automattic/studio/builds/16073).