### PR TITLE
Configure dependabot bundler updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ _None_
 ### Internal Changes
 
 - `openai_ask`: validate named function tools, default to `gpt-4.1`, use `max_completion_tokens`, and opt out of OpenAI request storage. [#719]
-- Configure Dependabot to update Ruby dependencies daily, grouping minor/patch bumps under `ruby-minor-and-patch`.
+- Configure Dependabot to update Ruby dependencies daily, grouping minor/patch bumps under `ruby-minor-and-patch`. [#724]
 
 ## 14.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _None_
 ### Internal Changes
 
 - `openai_ask`: validate named function tools, default to `gpt-4.1`, use `max_completion_tokens`, and opt out of OpenAI request storage. [#719]
+- Configure Dependabot to update Ruby dependencies daily, grouping minor/patch bumps under `ruby-minor-and-patch`.
 
 ## 14.6.0
 


### PR DESCRIPTION
## What does it do?

Sets up Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations. — n/a, YAML-only change.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable. — n/a, the dependabot config is consumed by GitHub, not the repo's CI.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass. — n/a, no Ruby changes.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md). — n/a, no breaking changes.

## Test plan

Dependabot config is consumed by GitHub, not the repo's CI. YAML validation passes (`yq . .github/dependabot.yml`).

---

Posted by Claude (Opus 4.7, 1M context) on behalf of @mokagio with approval.