### PR TITLE
Release 14.8.0 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ _None_
 
 ### New Features
 
-- Added `find_or_create_pull_request` action and `GithubHelper#find_pull_request`: returns the URL of the open Pull Request for a head branch, creating one only if none exists yet. Useful for "rolling" automations (e.g. a daily translations or dependency-update job) that force-push the same head branch on every run. [#733]
-- Added `ContinuousBuildCodeFormatter`, which derives an Android Play Store `versionCode` for a "continuous trunk" release model as `(major * 10 + minor) * 10^build_digits + build_number` (default `build_digits: 6`). It encodes a high-cardinality, monotonically increasing build number (e.g. a Buildkite build number) that `DerivedBuildCodeFormatter` cannot hold, validates that `minor <= 9`, and guards against exceeding the Play Store's maximum `versionCode`. [#735]
+_None_
 
 ### Bug Fixes
 
@@ -20,6 +19,13 @@ _None_
 ### Internal Changes
 
 _None_
+
+## 14.8.0
+
+### New Features
+
+- Added `find_or_create_pull_request` action and `GithubHelper#find_pull_request`: returns the URL of the open Pull Request for a head branch, creating one only if none exists yet. Useful for "rolling" automations (e.g. a daily translations or dependency-update job) that force-push the same head branch on every run. [#733]
+- Added `ContinuousBuildCodeFormatter`, which derives an Android Play Store `versionCode` for a "continuous trunk" release model as `(major * 10 + minor) * 10^build_digits + build_number` (default `build_digits: 6`). It encodes a high-cardinality, monotonically increasing build number (e.g. a Buildkite build number) that `DerivedBuildCodeFormatter` cannot hold, validates that `minor <= 9`, and guards against exceeding the Play Store's maximum `versionCode`. [#735]
 
 ## 14.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ _None_
 
 ### New Features
 
-- Added `find_or_create_pull_request` action and `GithubHelper#find_pull_request`: returns the URL of the open Pull Request for a head branch, creating one only if none exists yet. Useful for "rolling" automations (e.g. a daily translations or dependency-update job) that force-push the same head branch on every run. [#733]
-- Added `ContinuousBuildCodeFormatter`, which derives an Android Play Store `versionCode` for a "continuous trunk" release model as `(major * 10 + minor) * 10^build_digits + build_number` (default `build_digits: 6`). It encodes a high-cardinality, monotonically increasing build number (e.g. a Buildkite build number) that `DerivedBuildCodeFormatter` cannot hold, validates that `minor <= 9`, and guards against exceeding the Play Store's maximum `versionCode`. [#735]
+- `find_or_create_pull_request` action: returns the URL of the open Pull Request for a head branch, creating one only if none exists yet. [#733]
+- `ContinuousBuildCodeFormatter`: derives an Android Play Store `versionCode` for a "continuous trunk" release model as `(major * 10 + minor) * 10^build_digits + build_number` (default `build_digits: 6`). [#735]
 
 ## 14.7.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.7.0)
+    fastlane-plugin-wpmreleasetoolkit (14.8.0)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.7.0'
+    VERSION = '14.8.0'
   end
 end


### PR DESCRIPTION
Releasing new version 14.8.0.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### New Features

- Added `find_or_create_pull_request` action and `GithubHelper#find_pull_request`: returns the URL of the open Pull Request for a head branch, creating one only if none exists yet. Useful for "rolling" automations (e.g. a daily translations or dependency-update job) that force-push the same head branch on every run. [#733]
- Added `ContinuousBuildCodeFormatter`, which derives an Android Play Store `versionCode` for a "continuous trunk" release model as `(major * 10 + minor) * 10^build_digits + build_number` (default `build_digits: 6`). It encodes a high-cardinality, monotonically increasing build number (e.g. a Buildkite build number) that `DerivedBuildCodeFormatter` cannot hold, validates that `minor <= 9`, and guards against exceeding the Play Store's maximum `versionCode`. [#735]


```
