### PR TITLE
Release 14.7.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ _None_
 
 ### New Features
 
+_None_
+
+### Bug Fixes
+
+_None_
+
+### Internal Changes
+
+_None_
+
+## 14.7.0
+
+### New Features
+
 - Added new `update_apps_cdn_build_metadata` action to update metadata (e.g. visibility) of one or more existing builds on the Apps CDN without re-uploading the files, via the dedicated `/wpcom/v2/sites/{site_id}/a8c-cdn/builds/{post_id}` endpoint. Accepts an array of `post_ids`. This enables a two-phase release flow: upload builds as Internal first, then flip to External at publish time. [#701]
 
 ### Bug Fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.6.0)
+    fastlane-plugin-wpmreleasetoolkit (14.7.0)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.6.0'
+    VERSION = '14.7.0'
   end
 end


### PR DESCRIPTION
Releasing new version 14.7.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- Added new `update_apps_cdn_build_metadata` action to update metadata (e.g. visibility) of one or more existing builds on the Apps CDN without re-uploading the files, via the dedicated `/wpcom/v2/sites/{site_id}/a8c-cdn/builds/{post_id}` endpoint. Accepts an array of `post_ids`. This enables a two-phase release flow: upload builds as Internal first, then flip to External at publish time. [#701]

### Bug Fixes

- `openai_ask`: avoid logging sensitive tool diagnostics and refuse to execute additional tool calls after `max_tool_iterations`. [#719]
- Bump the `fastlane` floor to `~> 2.235` to pull in `jwt >= 3.2.0`, fixing [GHSA-c32j-vqhx-rx3x](https://github.com/advisories/GHSA-c32j-vqhx-rx3x) (ruby-jwt empty-key HMAC bypass). [#728]

### Internal Changes

- `openai_ask`: validate named function tools, default to `gpt-4.1`, use `max_completion_tokens`, and opt out of OpenAI request storage. [#719]
- Configure Dependabot to update Ruby dependencies daily, grouping minor/patch bumps under `ruby-minor-and-patch`. [#724]


```
