### PR TITLE
Clarify release lookup error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _None_
 
 ### Internal Changes
 
+- Added regression coverage for `upload_github_release_assets` direct release lookup errors. [#755]
 - Centralized `.strings` duplicate-key detection behind `StringsFileValidationHelper.scan_for_duplicate_keys`, returning a `[:scanned | :unsupported_format | :unscannable, payload]` tri-state that callers can map to their own warn-and-skip vs fail-closed policy. [#741]
 - `L10nHelper.strings_file_type` and `StringsFileValidationHelper.scan_for_duplicate_keys` accept `assume_valid:` to skip a redundant `plutil -lint` when the caller has already parsed the file. [#741]
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -254,7 +254,7 @@ module Fastlane
       def release_for_tag(repository:, version:)
         client.release_for_tag(repository, version)
       rescue Octokit::NotFound
-        # A 404 only means the fallback did not find a published release.
+        # A 404 only means the fallback did not find a release for this tag.
         # Other API errors should be surfaced.
         nil
       end

--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -254,6 +254,8 @@ module Fastlane
       def release_for_tag(repository:, version:)
         client.release_for_tag(repository, version)
       rescue Octokit::NotFound
+        # A 404 only means the fallback did not find a published release.
+        # Other API errors should be surfaced.
         nil
       end
 

--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -745,6 +745,20 @@ describe Fastlane::Helper::GithubHelper do
       end
     end
 
+    it 'does not hide unexpected direct release lookup errors' do
+      allow(client).to receive(:releases).with(test_repo).and_return([])
+      allow(client).to receive(:release_for_tag).with(test_repo, test_version).and_raise(Octokit::TooManyRequests)
+
+      with_tmp_file(named: 'test-app.zip') do |file_path|
+        expect(client).not_to receive(:release_assets)
+        expect(client).not_to receive(:upload_asset)
+
+        expect do
+          upload_release_assets(assets: [file_path])
+        end.to raise_error(Octokit::TooManyRequests)
+      end
+    end
+
     it 'uploads one asset to the existing release' do
       with_tmp_file(named: 'test-app.zip') do |file_path|
         expect(client).to receive(:upload_asset).with(release_url, file_path, { content_type: 'application/octet-stream' })


### PR DESCRIPTION
Adds a small regression test to confirm only missing releases are swallowed during the direct release lookup fallback.