### PR TITLE
Fix `create_github_release` crashing when no release notes are given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- `create_github_release` no longer crashes with `FrozenError` when the optional `release_notes_file_path` is omitted. [#759]
 
 ### Internal Changes
 

--- a/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/actions/common/create_github_release_action.rb
@@ -14,7 +14,7 @@ module Fastlane
         # Replace full URLs to PRs/Issues that are in `[https://some-url]` brackets with shorthand, because GitHub does not render them properly otherwise.
         # That syntax is sometimes used by devs in `RELEASE-NOTES.txt` when pointing to a PR to another repo (e.g. Gutenberg PR from WP repo).
         # We should NOT transform URLs to PRs/Issues that are in `[text](url)` form (those are valid), only the ones directly in `[]` brackets.
-        release_notes.gsub!(%r{\[https://github.com/([^/]*/[^/]*)/(pulls?|issues?)/([0-9]*)\]}, '[\1#\3]')
+        release_notes = release_notes.gsub(%r{\[https://github.com/([^/]*/[^/]*)/(pulls?|issues?)/([0-9]*)\]}, '[\1#\3]')
         prerelease = params[:prerelease]
         is_draft = params[:is_draft]
 

--- a/spec/create_github_release_spec.rb
+++ b/spec/create_github_release_spec.rb
@@ -15,7 +15,7 @@ describe Fastlane::Actions::CreateGithubReleaseAction do
 
   context 'when no release notes file is provided' do
     it 'creates the release with an empty description' do
-      expect(github_helper).to receive(:create_release).with(
+      allow(github_helper).to receive(:create_release).with(
         repository: test_repo,
         version: test_version,
         name: nil,
@@ -52,7 +52,7 @@ describe Fastlane::Actions::CreateGithubReleaseAction do
       NOTES
 
       with_tmp_file(named: 'release-notes.txt', content: notes) do |notes_path|
-        expect(github_helper).to receive(:create_release).with(
+        allow(github_helper).to receive(:create_release).with(
           repository: test_repo,
           version: test_version,
           name: nil,

--- a/spec/create_github_release_spec.rb
+++ b/spec/create_github_release_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Fastlane::Actions::CreateGithubReleaseAction do
+  let(:test_token) { 'ghp_fake_token' }
+  let(:test_repo) { 'repo-test/project-test' }
+  let(:test_version) { '1.0.0' }
+  let(:release_url) { 'https://github.com/repo-test/project-test/releases/tag/1.0.0' }
+  let(:github_helper) { instance_double(Fastlane::Helper::GithubHelper) }
+
+  before do
+    allow(Fastlane::Helper::GithubHelper).to receive(:new).and_return(github_helper)
+  end
+
+  context 'when no release notes file is provided' do
+    it 'creates the release with an empty description' do
+      expect(github_helper).to receive(:create_release).with(
+        repository: test_repo,
+        version: test_version,
+        name: nil,
+        target: nil,
+        description: '',
+        assets: [],
+        prerelease: false,
+        is_draft: true
+      ).and_return(release_url)
+
+      result = run_described_fastlane_action(
+        github_token: test_token,
+        repository: test_repo,
+        version: test_version,
+        release_assets: []
+      )
+
+      expect(result).to eq(release_url)
+    end
+  end
+
+  context 'when a release notes file is provided' do
+    it 'rewrites bracketed GitHub PR and issue URLs to shorthand' do
+      notes = <<~NOTES
+        - Fix a thing [https://github.com/org-test/other-repo/pull/123]
+        - Fix another thing [https://github.com/org-test/other-repo/issues/456]
+        - Leave markdown links alone [as a link](https://github.com/org-test/other-repo/pull/789)
+      NOTES
+
+      expected_description = <<~NOTES
+        - Fix a thing [org-test/other-repo#123]
+        - Fix another thing [org-test/other-repo#456]
+        - Leave markdown links alone [as a link](https://github.com/org-test/other-repo/pull/789)
+      NOTES
+
+      with_tmp_file(named: 'release-notes.txt', content: notes) do |notes_path|
+        expect(github_helper).to receive(:create_release).with(
+          repository: test_repo,
+          version: test_version,
+          name: nil,
+          target: nil,
+          description: expected_description,
+          assets: [],
+          prerelease: false,
+          is_draft: true
+        ).and_return(release_url)
+
+        result = run_described_fastlane_action(
+          github_token: test_token,
+          repository: test_repo,
+          version: test_version,
+          release_assets: [],
+          release_notes_file_path: notes_path
+        )
+
+        expect(result).to eq(release_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## The problem

`create_github_release` raises whenever `release_notes_file_path` is omitted:

```
create_github_release_action.rb:17:in `gsub!': [!] can't modify frozen String: "" (FrozenError)
```

`release_notes_file_path` is declared `optional: true`, so omitting it is a supported path — but the `''` fallback it lands on is a **frozen literal**, because the file sets `frozen_string_literal: true`. The next line then calls `gsub!` on it (the rewrite that turns bracketed GitHub PR/issue URLs into shorthand) and blows up.

`File.read` returns an unfrozen string, which is why the branch that *does* read a notes file has never hit this — and why every existing caller in the wild works. The optional path has simply never been exercised.

## What this PR does

- Uses the non-mutating `gsub` and reassigns. The regex and its behaviour are unchanged.
- Adds `spec/create_github_release_spec.rb`, which the action didn't have:
  - the no-notes path, covering the regression directly;
  - the URL-rewrite behaviour, pinning the one line this PR touches so `gsub` + reassignment is proven equivalent to `gsub!`.


## Checklist before requesting a review

- [ ] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [ ] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [ ] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [x] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section.
- [x] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider.
