### PR TITLE
Add `ios_lint_localization_placeholder_changes` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _None_
 ### New Features
 
 - Added `find_or_create_pull_request` action and `GithubHelper#find_pull_request`: returns the URL of the open Pull Request for a head branch, creating one only if none exists yet. Useful for "rolling" automations (e.g. a daily translations or dependency-update job) that force-push the same head branch on every run. [#733]
+- Added the platform-agnostic `StringPlaceholdersHelper` primitive (`placeholder_signature`, `placeholders_compatible?`, `incompatible_placeholder_changes`, `mixed_operators?`) and the `ios_lint_localization_placeholder_changes` action: fails when an existing localization key's source-language value changes its format placeholders — count, position, or argument type — between two versions of the base `.strings` file. Such a change silently breaks every existing translation filed under that key. Complements `ios_lint_localizations` on the temporal (base↔base across versions) axis. The action also aborts (by default, via `check_duplicate_keys`) when either input file defines a key more than once, since `plutil` silently keeps only the last value and a duplicate could otherwise hide a real placeholder change, and always aborts when a source value mixes positional (`%1$@`) and non-positional (`%@`) placeholders, which is invalid and makes the placeholder shape impossible to compare reliably. [#738]
 
 ### Bug Fixes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localization_placeholder_changes.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_lint_localization_placeholder_changes.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require 'fastlane/action'
+require_relative '../../helper/string_placeholders_helper'
+require_relative '../../helper/ios/ios_l10n_helper'
+require_relative '../../helper/ios/ios_strings_file_validation_helper'
+
+module Fastlane
+  module Actions
+    class IosLintLocalizationPlaceholderChangesAction < Action
+      def self.run(params)
+        # Parse and validate both inputs first, so a genuinely invalid file (a non-dictionary plist, an
+        # unparseable file) surfaces an accurate input error rather than tripping the duplicate-key
+        # scanner below and reporting it as a duplicate-check failure.
+        old_strings = read_strings(params[:old_file])
+        new_strings = read_strings(params[:new_file])
+
+        # Duplicate keys must be caught *before the comparison*: `plutil` silently keeps only the last
+        # value for a duplicated key, so a duplicate could hide a real placeholder change. They always
+        # abort — independently of `abort_on_violations`, which only governs *placeholder changes* —
+        # because the comparison itself is unreliable until each key is defined exactly once.
+        if params[:check_duplicate_keys]
+          duplicate_keys = duplicate_keys_by_file(params)
+          unless duplicate_keys.empty?
+            report_duplicate_keys(duplicate_keys)
+            UI.abort_with_message!(duplicate_keys_abort_message(duplicate_keys))
+          end
+        end
+
+        # A value mixing positional (`%1$@`) and non-positional (`%@`) placeholders is invalid —
+        # printf/`NSString` require all-or-nothing positional — so its placeholder signature has no
+        # well-defined argument order and can't be compared. Always abort (like duplicate keys, and
+        # independently of `abort_on_violations`): the comparison itself is unreliable for such a value.
+        mixed_keys = mixed_operator_keys_by_file(params[:old_file] => old_strings, params[:new_file] => new_strings)
+        unless mixed_keys.empty?
+          report_mixed_operators(mixed_keys)
+          UI.abort_with_message!(mixed_operators_abort_message(mixed_keys))
+        end
+
+        violations = Fastlane::Helper::StringPlaceholdersHelper.incompatible_placeholder_changes(old_strings, new_strings)
+        report(violations)
+
+        UI.abort_with_message!(abort_message(violations.length)) if !violations.empty? && params[:abort_on_violations]
+
+        violations
+      end
+
+      # Reads a `.strings` file into a `{ key => value }` hash. A malformed file is an *input* error
+      # (like a missing file), so surface a clean, user-facing message naming it rather than letting a
+      # raw `plutil` stderr dump escape the lane. `read_strings_file_as_hash` shells out to `plutil`,
+      # which handles text/XML/binary plists, so this only trips on genuinely unparseable input.
+      def self.read_strings(path)
+        strings =
+          begin
+            Fastlane::Helper::Ios::L10nHelper.read_strings_file_as_hash(path: path)
+          rescue StandardError => e
+            UI.user_error!("Could not parse `#{File.basename(path)}` as a `.strings` file. #{e.message.strip}")
+          end
+        return strings if strings.is_a?(Hash)
+
+        UI.user_error!("`#{File.basename(path)}` is not a valid `.strings` file (expected a dictionary of key/value pairs).")
+      end
+
+      def self.report(violations)
+        if violations.empty?
+          UI.success('No incompatible placeholder changes found between the two versions of the strings file.')
+          return
+        end
+
+        violations.each do |violation|
+          UI.error <<~MSG
+            `#{violation[:key]}` changed its format placeholders incompatibly:
+                was: #{violation[:old].inspect}  [#{describe_signature(violation[:old_signature])}]
+                now: #{violation[:new].inspect}  [#{describe_signature(violation[:new_signature])}]
+          MSG
+        end
+      end
+
+      def self.describe_signature(signature)
+        signature.empty? ? 'no placeholders' : signature
+      end
+
+      def self.abort_message(count)
+        <<~MSG
+          #{count} localization key(s) changed their format placeholders incompatibly.
+
+          Existing translations are keyed by the string's key, not its English text, so changing
+          the placeholders of an existing key would silently break every translation for that key.
+          Give the changed copy a brand new key instead, so the previous translations stay valid
+          for the previous key and the new copy gets translated from scratch.
+        MSG
+      end
+
+      # Finds duplicate keys in the old and new files, returned as `{ path => { key => [lines] } }`,
+      # only including files that actually have duplicates. Format detection and scanning are delegated
+      # to `StringsFileValidationHelper.scan_for_duplicate_keys`; `duplicate_keys_in` maps each outcome.
+      def self.duplicate_keys_by_file(params)
+        [params[:old_file], params[:new_file]].uniq.each_with_object({}) do |path, result|
+          duplicates = duplicate_keys_in(path)
+          result[path] = duplicates unless duplicates.empty?
+        end
+      end
+
+      def self.duplicate_keys_in(path)
+        # `run` has already parsed both files via `read_strings`, so the plist is known-valid here —
+        # `assume_valid: true` skips the redundant `plutil -lint` inside the format check.
+        status, payload = Fastlane::Helper::Ios::StringsFileValidationHelper.scan_for_duplicate_keys(file: path, assume_valid: true)
+        case status
+        when :scanned then payload
+        # A non-`:text` plist (xml/binary) has no tokenizer here, but `plutil` collapses any duplicate to
+        # its last value when parsing it, and toolkit-generated XML is built from a Hash and is dup-free
+        # anyway — so there's nothing to catch.
+        when :unsupported_format then {}
+        # A `:text` file `plutil` parses but our scanner can't tokenize (e.g. a nested dictionary/array
+        # value — valid old-style plist, but not a flat `.strings`). We can't guarantee each key is defined
+        # exactly once, and `plutil` keeps only the *last* value for a duplicate, so proceeding could
+        # compare the wrong value and miss a real placeholder change. Fail closed rather than compare blindly.
+        when :unscannable then UI.abort_with_message!(unverifiable_duplicates_abort_message(path, payload))
+        end
+      end
+
+      # Emits one `UI.error` per file in a `{ path => { key => detail } }` hash: a headline naming the
+      # file and the offending-key count, then one indented line per key formatted by the given block.
+      def self.report_per_file(by_path, headline:, &entry)
+        by_path.each do |path, entries|
+          UI.error <<~MSG
+            `#{File.basename(path)}` #{headline.call(entries.count)}:
+            #{entries.map(&entry).join("\n")}
+          MSG
+        end
+      end
+
+      def self.report_duplicate_keys(duplicate_keys)
+        report_per_file(duplicate_keys, headline: ->(count) { "defines #{count} key(s) more than once" }) do |key, lines|
+          "    `#{key}` at lines #{lines.join(', ')}"
+        end
+      end
+
+      def self.duplicate_keys_abort_message(duplicate_keys)
+        count = duplicate_keys.values.sum(&:count)
+        <<~MSG
+          #{count} localization key(s) are defined more than once in the source strings.
+
+          Parsing `.strings` files relies on `plutil`, which silently keeps only the *last* value for
+          a duplicated key. This check would therefore compare against the wrong value and could miss a
+          real, translation-breaking placeholder change — the exact failure it exists to catch. Define
+          each key exactly once and regenerate the file before re-running this check.
+        MSG
+      end
+
+      def self.unverifiable_duplicates_abort_message(path, error_message)
+        <<~MSG
+          Could not verify `#{File.basename(path)}` for duplicate keys: #{error_message.strip}
+
+          Parsing `.strings` files relies on `plutil`, which silently keeps only the *last* value for a
+          duplicated key, so this action guards against a duplicate hiding a real placeholder change. The
+          file parses as text but our duplicate-key scanner couldn't tokenize it, so that guarantee can't
+          be established and the comparison would be unreliable. Make sure the file is a flat `.strings`
+          (each line a `key = value;` pair), or pass `check_duplicate_keys: false` to skip this check.
+        MSG
+      end
+
+      # Finds keys whose value mixes positional and non-positional placeholders, per file, returned as
+      # `{ path => { key => value } }`, only including files that have any.
+      def self.mixed_operator_keys_by_file(strings_by_path)
+        strings_by_path.each_with_object({}) do |(path, strings), result|
+          mixed = strings.select { |_key, value| Fastlane::Helper::StringPlaceholdersHelper.mixed_operators?(value) }
+          result[path] = mixed unless mixed.empty?
+        end
+      end
+
+      def self.report_mixed_operators(mixed_keys)
+        report_per_file(mixed_keys, headline: ->(count) { "has #{count} key(s) that mix positional and non-positional placeholders" }) do |key, value|
+          "    `#{key}`: #{value.inspect}"
+        end
+      end
+
+      def self.mixed_operators_abort_message(mixed_keys)
+        count = mixed_keys.values.sum(&:count)
+        <<~MSG
+          #{count} localization key(s) mix positional (`%1$@`) and non-positional (`%@`) placeholders in a single value.
+
+          Mixing the two in one format string is invalid — `printf`/`NSString` require either all-positional
+          or all-non-positional — so the placeholder shape can't be compared reliably. Give every placeholder
+          an explicit `%N$` position, or none, and regenerate the file before re-running this check.
+        MSG
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Checks that no existing localization key changed its format placeholders between two versions of a source `.strings` file'
+      end
+
+      def self.details
+        <<~DETAILS
+          Compares two versions (old vs new) of the same base-language `.strings` file and reports any
+          key — present in both — whose format placeholders (`%@`, `%1$d`, …) changed in count, position,
+          or argument type.
+
+          This is the temporal counterpart to `ios_lint_localizations` (which compares each translation
+          against the base language at a single point in time). Translations are filed by key, not by
+          English text, so changing the placeholders of an existing key silently breaks every translation
+          of that key. New and removed keys are ignored on purpose: copy that needs different placeholders
+          is expected to land under a brand new key.
+
+          By default it also aborts if either input file defines the same key more than once: `plutil`
+          silently keeps only the last value for a duplicated key, which would let a duplicate hide a
+          real placeholder change. Disable this with `check_duplicate_keys: false`.
+
+          Note: parsing `.strings` files relies on `plutil`, so this action only runs on macOS.
+        DETAILS
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :old_file,
+            env_name: 'FL_IOS_LINT_L10N_PLACEHOLDER_CHANGES_OLD_FILE',
+            description: 'Path to the previous version of the base-language `.strings` file',
+            optional: false,
+            type: String,
+            verify_block: proc do |value|
+              UI.user_error!("`old_file` not found at path: #{value}") unless File.exist?(value)
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :new_file,
+            env_name: 'FL_IOS_LINT_L10N_PLACEHOLDER_CHANGES_NEW_FILE',
+            description: 'Path to the newly-generated version of the base-language `.strings` file',
+            optional: false,
+            type: String,
+            verify_block: proc do |value|
+              UI.user_error!("`new_file` not found at path: #{value}") unless File.exist?(value)
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :abort_on_violations,
+            env_name: 'FL_IOS_LINT_L10N_PLACEHOLDER_CHANGES_ABORT',
+            description: 'Should we abort the rest of the lane with a global error if any incompatible changes are found?',
+            optional: true,
+            default_value: true,
+            type: Boolean
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :check_duplicate_keys,
+            env_name: 'FL_IOS_LINT_L10N_PLACEHOLDER_CHANGES_CHECK_DUPLICATE_KEYS',
+            description: 'Abort if either input file defines the same key more than once. `plutil` keeps only the last value for a duplicated key, which would otherwise let a duplicate silently hide a real placeholder change',
+            optional: true,
+            default_value: true,
+            type: Boolean
+          ),
+        ]
+      end
+
+      def self.return_type
+        :array
+      end
+
+      def self.return_value
+        'An array of incompatible changes, each a hash with the keys `:key`, `:old`, `:new`, `:old_signature` and `:new_signature`. Empty if there are no incompatible changes.'
+      end
+
+      def self.authors
+        ['Automattic']
+      end
+
+      def self.is_supported?(platform)
+        %i[ios mac].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/string_placeholders_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/string_placeholders_helper.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Fastlane
+  module Helper
+    # Platform-agnostic primitive for comparing the placeholder "shape" — the
+    # count, position, and argument type of the printf/`NSString` format
+    # specifiers — of localized string values.
+    #
+    # This is purposely **pure Ruby** (no file I/O, no shelling out) so it runs
+    # on any platform: the same `%@`/`%1$d`/`%2$s` placeholder syntax is shared by
+    # iOS and Android. The platform-specific actions parse their respective file
+    # format into a `{ key => value }` hash and then call into this helper.
+    #
+    # The main use case is a temporal guardrail: when a source-language string is
+    # regenerated, an existing key's value must not change its placeholders
+    # (e.g. `"%1$@ liked your post"` → `"%1$d people liked your post"`). Existing
+    # translations stay filed under the same key, so a placeholder-incompatible
+    # change would silently break every translation of that key. Copy that needs
+    # different placeholders is expected to land under a brand new key instead.
+    #
+    module StringPlaceholdersHelper
+      # printf / `NSString` conversion characters grouped by the argument type a
+      # translation must preserve. Width, precision and length modifiers don't
+      # affect the argument type, so they are intentionally not part of the class.
+      #
+      # `%d` ↔ `%i` is compatible (both consume an `int`); `%d` ↔ `%@` is not
+      # (`int` vs `object`).
+      CONVERSION_CLASSES = {
+        '@' => 'object',
+        'd' => 'int', 'i' => 'int', 'u' => 'int', 'o' => 'int', 'x' => 'int', 'X' => 'int',
+        'f' => 'float', 'e' => 'float', 'E' => 'float', 'g' => 'float', 'G' => 'float', 'a' => 'float', 'A' => 'float',
+        'c' => 'char', 'C' => 'char',
+        's' => 'cstring', 'S' => 'cstring',
+        'p' => 'pointer'
+      }.freeze
+
+      # A single format specifier: a `%`, an optional positional argument (`1$`),
+      # flags, width, precision, an optional length modifier, then the conversion
+      # character. `%%` (a literal percent) is matched too so it can be explicitly
+      # skipped rather than mistaken for a placeholder.
+      #
+      # The flag class includes the two thousands-grouping flags — C/POSIX `'` (`%'d`) and
+      # Java/Android `,` (`%,d`) — alongside the standard `-`, `+`, `0`, `#`. Omitting the grouping
+      # flags would drop a real placeholder: `%,d` would match nothing and vanish from the signature, so
+      # a count change on an all-grouped string (`"%,d of %,d"` → `"%,d done"`) would be silently missed.
+      # Adding or removing a grouping flag stays compatible (it doesn't change the argument type). (Java's
+      # `(` accounting flag is intentionally excluded — `%(` collides with parenthetical copy and
+      # Python-style `%(name)s`.)
+      #
+      # The printf space flag (`% d`) is deliberately NOT in the class. A `%` followed by a space is how
+      # a *literal* percent reads in real copy (`"50% off"`, `"100% done"`), so recognizing `% d` as a
+      # space-flagged specifier would invent a phantom placeholder out of ordinary text — flagging benign
+      # copy edits and, worse, masking a real placeholder removal when the phantom happens to match the
+      # removed argument's type. Treating a glued `%d` as a specifier but a spaced `% word` as a literal
+      # percent matches how localized strings are actually written.
+      #
+      # `*` dynamic width/precision (`%*d`, `%.*f`) is deliberately NOT matched: it consumes an extra
+      # `int` argument that this one-slot-per-specifier model can't represent. Leaving it unrecognized
+      # is the safe choice — rather than silently treating `%*d` as compatible with `%d`, a change to
+      # or from a `*` specifier surfaces as a difference and gets flagged.
+      #
+      # Precision is `.` followed by *zero or more* digits, so the valid C "precision 0" form (`%.f`)
+      # is recognized as a float rather than silently dropped.
+      #
+      # `%n` (the write-back conversion) is intentionally NOT in the conversion class: it consumes no
+      # printable argument, has no place in a localized string, and is a format-string hazard — so a
+      # stray `%n` in copy is treated as a literal percent, not a placeholder.
+      SPECIFIER = /%(?<position>\d+\$)?[-+0#,']*\d*(?:\.\d*)?(?:hh|h|ll|l|q|L|z|t|j)?(?<conversion>[@diouxXeEfgGaAcCsSp%])/
+
+      # A canonical signature of the placeholders in a string value.
+      #
+      # Two values with the same signature are placeholder-compatible. The
+      # signature is invariant to benign copy edits, to reordering equivalent
+      # positional arguments, and to repeating a positional argument (which still
+      # consumes a single argument), but sensitive to a change in the count,
+      # position, or argument type of the placeholders.
+      #
+      # @param [String] value The string value to compute a signature for.
+      # @return [String] e.g. `"1:int,2:object"`, or `''` if there are no placeholders.
+      #
+      def self.placeholder_signature(value)
+        # Collapse the specifiers into argument *slots* keyed by position: an explicit `%1$…` keys by
+        # its number, a non-positional `%…` by its order of appearance. Keying (rather than listing)
+        # means a positional argument referenced more than once (`%1$@ … %1$@`) collapses to a single
+        # slot — it still consumes one argument, so it stays compatible with a single `%1$@`. Sorting
+        # by position keeps the signature invariant to reordering equivalent positional arguments.
+        slots = {}
+        extract_specifiers(value).each_with_index do |specifier, index|
+          slots[specifier[:position] || (index + 1)] = specifier[:class]
+        end
+        slots.sort.map { |position, klass| "#{position}:#{klass}" }.join(',')
+      end
+
+      # Whether two string values share the same placeholder shape.
+      #
+      # @param [String] old_value The first value to compare.
+      # @param [String] new_value The second value to compare.
+      # @return [Boolean] `true` if both values have the same placeholder signature.
+      #
+      def self.placeholders_compatible?(old_value, new_value)
+        placeholder_signature(old_value) == placeholder_signature(new_value)
+      end
+
+      # Given two `{ key => value }` hashes, finds the keys present in **both**
+      # whose placeholder signature changed.
+      #
+      # New and removed keys are ignored on purpose: copy that needs a fresh
+      # translation is expected to land under a new key (which shows up as
+      # remove-old + add-new, not as a change to an existing key).
+      #
+      # @param [Hash<String,String>] old_strings The previous `{ key => value }` strings.
+      # @param [Hash<String,String>] new_strings The new `{ key => value }` strings.
+      # @return [Array<Hash>] One entry per incompatible change, sorted by key, each
+      #         `{ key:, old:, new:, old_signature:, new_signature: }`.
+      #
+      def self.incompatible_placeholder_changes(old_strings, new_strings)
+        (old_strings.keys & new_strings.keys).sort.filter_map do |key|
+          old_signature = placeholder_signature(old_strings[key])
+          new_signature = placeholder_signature(new_strings[key])
+          next if old_signature == new_signature
+
+          { key: key, old: old_strings[key], new: new_strings[key], old_signature: old_signature, new_signature: new_signature }
+        end
+      end
+
+      # Whether a value mixes positional (`%1$@`) and non-positional (`%@`) format specifiers in a
+      # single string. This is invalid — `printf`/`NSString`/`Formatter` require either all-positional
+      # or all-non-positional — so such a value has no well-defined argument order and its
+      # `placeholder_signature` can't be trusted. Callers should reject a mixed value rather than
+      # compare it.
+      #
+      # @param [String] value The string value to check.
+      # @return [Boolean] `true` if the value contains both a positional and a non-positional specifier.
+      #
+      def self.mixed_operators?(value)
+        specifiers = extract_specifiers(value)
+        specifiers.any? { |specifier| specifier[:position] } && specifiers.any? { |specifier| specifier[:position].nil? }
+      end
+
+      # The format specifiers found in a value, as an array of
+      # `{ position:, class: }` hashes, excluding the literal `%%`.
+      # `position` is `nil` for non-positional specifiers.
+      #
+      # @param [String] value The string value to scan.
+      # @return [Array<Hash>] The specifiers, in order of appearance.
+      #
+      def self.extract_specifiers(value)
+        found = []
+        value.to_s.scan(SPECIFIER) do
+          match = Regexp.last_match
+          conversion = match[:conversion]
+          next if conversion == '%' # literal percent, not a placeholder
+
+          found << { position: match[:position]&.delete('$')&.to_i, class: CONVERSION_CLASSES.fetch(conversion, conversion) }
+        end
+        found
+      end
+      private_class_method :extract_specifiers
+    end
+  end
+end

--- a/spec/ios_lint_localization_placeholder_changes_spec.rb
+++ b/spec/ios_lint_localization_placeholder_changes_spec.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Fastlane::Actions::IosLintLocalizationPlaceholderChangesAction do
+  before do
+    # Prevent the action from actually aborting the (test) lane when violations are found.
+    allow(FastlaneCore::UI).to receive(:abort_with_message!)
+  end
+
+  # Writes `old` and `new` as ASCII-plist `.strings` files in a temporary
+  # directory and runs the action against them.
+  def lint_placeholder_changes(old:, new:, **extra_params)
+    in_tmp_dir do |tmp_dir|
+      old_file = File.join(tmp_dir, 'old.strings')
+      new_file = File.join(tmp_dir, 'new.strings')
+      File.write(old_file, old)
+      File.write(new_file, new)
+      run_described_fastlane_action({ old_file: old_file, new_file: new_file }.merge(extra_params))
+    end
+  end
+
+  it 'returns no violations and does not abort when placeholders are unchanged' do
+    expect(FastlaneCore::UI).not_to receive(:abort_with_message!)
+
+    result = lint_placeholder_changes(
+      old: <<~OLD,
+        "greeting" = "Hello %@";
+        "count" = "%d items";
+      OLD
+      new: <<~NEW
+        "greeting" = "Hi %@";
+        "count" = "%d items remaining";
+      NEW
+    )
+
+    expect(result).to eq([])
+  end
+
+  it 'prints a success message when there are no incompatible changes' do
+    # The lane runner also emits `UI.success` ("Driving the lane …"), so capture all of them and
+    # assert ours is among them rather than constraining every call.
+    messages = []
+    allow(FastlaneCore::UI).to receive(:success) { |m| messages << m }
+
+    lint_placeholder_changes(old: '"greeting" = "Hi %@";', new: '"greeting" = "Hello %@";')
+
+    expect(messages.join("\n")).to include('No incompatible placeholder changes')
+  end
+
+  it 'reports and aborts when an existing key changes its placeholder type' do
+    expect(FastlaneCore::UI).to receive(:abort_with_message!)
+
+    result = lint_placeholder_changes(
+      old: '"likes" = "%d likes";',
+      new: '"likes" = "%@ likes";'
+    )
+
+    expect(result).to eq(
+      [{ key: 'likes', old: '%d likes', new: '%@ likes', old_signature: '1:int', new_signature: '1:object' }]
+    )
+  end
+
+  it 'actually halts the lane (raises) when it aborts on violations, instead of returning' do
+    # The `before` block stubs `abort_with_message!` to a no-op so the other examples can inspect the
+    # return value. Here we let the real one run to prove the abort genuinely stops the lane: in
+    # production `UI.abort_with_message!` raises, so the action must not fall through to its `return`.
+    allow(FastlaneCore::UI).to receive(:abort_with_message!).and_call_original
+
+    expect do
+      lint_placeholder_changes(old: '"likes" = "%d likes";', new: '"likes" = "%@ likes";')
+    end.to raise_error(/changed their format placeholders incompatibly/)
+  end
+
+  it 'ignores added and removed keys, only flagging changes to keys present in both' do
+    result = lint_placeholder_changes(
+      old: <<~OLD,
+        "shared" = "Hello %@";
+        "removed" = "%d gone";
+      OLD
+      new: <<~NEW
+        "shared" = "Hi %@";
+        "added" = "%d new";
+      NEW
+    )
+
+    expect(result).to eq([])
+  end
+
+  it 'does not abort when `abort_on_violations` is false but still returns the violations' do
+    expect(FastlaneCore::UI).not_to receive(:abort_with_message!)
+
+    result = lint_placeholder_changes(
+      old: '"msg" = "%1$d in %2$@";',
+      new: '"msg" = "%1$d only";',
+      abort_on_violations: false
+    )
+
+    expect(result).to eq(
+      [{ key: 'msg', old: '%1$d in %2$@', new: '%1$d only', old_signature: '1:int,2:object', new_signature: '1:int' }]
+    )
+  end
+
+  it 'fails with a friendly error when a file does not exist' do
+    in_tmp_dir do |tmp_dir|
+      old_file = File.join(tmp_dir, 'old.strings')
+      File.write(old_file, '"key" = "value";')
+      missing_file = File.join(tmp_dir, 'does-not-exist.strings')
+
+      expect do
+        run_described_fastlane_action(old_file: old_file, new_file: missing_file)
+      end.to raise_error(/not found/)
+    end
+  end
+
+  context 'when a source file defines the same key more than once' do
+    # `plutil` keeps only the *last* value for a duplicated key, so without this guard the
+    # incompatible first definition below would be silently discarded and the change missed.
+    it 'aborts with an explanation, before the (now-unreliable) comparison can hide the change' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/defined more than once/)
+
+      result = lint_placeholder_changes(
+        old: '"likes" = "%d likes";',
+        new: <<~NEW
+          "likes" = "%@ likes";
+          "likes" = "%d likes";
+        NEW
+      )
+
+      expect(result).to eq([])
+    end
+
+    it 'halts on the duplicate key *before* the placeholder comparison runs' do
+      # Here the duplicated *last* value (`%@ likes`) is itself incompatible with old (`%d likes`), so a
+      # comparison run first would raise about a placeholder change. Letting the real abort run (rather
+      # than the no-op stub) and asserting we get the duplicate-key error instead proves the duplicate
+      # guard halts the action ahead of the now-unreliable comparison — not merely that both happen to
+      # yield `[]`.
+      allow(FastlaneCore::UI).to receive(:abort_with_message!).and_call_original
+
+      expect do
+        lint_placeholder_changes(
+          old: '"likes" = "%d likes";',
+          new: <<~NEW
+            "likes" = "%@ likes";
+            "likes" = "%@ likes";
+          NEW
+        )
+      end.to raise_error(/defined more than once/)
+    end
+
+    it 'lists each duplicated key and its line numbers in the error output' do
+      errors = []
+      allow(FastlaneCore::UI).to receive(:error) { |m| errors << m }
+
+      lint_placeholder_changes(
+        old: '"likes" = "%d likes";',
+        new: <<~NEW
+          "dup" = "a";
+          "dup" = "b";
+        NEW
+      )
+
+      expect(errors.join("\n")).to include('defines 1 key(s) more than once')
+      expect(errors.join("\n")).to include('`dup` at lines 1, 2')
+    end
+
+    it 'also catches duplicates in the old file' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/defined more than once/)
+
+      lint_placeholder_changes(
+        old: <<~OLD,
+          "greeting" = "Hello %@";
+          "greeting" = "Hello %@";
+        OLD
+        new: '"greeting" = "Hello %@";'
+      )
+    end
+
+    it 'aborts on duplicate keys even when `abort_on_violations` is false (they corrupt the comparison itself)' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/defined more than once/)
+
+      lint_placeholder_changes(
+        old: '"k" = "%@";',
+        new: <<~NEW,
+          "k" = "%@";
+          "k" = "%@";
+        NEW
+        abort_on_violations: false
+      )
+    end
+
+    it 'does not check for duplicates when `check_duplicate_keys` is false (plutil silently keeps the last value)' do
+      expect(FastlaneCore::UI).not_to receive(:abort_with_message!)
+
+      result = lint_placeholder_changes(
+        old: '"likes" = "%d likes";',
+        new: <<~NEW,
+          "likes" = "%@ likes";
+          "likes" = "%d likes";
+        NEW
+        check_duplicate_keys: false
+      )
+
+      expect(result).to eq([]) # the incompatible first definition is silently discarded
+    end
+
+    it 'detects duplicates even when the keys are unquoted (`InfoPlist.strings` style)' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/defined more than once/)
+
+      lint_placeholder_changes(
+        old: "NSHumanReadableCopyright = \"© %@\";\n",
+        new: <<~NEW
+          NSHumanReadableCopyright = "© %@";
+          NSHumanReadableCopyright = "© %d";
+        NEW
+      )
+    end
+  end
+
+  context 'when a `:text` file parses for `plutil` but the scanner cannot tokenize it' do
+    # An old-style plist value can be a nested dictionary (`"k" = { a = b; };`) — valid input that
+    # `plutil` parses, but not a flat `.strings` file the duplicate-key scanner can tokenize. The check
+    # must not silently skip and compare blindly: each key being defined once is a precondition for a
+    # reliable comparison, so we fail closed.
+    it 'aborts (fails closed) rather than skipping the duplicate-key check' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/Could not verify .* for duplicate keys/).and_call_original
+
+      expect do
+        lint_placeholder_changes(old: '"greeting" = "Hello %@";', new: "\"k\" = { a = b; };\n")
+      end.to raise_error(/Could not verify .* for duplicate keys/)
+    end
+
+    it 'proceeds (no abort) when the duplicate-key check is explicitly disabled' do
+      expect(FastlaneCore::UI).not_to receive(:abort_with_message!)
+
+      result = lint_placeholder_changes(
+        old: '"greeting" = "Hello %@";',
+        new: "\"k\" = { a = b; };\n",
+        check_duplicate_keys: false
+      )
+
+      expect(result).to eq([])
+    end
+  end
+
+  context 'with `InfoPlist.strings`-style unquoted keys and values' do
+    # `CFBundleName = WordPress;` (key and value unquoted) is valid ASCII-plist; the scanner now
+    # tokenizes it, so the action compares it like any other file instead of failing closed.
+    it 'compares them without aborting' do
+      expect(FastlaneCore::UI).not_to receive(:abort_with_message!)
+
+      result = lint_placeholder_changes(
+        old: "CFBundleName = WordPress;\n",
+        new: "CFBundleName = Jetpack;\n"
+      )
+
+      expect(result).to eq([])
+    end
+
+    it 'still flags an incompatible placeholder change under an unquoted key' do
+      # A value carrying a `%` placeholder is always quoted (a bare `%` isn't valid unquoted), so the
+      # comparison runs on the quoted value while the key stays unquoted.
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/changed their format placeholders/)
+
+      result = lint_placeholder_changes(
+        old: 'NSHumanReadableCopyright = "Count: %d";',
+        new: 'NSHumanReadableCopyright = "Count: %@";'
+      )
+
+      expect(result).to eq(
+        [{ key: 'NSHumanReadableCopyright', old: 'Count: %d', new: 'Count: %@', old_signature: '1:int', new_signature: '1:object' }]
+      )
+    end
+  end
+
+  context 'when an input file cannot be parsed' do
+    it 'fails with a clean error (not a raw plutil dump) for a malformed `.strings` file' do
+      in_tmp_dir do |tmp_dir|
+        old_file = File.join(tmp_dir, 'old.strings')
+        new_file = File.join(tmp_dir, 'new.strings')
+        File.write(old_file, '"key" = "value";')
+        File.write(new_file, '"key" = "value"') # missing trailing semicolon — plutil rejects it
+
+        expect do
+          run_described_fastlane_action(old_file: old_file, new_file: new_file)
+        end.to raise_error(/Could not parse `new\.strings`/)
+      end
+    end
+
+    it 'fails with a clean error for a valid plist that is not a key/value dictionary' do
+      in_tmp_dir do |tmp_dir|
+        old_file = File.join(tmp_dir, 'old.strings')
+        new_file = File.join(tmp_dir, 'new.strings')
+        File.write(old_file, '"key" = "value";')
+        File.write(new_file, '( "just", "an", "array" )') # valid plist, but an array, not a dictionary
+
+        expect do
+          run_described_fastlane_action(old_file: old_file, new_file: new_file)
+        end.to raise_error(/not a valid `\.strings` file/)
+      end
+    end
+  end
+
+  context 'when a source value mixes positional and non-positional placeholders' do
+    # Mixing `%1$@` and `%@` in one value is invalid (printf/`NSString` require all-or-nothing
+    # positional), so its placeholder signature has no well-defined argument order and can't be
+    # compared. The action always aborts — like duplicate keys, independently of `abort_on_violations`.
+    it 'aborts, naming the offending key, instead of comparing an unreliable signature' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/mix positional.*and non-positional/).and_call_original
+
+      expect do
+        lint_placeholder_changes(old: '"greeting" = "Hello %@";', new: '"greeting" = "%1$@ says %d";')
+      end.to raise_error(/mix positional.*and non-positional/)
+    end
+
+    it 'aborts even when `abort_on_violations` is false (the signature itself is unreliable)' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/mix positional.*and non-positional/).and_call_original
+
+      expect do
+        lint_placeholder_changes(old: '"k" = "%@";', new: '"k" = "%1$@ and %d";', abort_on_violations: false)
+      end.to raise_error(/mix positional.*and non-positional/)
+    end
+
+    it 'detects a mix in the old file too' do
+      expect(FastlaneCore::UI).to receive(:abort_with_message!).with(/mix positional.*and non-positional/).and_call_original
+
+      expect do
+        lint_placeholder_changes(old: '"k" = "%1$@ and %d";', new: '"k" = "%@";')
+      end.to raise_error(/mix positional.*and non-positional/)
+    end
+  end
+end

