### PR TITLE
Release 14.11.1 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ _None_
 
 ### Bug Fixes
 
-- `create_github_release` no longer crashes with `FrozenError` when the optional `release_notes_file_path` is omitted. [#759]
+_None_
 
 ### Internal Changes
 
 _None_
+
+## 14.11.1
+
+### Bug Fixes
+
+- `create_github_release` no longer crashes with `FrozenError` when the optional `release_notes_file_path` is omitted. [#759]
 
 ## 14.11.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.11.0)
+    fastlane-plugin-wpmreleasetoolkit (14.11.1)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.11.0'
+    VERSION = '14.11.1'
   end
 end


### PR DESCRIPTION
Releasing new version 14.11.1.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- `create_github_release` no longer crashes with `FrozenError` when the optional `release_notes_file_path` is omitted. [#759]


```
