### PR TITLE
Add `values-car` pruning regression test

### DIFF
--- a/spec/android_prune_orphaned_translations_spec.rb
+++ b/spec/android_prune_orphaned_translations_spec.rb
@@ -89,6 +89,26 @@ describe Fastlane::Actions::AndroidPruneOrphanedTranslationsAction do
     end
   end
 
+  it 'leaves car UI mode qualifier directories untouched' do
+    Dir.mktmpdir do |dir|
+      res_dir = File.join(dir, 'res')
+      write_file(File.join(res_dir, 'values', 'strings.xml'), default_strings)
+      car_file = File.join(res_dir, 'values-car', 'strings.xml')
+      car_content = <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <resources>
+            <string name="car_only">Car</string>
+        </resources>
+      XML
+      write_file(car_file, car_content)
+
+      pruned = run_described_fastlane_action(res_dir: res_dir)
+
+      expect(pruned).to eq(0)
+      expect(File.read(car_file)).to eq(car_content)
+    end
+  end
+
   it 'treats keys from `additional_source_strings_paths` as valid (flavor overlay case)' do
     Dir.mktmpdir do |dir|
       res_dir = File.join(dir, 'res')


### PR DESCRIPTION
## What does it do?

Adds test-only coverage showing that `android_prune_orphaned_translations` currently treats `values-car` as a locale directory and prunes car UI mode resources.
No production fix is included; this is stacked on #734 to make the review finding executable.

Expected failure:

```sh
bundle exec rspec spec/android_prune_orphaned_translations_spec.rb
```

The new example, `leaves car UI mode qualifier directories untouched`, fails with `expected: 0, got: 1`.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
