### PR TITLE
Skip Android UI-mode `values-*` qualifier dirs (e.g. `values-car`) when pruning

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_prune_orphaned_translations_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/android/android_prune_orphaned_translations_action.rb
@@ -6,10 +6,18 @@ require 'nokogiri'
 module Fastlane
   module Actions
     class AndroidPruneOrphanedTranslationsAction < Action
-      # Matches an Android `values-<qualifier>` directory whose qualifier is a locale (a language code, optional
-      # region, or a BCP-47 `b+` form), so non-locale qualifier dirs (e.g. `values-night`, `values-v21`,
-      # `values-land`) are left untouched.
+      # Matches an Android `values-<qualifier>` directory whose qualifier is a locale: a 2- or 3-letter language
+      # code (`fr`, `kmr`), an optional region (`pt-rBR`, `es-r419`), or a BCP-47 `b+` form (`b+sr+Latn`), so
+      # non-locale qualifier dirs (e.g. `values-night`, `values-v21`, `values-land`) are left untouched.
       LOCALE_VALUES_DIR_REGEX = /\Avalues-(?:b\+[a-zA-Z]+(?:\+[a-zA-Z0-9]+)*|[a-z]{2,3}(?:-r(?:[A-Z]{2}|\d{3}))?)\z/
+
+      # Android UI-mode qualifiers, which are never locales:
+      # https://developer.android.com/guide/topics/resources/providing-resources#UiModeQualifier
+      # `car` is indistinguishable by shape from a 3-letter ISO 639 language code, so `LOCALE_VALUES_DIR_REGEX`
+      # would otherwise treat `values-car` as a locale and prune its (valid) car-mode resources. There's no purely
+      # syntactic way to tell the two apart, so we exclude the documented UI-mode qualifiers explicitly. (`car` is
+      # the only one short enough to currently match the regex; the rest are listed to capture the full set.)
+      UI_MODE_QUALIFIERS = %w[car desk television appliance watch vrheadset].freeze
 
       DEFAULT_SOURCE_STRINGS_FILE_NAME = 'strings.xml'
       DEFAULT_SOURCE_STRINGS_RELATIVE_PATH = File.join('values', DEFAULT_SOURCE_STRINGS_FILE_NAME).freeze
@@ -20,7 +28,8 @@ module Fastlane
         valid_keys = collect_keys(source_paths)
 
         locale_files = Dir.glob(File.join(res_dir, 'values-*', DEFAULT_SOURCE_STRINGS_FILE_NAME)).select do |file|
-          File.basename(File.dirname(file)).match?(LOCALE_VALUES_DIR_REGEX)
+          dir_name = File.basename(File.dirname(file))
+          dir_name.match?(LOCALE_VALUES_DIR_REGEX) && !UI_MODE_QUALIFIERS.include?(dir_name.delete_prefix('values-'))
         end
         total_pruned = 0
 

--- a/spec/android_prune_orphaned_translations_spec.rb
+++ b/spec/android_prune_orphaned_translations_spec.rb
@@ -109,6 +109,30 @@ describe Fastlane::Actions::AndroidPruneOrphanedTranslationsAction do
     end
   end
 
+  # `kmr` (Northern Kurdish) is a real 3-letter legacy locale used by e.g. WordPress-Android, so it must still be
+  # pruned — guarding against an over-eager "restrict locales to 2 letters" fix for the `values-car` collision.
+  it 'prunes 3-letter legacy locale directories (e.g. values-kmr)' do
+    Dir.mktmpdir do |dir|
+      res_dir = File.join(dir, 'res')
+      write_file(File.join(res_dir, 'values', 'strings.xml'), default_strings)
+      kmr_file = File.join(res_dir, 'values-kmr', 'strings.xml')
+      write_file(kmr_file, <<~XML)
+        <?xml version="1.0" encoding="UTF-8"?>
+        <resources>
+            <string name="hello">Silav</string>
+            <string name="orphan_string">Sêwî</string>
+        </resources>
+      XML
+
+      pruned = run_described_fastlane_action(res_dir: res_dir)
+
+      expect(pruned).to eq(1)
+      content = File.read(kmr_file)
+      expect(content).to include('name="hello"')
+      expect(content).not_to include('orphan_string')
+    end
+  end
+
   it 'treats keys from `additional_source_strings_paths` as valid (flavor overlay case)' do
     Dir.mktmpdir do |dir|
       res_dir = File.join(dir, 'res')


### PR DESCRIPTION
> Heads up: this is _a_ solution that passes the regression test and is correct for WordPress-Android, but I don't have full context on GlotPress export conventions or every consuming app. Happy for someone with more context (`@wordpress-mobile/apps-infra-tooling`) to take over or steer this differently.

## The situation

#746 (by `@mokagio`, already merged into this branch) added a regression test showing that `android_prune_orphaned_translations` treats `values-car` as a locale and would prune its resources. That test currently fails on this branch.

Root cause: the locale-detection regex's 2–3 letter language branch (`[a-z]{2,3}`) matches `car`. But `values-car` is the Android **UI-mode** qualifier ([docs](https://developer.android.com/guide/topics/resources/providing-resources#UiModeQualifier)), not a locale. The catch is that `car` is *also* a valid 3-letter ISO 639 language code, so there's **no purely syntactic way** for a regex to tell `values-car`-the-UI-mode from `values-car`-the-language — Android itself can't either.

## What this PR does

- Keeps the 2–3 letter locale grammar and explicitly excludes Android's documented UI-mode qualifiers via a `UI_MODE_QUALIFIERS` list. In practice `car` is the only one short enough to collide today; the rest are listed to capture the documented set.
- Adds a `values-kmr` (Northern Kurdish) test so 3-letter legacy locales keep getting pruned.

## Alternatives considered

- **Restrict legacy locales to 2 letters** — simpler, but rejected: WordPress-Android ships `values-kmr`, a real 3-letter legacy locale that must still be pruned. A 2-letter rule would silently skip it.
- **Validate against a real ISO 639 language list** — doesn't help: `car` *is* a valid ISO 639 code, so a language list would still classify `values-car` as a locale.

## Open question (not a blocker)

Could the GlotPress → Android export ever emit *other* folder names that collide with a non-locale qualifier? If so, we'd just extend the same exclusion list. Confirming the export's folder-naming conventions separately; not a blocker for WordPress-Android (no `values-car`).

## Notes

- Targets the #734 branch (`add/prune-orphaned-translations`) so the regression + fix stay contained in one reviewable PR rather than folded into the larger feature PR.
- Full spec + RuboCop green locally.
