### PR TITLE
[codex] Add failing release asset specs

### DIFF
--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -665,6 +665,39 @@ describe Fastlane::Helper::GithubHelper do
       end.to raise_error(FastlaneCore::Interface::FastlaneError, "Can't find file missing-file.zip!")
     end
 
+    it 'fails clearly if an asset is not a file path' do
+      expect(client).not_to receive(:release_for_tag)
+      expect(client).not_to receive(:release_assets)
+      expect(client).not_to receive(:upload_asset)
+
+      expect do
+        upload_release_assets(assets: [123])
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, 'release_assets must contain file paths')
+    end
+
+    it 'fails without mutating GitHub when local assets have duplicate filenames' do
+      in_tmp_dir do |tmpdir|
+        first_dir = File.join(tmpdir, 'ios')
+        second_dir = File.join(tmpdir, 'tvos')
+        Dir.mkdir(first_dir)
+        Dir.mkdir(second_dir)
+
+        first_file_path = File.join(first_dir, 'test-app.zip')
+        second_file_path = File.join(second_dir, 'test-app.zip')
+        File.write(first_file_path, 'ios')
+        File.write(second_file_path, 'tvos')
+
+        expect(client).not_to receive(:release_for_tag)
+        expect(client).not_to receive(:release_assets)
+        expect(client).not_to receive(:delete_release_asset)
+        expect(client).not_to receive(:upload_asset)
+
+        expect do
+          upload_release_assets(assets: [first_file_path, second_file_path], replace_existing: false)
+        end.to raise_error(FastlaneCore::Interface::FastlaneError, 'release_assets must not contain duplicate filenames')
+      end
+    end
+
     it 'uploads one asset to the existing release' do
       with_tmp_file(named: 'test-app.zip') do |file_path|
         expect(client).to receive(:upload_asset).with(release_url, file_path, { content_type: 'application/octet-stream' })


### PR DESCRIPTION
## What does it do?

Adds failing specs stacked on #743 to document two helper validation gaps:

- non-string `release_assets` entries should fail through `UI.user_error!`
- duplicate local asset filenames should fail before any GitHub release mutation

## Checklist before requesting a review

<details>
<summary>Sort of irrelevant here...</summary>


- [x] Run `bundle exec rubocop` to test for code style violations and recommendations. (`rubocop --cache false spec/github_helper_spec.rb`)
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass. Intentionally failing specs; local RSpec startup is also blocked here by the repo bundle/native `nokogiri` setup.
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section. Not applicable: tests-only stacked PR.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider. Not applicable.

</details>
