### PR TITLE
Fix GitHub release asset lookup on upload_github_release_assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ _None_
 - `StringsFileValidationHelper.find_duplicated_keys` now parses unquoted keys/values and inter-token comments, matching the grammar `plutil` accepts, instead of raising `Invalid character`. This lets `ios_lint_localizations`' `check_duplicate_keys` work on `InfoPlist.strings`-style files. [#741]
 - `ios_lint_localizations`' `check_duplicate_keys` now warns and skips, rather than crashing, on a file that parses as a property list but isn't a tokenizable flat `.strings`. [#741]
 - `L10nHelper.merge_strings` now prefixes keys via a comment-aware tokenizer, so unquoted keys, unquoted values, and keys behind an inter-token comment are prefixed in the output consistently with the reported keys. [#741]
-- `upload_github_release_assets`: make release lookup more resilient by falling back to GitHub's direct release-by-tag lookup when the releases list does not include the requested release.
+- `upload_github_release_assets`: make release lookup more resilient by falling back to GitHub's direct release-by-tag lookup when the releases list does not include the requested release. [#753]
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _None_
 - `StringsFileValidationHelper.find_duplicated_keys` now parses unquoted keys/values and inter-token comments, matching the grammar `plutil` accepts, instead of raising `Invalid character`. This lets `ios_lint_localizations`' `check_duplicate_keys` work on `InfoPlist.strings`-style files. [#741]
 - `ios_lint_localizations`' `check_duplicate_keys` now warns and skips, rather than crashing, on a file that parses as a property list but isn't a tokenizable flat `.strings`. [#741]
 - `L10nHelper.merge_strings` now prefixes keys via a comment-aware tokenizer, so unquoted keys, unquoted values, and keys behind an inter-token comment are prefixed in the output consistently with the reported keys. [#741]
+- `upload_github_release_assets`: make release lookup more resilient by falling back to GitHub's direct release-by-tag lookup when the releases list does not include the requested release.
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -200,7 +200,7 @@ module Fastlane
       # @raise [Fastlane::UI::Error] UI.user_error! if the release does not exist.
       #
       def get_release(repository:, version:)
-        release = client.releases(repository).find { |candidate| candidate.tag_name == version }
+        release = find_release(repository: repository, version: version)
         return release unless release.nil?
 
         UI.user_error!("Could not find GitHub Release for tag #{version} in #{repository}")
@@ -243,6 +243,22 @@ module Fastlane
 
         release.html_url
       end
+
+      def find_release(repository:, version:)
+        release = client.releases(repository).find { |candidate| candidate.tag_name == version }
+        return release unless release.nil?
+
+        release_for_tag(repository: repository, version: version)
+      end
+
+      def release_for_tag(repository:, version:)
+        client.release_for_tag(repository, version)
+      rescue Octokit::NotFound
+        nil
+      end
+
+      private :find_release
+      private :release_for_tag
 
       # Use the GitHub API to generate release notes based on the list of PRs between current tag and previous tag.
       # @note This API uses the `.github/release.yml` config file to classify the PRs by category in the generated list according to PR labels.

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -640,12 +640,14 @@ describe Fastlane::Helper::GithubHelper do
 
     before do
       allow(Octokit::Client).to receive(:new).and_return(client)
+      allow(client).to receive(:release_for_tag).with(test_repo, test_version).and_return(release)
       allow(client).to receive(:releases).with(test_repo).and_return([release])
       allow(client).to receive(:release_assets).with(release_url).and_return(existing_assets)
       allow(client).to receive_messages(upload_asset: uploaded_asset, delete_release_asset: true)
     end
 
     it 'fails clearly if the release does not exist' do
+      allow(client).to receive(:release_for_tag).with(test_repo, test_version).and_raise(Octokit::NotFound)
       allow(client).to receive(:releases).with(test_repo).and_return([])
 
       with_tmp_file(named: 'test-app.zip') do |file_path|
@@ -702,10 +704,39 @@ describe Fastlane::Helper::GithubHelper do
       draft_release = sawyer_resource_stub(url: release_url, html_url: release_html_url, tag_name: test_version, draft: true)
       other_release = sawyer_resource_stub(url: 'https://api.github.com/repos/repo-test/project-test/releases/456', html_url: 'https://github.com/repo-test/project-test/releases/tag/0.9.0', tag_name: '0.9.0')
 
+      allow(client).to receive(:release_for_tag).with(test_repo, test_version).and_raise(Octokit::NotFound)
       allow(client).to receive(:releases).with(test_repo).and_return([other_release, draft_release])
       allow(client).to receive(:release_assets).with(release_url).and_return([])
 
       with_tmp_file(named: 'test-app.zip') do |file_path|
+        expect(client).to receive(:upload_asset).with(release_url, file_path, { content_type: 'application/octet-stream' })
+
+        result = upload_release_assets(assets: [file_path])
+
+        expect(result).to eq(release_html_url)
+      end
+    end
+
+    it 'uses the release list without calling the direct release-by-tag lookup' do
+      draft_release = sawyer_resource_stub(url: 'draft-api-url', html_url: 'draft-html-url', tag_name: test_version, draft: true)
+
+      allow(client).to receive(:releases).with(test_repo).and_return([draft_release])
+      expect(client).not_to receive(:release_for_tag)
+      allow(client).to receive(:release_assets).with(draft_release.url).and_return([])
+
+      with_tmp_file(named: 'test-app.zip') do |file_path|
+        expect(client).to receive(:upload_asset).with(draft_release.url, file_path, { content_type: 'application/octet-stream' })
+
+        result = upload_release_assets(assets: [file_path])
+
+        expect(result).to eq(draft_release.html_url)
+      end
+    end
+
+    it 'falls back to the direct release-by-tag lookup when the release list misses' do
+      with_tmp_file(named: 'test-app.zip') do |file_path|
+        allow(client).to receive(:releases).with(test_repo).and_return([])
+        allow(client).to receive(:release_for_tag).with(test_repo, test_version).and_return(release)
         expect(client).to receive(:upload_asset).with(release_url, file_path, { content_type: 'application/octet-stream' })
 
         result = upload_release_assets(assets: [file_path])

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -717,7 +717,7 @@ describe Fastlane::Helper::GithubHelper do
       end
     end
 
-    it 'uses the release list without calling the direct release-by-tag lookup' do
+    it 'uses the release list if available' do
       draft_release = sawyer_resource_stub(url: 'draft-api-url', html_url: 'draft-html-url', tag_name: test_version, draft: true)
 
       allow(client).to receive(:releases).with(test_repo).and_return([draft_release])


### PR DESCRIPTION
## What does it do?

Fixes `upload_github_release_assets` release lookup when the releases list misses an existing published release.

The helper still checks `client.releases(repository)` first so draft releases continue to work. If that list does not include the requested tag, it falls back to GitHub's direct release-by-tag endpoint once. A missing release still fails with the existing clear error.

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
