### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/docs/screenshot-compositor.md
+++ b/docs/screenshot-compositor.md
@@ -131,7 +131,7 @@ Sets the origin of the screenshot text bounding box. This must be provided as an
 
 **`font_size`**
 
-Sets the font size for the screenshot text. If this value is too large, the compositor will crash saying it was unable to draw the text within the bounding box specifed in `text_size`.*
+Sets the font size for the screenshot text. If this value is too large, the compositor will crash saying it was unable to draw the text within the bounding box specified in `text_size`.*
 
 **`screenshot_size`**
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -151,7 +151,7 @@ module Fastlane
       end
 
       ### A helper function to extract the distance from the provided string.
-      ### (ie – this function will recieve "behind 2" or "ahead 6" and return 2 or 6, respectively.
+      ### (ie – this function will receive "behind 2" or "ahead 6" and return 2 or 6, respectively.
       def self.parse_distance(match)
         distance = match.to_s.scan(/\d+/).first
 
@@ -265,7 +265,7 @@ module Fastlane
       end
 
       ## Updates the project encryption key defined in ~/.mobile-secrets/keys.json
-      ## The updated file is commited and push to the repo
+      ## The updated file is committed and push to the repo
       def self.update_project_encryption_key
         # Update keys.json with the new key
         keys_json = mobile_secrets_keys_json

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/configure_helper.rb
@@ -265,7 +265,7 @@ module Fastlane
       end
 
       ## Updates the project encryption key defined in ~/.mobile-secrets/keys.json
-      ## The updated file is committed and push to the repo
+      ## The updated file is committed and pushed to the repo
       def self.update_project_encryption_key
         # Update keys.json with the new key
         keys_json = mobile_secrets_keys_json

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/ios/ios_l10n_linter_helper.rb
@@ -14,7 +14,7 @@ module Fastlane
         attr_reader :install_path, :version
 
         # @param [String] install_path The path to install SwiftGen to. Usually something like "$PROJECT_DIR/vendor/swiftgen/#{SWIFTGEN_VERSION}".
-        #        It's recommended to provide an absolute path here rather than a relative one, to ensure it's not dependant on where the action is run from.
+        #        It's recommended to provide an absolute path here rather than a relative one, to ensure it's not dependent on where the action is run from.
         # @param [String] version The version of SwiftGen to use. This will be used both:
         #        - to check if the current version located in `install_path`, if it already exists, is the expected one
         #        - to know which version to download if there is not one installed in `install_path` yet

--- a/spec/upload_to_s3_spec.rb
+++ b/spec/upload_to_s3_spec.rb
@@ -273,7 +273,7 @@ describe Fastlane::Actions::UploadToS3Action do
           end
         end
 
-        # Untill we remove the deprecated skip_if_exists option, if_exists needs to be optional.
+        # Until we remove the deprecated skip_if_exists option, if_exists needs to be optional.
         # if_exists also has a verify_block that will throw if the given value doesn't match the allowed ones.
         # This test makes sure that if the user omits or set if_exists as nil, Fastlane bypasses the verify_block.
         # This is models a possible usage for the action—we want to be extra careful.


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments and documentation — no behaviour change. Code identifiers and user-facing strings are untouched.

Each commit is one file, so the change is easy to review file by file.

## Testing instructions

No runtime impact — comment/doc-only. A green CI build is sufficient.

---

*Posted by Claude (Opus 4.8) on behalf of @mokagio with approval.*