--- a/spec/string_placeholders_helper_spec.rb
+++ b/spec/string_placeholders_helper_spec.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Fastlane::Helper::StringPlaceholdersHelper do
+  describe '.placeholder_signature' do
+    # The exact worked examples from the issue spec — these must match byte-for-byte.
+    {
+      'Just text' => '',
+      'Hello %@' => '1:object',
+      '%1$d items in %2$@' => '1:int,2:object',
+      '%2$@ told by %1$@' => '1:object,2:object',
+      '100%% sure about %@' => '1:object',
+      '%d likes' => '1:int'
+    }.each do |value, expected_signature|
+      it "returns #{expected_signature.inspect} for #{value.inspect}" do
+        expect(described_class.placeholder_signature(value)).to eq(expected_signature)
+      end
+    end
+
+    context 'when mapping conversion characters to argument-type classes' do
+      it 'maps `%d` and `%i` to the same `int` class' do
+        expect(described_class.placeholder_signature('%i likes')).to eq('1:int')
+        expect(described_class.placeholder_signature('%d likes')).to eq(described_class.placeholder_signature('%i likes'))
+      end
+
+      it 'groups the other unsigned/hex integer conversions as `int`' do
+        %w[%u %o %x %X].each do |specifier|
+          expect(described_class.placeholder_signature("value: #{specifier}")).to eq('1:int')
+        end
+      end
+
+      it 'groups all floating-point conversions as `float`' do
+        %w[%f %e %E %g %G %a %A].each do |specifier|
+          expect(described_class.placeholder_signature("value: #{specifier}")).to eq('1:float')
+        end
+      end
+
+      it 'classes `%c`/`%C` as `char`, `%s`/`%S` as `cstring`, and `%p` as `pointer`' do
+        expect(described_class.placeholder_signature('%c')).to eq('1:char')
+        expect(described_class.placeholder_signature('%C')).to eq('1:char')
+        expect(described_class.placeholder_signature('%s')).to eq('1:cstring')
+        expect(described_class.placeholder_signature('%S')).to eq('1:cstring')
+        expect(described_class.placeholder_signature('%p')).to eq('1:pointer')
+      end
+    end
+
+    context 'with edge-case values' do
+      it 'returns an empty signature for nil, empty, and whitespace-only values' do
+        expect(described_class.placeholder_signature(nil)).to eq('')
+        expect(described_class.placeholder_signature('')).to eq('')
+        expect(described_class.placeholder_signature("   \n\t")).to eq('')
+      end
+
+      it 'skips the literal `%%` and does not count it as a placeholder' do
+        expect(described_class.placeholder_signature('100%% done')).to eq('')
+        expect(described_class.placeholder_signature('%% then %@ then %%')).to eq('1:object')
+      end
+
+      it 'treats a single literal `%` followed by a space as a literal percent, not a specifier' do
+        # Common display copy uses a bare `%` ("50% off"). The printf space flag (`% d`) is deliberately
+        # not recognized, so the following word is not mistaken for a space-flagged specifier.
+        expect(described_class.placeholder_signature('50% off')).to eq('')
+        expect(described_class.placeholder_signature('100% done')).to eq('')
+        expect(described_class.placeholder_signature('Battery at 50% and charging')).to eq('')
+        expect(described_class.placeholder_signature('100% complete.')).to eq('')
+        # A real placeholder alongside literal-percent copy keeps only the real one.
+        expect(described_class.placeholder_signature('You saved %@ — 50% off')).to eq('1:object')
+      end
+
+      it 'treats the write-back `%n` conversion as a literal, not a placeholder' do
+        # `%n` consumes no printable argument and has no place in a localized string, so it is not
+        # recognized as a specifier (and never classed as a bogus `n` type).
+        expect(described_class.placeholder_signature('%n')).to eq('')
+        expect(described_class.placeholder_signature('Press %n to continue')).to eq('')
+      end
+
+      it 'recognizes the C "precision 0" form `%.f` (a dot with no digits) as a float' do
+        # `.` followed by zero digits is valid (precision 0); it must not drop the placeholder.
+        expect(described_class.placeholder_signature('%.f km')).to eq('1:float')
+        expect(described_class.placeholders_compatible?('%.1f km', '%.f km')).to be(true)
+      end
+
+      it 'ignores width, precision, and length modifiers when classing the type' do
+        expect(described_class.placeholder_signature('%5d')).to eq('1:int')
+        expect(described_class.placeholder_signature('%.2f')).to eq('1:float')
+        expect(described_class.placeholder_signature('%-8.3f')).to eq('1:float')
+        expect(described_class.placeholder_signature('%1$ld')).to eq('1:int')
+        expect(described_class.placeholder_signature('%lld')).to eq('1:int')
+      end
+
+      it 'numbers non-positional specifiers by order of appearance' do
+        expect(described_class.placeholder_signature('%@ and %d and %f')).to eq('1:object,2:int,3:float')
+      end
+
+      it 'sorts positional specifiers by their explicit position' do
+        expect(described_class.placeholder_signature('%3$@ %1$d %2$f')).to eq('1:int,2:float,3:object')
+      end
+
+      it 'handles non-ASCII copy and escaped quotes/backslashes around the placeholders' do
+        expect(described_class.placeholder_signature('「%@」を削除しますか？')).to eq('1:object')
+        expect(described_class.placeholder_signature('Path \\"%@\\" — %d items\\\\')).to eq('1:object,2:int')
+      end
+
+      it 'is deterministic for the rare/invalid mix of positional and non-positional specifiers' do
+        signature = described_class.placeholder_signature('%1$@ and %d')
+        expect(signature).to eq('1:object,2:int')
+        # Calling it again on the same input yields the same result.
+        expect(described_class.placeholder_signature('%1$@ and %d')).to eq(signature)
+      end
+    end
+
+    context 'with a positional argument referenced more than once' do
+      # `%1$@ … %1$@` consumes a single argument (printed twice), so it must collapse to one slot and
+      # stay compatible with a single `%1$@` — repeating an argument is not a placeholder change.
+      it 'collapses a repeated positional argument to a single slot' do
+        expect(described_class.placeholder_signature('%1$@ and %1$@')).to eq('1:object')
+        expect(described_class.placeholder_signature('%1$@')).to eq('1:object')
+      end
+
+      it 'collapses three references to the same positional argument' do
+        expect(described_class.placeholder_signature('%1$d, %1$d and %1$d')).to eq('1:int')
+      end
+
+      it 'keeps the other arguments when one positional argument repeats' do
+        expect(described_class.placeholder_signature('%1$@ told %2$d, then %1$@ again')).to eq('1:object,2:int')
+      end
+
+      it 'does not collapse distinct non-positional placeholders of the same type' do
+        # Non-positional args are consumed in order, so two `%@` are two separate arguments.
+        expect(described_class.placeholder_signature('%@ and %@')).to eq('1:object,2:object')
+      end
+    end
+
+    context 'with thousands-grouping flags' do
+      # The C/POSIX `'` and Java/Android `,` grouping flags must be recognized, otherwise the whole
+      # specifier fails to match and silently vanishes from the signature — masking a real change.
+      it 'recognizes the `,` (Java/Android) and `\'` (C/POSIX) grouping flags as a normal `int`' do
+        expect(described_class.placeholder_signature('%,d')).to eq('1:int')
+        expect(described_class.placeholder_signature("%'d")).to eq('1:int')
+        expect(described_class.placeholder_signature('%,12d')).to eq('1:int')
+        expect(described_class.placeholder_signature('%1$,d in %2$@')).to eq('1:int,2:object')
+      end
+
+      it 'treats a grouped int the same as a plain int (the flag does not change the argument type)' do
+        expect(described_class.placeholder_signature('%,d')).to eq(described_class.placeholder_signature('%d'))
+      end
+    end
+
+    context 'with `*` dynamic width or precision' do
+      # `%*d`/`%.*f` consume an extra `int` (the width/precision) that the one-slot-per-specifier
+      # model can't represent, so they are intentionally left unrecognized rather than silently
+      # treated as compatible with a fixed-width/precision specifier.
+      it 'does not recognize a `*` specifier (so it cannot masquerade as its fixed counterpart)' do
+        expect(described_class.placeholder_signature('%.*f km')).to eq('')
+        expect(described_class.placeholder_signature('%*d items')).to eq('')
+      end
+    end
+  end
+
+  describe '.placeholders_compatible?' do
+    # The exact compatibility table from the issue spec.
+    [
+      ['Hello %@', 'Hi %@', true],                       # text-only change
+      ['%1$@ said %2$@', '%2$@ told by %1$@', true],     # positional reorder, same types
+      ['%d likes', '%@ likes', false],                  # int → object
+      ['%1$d in %2$@', '%1$d only', false],             # dropped a placeholder
+    ].each do |old_value, new_value, expected|
+      it "returns #{expected} for #{old_value.inspect} → #{new_value.inspect}" do
+        expect(described_class.placeholders_compatible?(old_value, new_value)).to be(expected)
+      end
+    end
+
+    it 'treats `%d` ↔ `%i` as compatible (same argument type)' do
+      expect(described_class.placeholders_compatible?('%d apples', '%i apples')).to be(true)
+    end
+
+    it 'treats two placeholder-free strings as compatible' do
+      expect(described_class.placeholders_compatible?('Old copy', 'New copy')).to be(true)
+    end
+
+    it 'treats adding a placeholder to a placeholder-free string as incompatible' do
+      expect(described_class.placeholders_compatible?('Done', 'Done %@')).to be(false)
+    end
+
+    it 'treats repeating a positional argument as compatible (the same argument consumed twice)' do
+      expect(described_class.placeholders_compatible?('%1$@', '%1$@ and %1$@')).to be(true)
+    end
+
+    it 'treats adding a genuinely new positional argument as incompatible' do
+      expect(described_class.placeholders_compatible?('%1$@', '%1$@ in %2$@')).to be(false)
+    end
+
+    it 'treats adding or removing a thousands-grouping flag as compatible (same `int` argument)' do
+      expect(described_class.placeholders_compatible?('%d items', '%,d items')).to be(true)
+    end
+
+    it 'still catches a count change between two grouped-int placeholders' do
+      # Both sides use the `,` grouping flag; without flag support both would collapse to an empty
+      # signature and this translation-breaking 2 → 1 count change would be silently passed.
+      expect(described_class.placeholders_compatible?('%,d of %,d', '%,d done')).to be(false)
+    end
+
+    it 'flags a change between a fixed and a `*` dynamic width/precision specifier' do
+      # `%.1f km` consumes one float; `%.*f km` consumes an int (precision) + a float. Treating them
+      # as compatible would let an existing translation render the precision where the value belongs.
+      expect(described_class.placeholders_compatible?('%.1f km', '%.*f km')).to be(false)
+      expect(described_class.placeholders_compatible?('%5d items', '%*d items')).to be(false)
+    end
+  end
+
+  describe '.incompatible_placeholder_changes' do
+    it 'returns an empty array when nothing changed incompatibly' do
+      old_strings = { 'greeting' => 'Hello %@', 'count' => '%d items' }
+      new_strings = { 'greeting' => 'Hi %@', 'count' => '%d items' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq([])
+    end
+
+    it 'does not report a positional reorder of equivalently-typed args' do
+      old_strings = { 'attribution' => '%1$@ said %2$@' }
+      new_strings = { 'attribution' => '%2$@ told by %1$@' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq([])
+    end
+
+    it 'reports a key whose argument type changed, with full detail' do
+      old_strings = { 'likes' => '%d likes' }
+      new_strings = { 'likes' => '%@ likes' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq(
+        [{ key: 'likes', old: '%d likes', new: '%@ likes', old_signature: '1:int', new_signature: '1:object' }]
+      )
+    end
+
+    it 'reports a key whose placeholder count changed' do
+      old_strings = { 'msg' => '%1$d in %2$@' }
+      new_strings = { 'msg' => '%1$d only' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq(
+        [{ key: 'msg', old: '%1$d in %2$@', new: '%1$d only', old_signature: '1:int,2:object', new_signature: '1:int' }]
+      )
+    end
+
+    it 'still catches a real placeholder removal when the new copy contains a literal `%`' do
+      # The translation-breaking change: `%d` is dropped, but the new copy has a bare `%` ("100% done").
+      # If `% d` were parsed as a phantom int specifier, the signatures would both be `1:int` and this
+      # removal would be silently masked — the exact failure this check exists to catch.
+      old_strings = { 'progress' => '%d items left' }
+      new_strings = { 'progress' => '100% done' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq(
+        [{ key: 'progress', old: '%d items left', new: '100% done', old_signature: '1:int', new_signature: '' }]
+      )
+    end
+
+    it 'does not flag a copy edit on a string that contains a literal `%`' do
+      # A bare `%` followed by a space is literal-percent copy, so editing the surrounding words is not a
+      # placeholder change and must not be reported.
+      old_strings = { 'sale' => '50% off' }
+      new_strings = { 'sale' => '50% off today only' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq([])
+    end
+
+    it 'ignores keys that were added or removed' do
+      old_strings = { 'shared' => 'Hello %@', 'removed' => '%d gone' }
+      new_strings = { 'shared' => 'Hi %@', 'added' => '%d new' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq([])
+    end
+
+    it 'returns one entry per incompatible key, sorted by key' do
+      old_strings = { 'zebra' => '%@', 'alpha' => '%d', 'stable' => 'Hi %@' }
+      new_strings = { 'zebra' => '%d', 'alpha' => '%@', 'stable' => 'Hello %@' }
+      result = described_class.incompatible_placeholder_changes(old_strings, new_strings)
+      expect(result.map { |change| change[:key] }).to eq(%w[alpha zebra])
+    end
+
+    it 'does not flag a copy edit that merely repeats an existing positional argument' do
+      old_strings = { 'cta' => 'Open %1$@' }
+      new_strings = { 'cta' => 'Open %1$@ — and again, %1$@!' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq([])
+    end
+
+    it 'still flags adding a genuinely new argument' do
+      old_strings = { 'cta' => 'Open %1$@' }
+      new_strings = { 'cta' => 'Open %1$@ in %2$@' }
+      expect(described_class.incompatible_placeholder_changes(old_strings, new_strings)).to eq(
+        [{ key: 'cta', old: 'Open %1$@', new: 'Open %1$@ in %2$@', old_signature: '1:object', new_signature: '1:object,2:object' }]
+      )
+    end
+  end
+
+  describe '.mixed_operators?' do
+    it 'is false for an all-non-positional value' do
+      expect(described_class.mixed_operators?('%@ and %d and %f')).to be(false)
+    end
+
+    it 'is false for an all-positional value' do
+      expect(described_class.mixed_operators?('%2$@ and %1$d')).to be(false)
+    end
+
+    it 'is false for a value with no placeholders (including a literal `%%`)' do
+      expect(described_class.mixed_operators?('Just text')).to be(false)
+      expect(described_class.mixed_operators?('100%% literal')).to be(false)
+      expect(described_class.mixed_operators?(nil)).to be(false)
+    end
+
+    it 'is false for an all-positional value that also contains a literal `%`' do
+      # A bare `%` ("50% off") must not be parsed as a phantom non-positional specifier; otherwise this
+      # valid all-positional string would look mixed and the action would abort the lane on valid copy.
+      expect(described_class.mixed_operators?('%1$@ uploaded — 50% off')).to be(false)
+      expect(described_class.mixed_operators?('%1$@ done, 5% saved')).to be(false)
+    end
+
+    it 'is true when a value mixes positional and non-positional specifiers' do
+      expect(described_class.mixed_operators?('%2$@ and %d')).to be(true)
+      expect(described_class.mixed_operators?('%@ and %1$d')).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
> **Depends on #741.** The `.strings` parsing and duplicate-key detection this action builds on were extracted there, so this PR is now just the primitive + the action. Review/merge #741 first; GitHub will retarget this PR to `trunk` once it lands.

## What does it do?

Adds a placeholder-compatibility guardrail for localization source strings, as requested in #736.

Existing translations are keyed by a string's **key**, not its English text. If an existing key's source value changes its format placeholders — count, position, or argument type — every translation filed under that key silently breaks (or crashes) at the new call site. This is a **different axis** from `ios_lint_localizations`, which compares each _translation_ against the base language at a single point in time; this compares **base ↔ base across versions** (temporal).

### 1. Reusable primitive — `Fastlane::Helper::StringPlaceholdersHelper`

Pure Ruby, no file I/O, platform-agnostic (the `%@` / `%1$d` placeholder syntax is shared by iOS and Android):

- `placeholder_signature(value)` — canonical signature of a value's placeholders (`''` if none), e.g. `"1:int,2:object"`.
- `placeholders_compatible?(a, b)` — `signature(a) == signature(b)`.
- `incompatible_placeholder_changes(old_hash, new_hash)` — the keys present in **both** whose signature differs. New/removed keys are ignored on purpose: copy that needs a fresh translation is expected to land under a new key.
- `mixed_operators?(value)` — whether a value invalidly mixes positional (`%1$@`) and non-positional (`%@`) specifiers.

The signature is invariant to benign copy edits and to reordering equivalent positional args, but sensitive to count/position/type changes. `%d`↔`%i` are compatible; `%%` is skipped; the `,`/`'` grouping flags are recognized; `*` dynamic width/precision and the write-back `%n` are deliberately left unrecognized. A single literal `%` followed by whitespace is treated as a literal percent, not a specifier, so ordinary copy like `"50% off"` doesn't fabricate a phantom placeholder.

### 2. iOS action — `ios_lint_localization_placeholder_changes`

Takes `old_file` / `new_file` (the previous and newly-generated base `.strings`), parses them via the existing `L10nHelper.read_strings_file_as_hash` (plutil), runs the primitive, and reports. Mirrors `ios_lint_localizations`'s `abort_on_violations` (default `true`).

It **fails closed** on any input where the comparison would be unreliable:

- **`check_duplicate_keys`** (default `true`) — aborts when either file defines a key more than once (`plutil` silently keeps only the *last* value, which could otherwise hide a real placeholder change). Delegates to the shared `StringsFileValidationHelper.scan_for_duplicate_keys` from #741.
- **Always aborts** (independently of `abort_on_violations`) when a value mixes positional and non-positional placeholders — that's invalid and leaves the signature undefined.

## Worked examples (match the issue spec — verified by tests)

| Value | Signature |
|---|---|
| `Just text` | (empty) |
| `Hello %@` | `1:object` |
| `%1$d items in %2$@` | `1:int,2:object` |
| `%2$@ told by %1$@` | `1:object,2:object` |
| `100%% sure about %@` | `1:object` |
| `%d likes` | `1:int` |

## Notes / scope

- **Builds on #741**, which carries the `.strings` parsing (unquoted keys/values, inter-token comments) and the `scan_for_duplicate_keys` helper this action calls.
- **Android wrapper deferred to a follow-up**, as the issue permits — the primitive is already platform-agnostic, so the follow-up is a thin `android_*` parse-and-call wrapper.
- **Reuses `L10nHelper.read_strings_file_as_hash`** rather than adding a second `.strings` parser — the action is therefore macOS-only by design, like `ios_lint_localizations`.
- `.stringsdict` / ICU plurals are out of scope (likely v2).
- No `MIGRATION.md` entry — purely additive.

## Test Plan

- [x] `bundle exec rubocop` — no violations.
- [x] `bundle exec rspec` — all green. Helper specs cover every worked example + edge cases (`%%`, a literal `%` in copy, nil/whitespace, non-ASCII, escapes, width/precision/length modifiers, `%d`↔`%i`, the `,`/`'` grouping flags, `*` dynamic width/precision, `%n`, `%.f`, and the invalid positional/non-positional mix). Action specs write real `.strings` fixtures parsed by `plutil`: no-op, abort, `abort_on_violations: false`, add/remove ignored, duplicate-key abort, fail-closed on an un-tokenizable file, mixed-operator abort, and missing file.

## Related issues

- Implements the primitive + iOS wrapper from #736.
- Foundation (`.strings` parsing + `scan_for_duplicate_keys`) extracted to #741.
- Reference implementation: wordpress-mobile/WordPress-iOS#25675 (`fastlane/helpers/string_placeholders.rb` + the `validate_string_placeholders` lane). WPiOS will adopt the toolkit version and delete the project-side copy once this lands.
