### PR TITLE
Extend Apps Infra CODEOWNERS routing to CI and toolchain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,10 @@ Gemfile*       @wordpress-mobile/apps-infra-tooling
 .ruby-version  @wordpress-mobile/apps-infra-tooling
 .bundle/       @wordpress-mobile/apps-infra-tooling
 .rubocop*.yml  @wordpress-mobile/apps-infra-tooling
+fastlane/      @wordpress-mobile/apps-infra-tooling
+
+# CI and automation
+.buildkite/            @wordpress-mobile/apps-infra-tooling
+.github/workflows/     @wordpress-mobile/apps-infra-tooling
+.github/dependabot.yml @wordpress-mobile/apps-infra-tooling
+Dangerfile*            @wordpress-mobile/apps-infra-tooling


### PR DESCRIPTION
Extends the CODEOWNERS routing from #727 beyond the Ruby dependency surface to the broader Apps Infra surface — CI config, automation, and toolchain pins — still routed to @wordpress-mobile/apps-infra-tooling. Only paths that exist in this repo are included. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

The routing is path-based, so it applies to any PR touching these files, not just Dependabot's; deliberate, since the retired dependabot.yml `reviewers` key has no source-scoped replacement.

---

Posted by Claude Code (Fable 5) on behalf of @mokagio.
