### PR TITLE
List the wrong release first in release lookup specs

### DIFF
--- a/spec/github_helper_spec.rb
+++ b/spec/github_helper_spec.rb
@@ -737,7 +737,9 @@ describe Fastlane::Helper::GithubHelper do
       stale_release = sawyer_resource_stub(id: 1, url: 'stale-api-url', html_url: 'stale-html-url', tag_name: test_version, draft: true)
       latest_release = sawyer_resource_stub(id: 2, url: 'latest-api-url', html_url: 'latest-html-url', tag_name: test_version, draft: true)
 
-      allow(client).to receive(:releases).with(test_repo).and_return([latest_release, stale_release])
+      # The stale release comes first, so that a lookup relying on the order the API happens to return the releases in
+      # would pick the wrong one.
+      allow(client).to receive(:releases).with(test_repo).and_return([stale_release, latest_release])
       expect(client).not_to receive(:release_for_tag)
       allow(client).to receive(:release_assets).with(latest_release.url).and_return([])
 
@@ -757,7 +759,9 @@ describe Fastlane::Helper::GithubHelper do
       published_release = sawyer_resource_stub(id: 351_929_162, url: 'published-api-url', html_url: 'published-html-url', tag_name: test_version, draft: false)
       leftover_draft = sawyer_resource_stub(id: 352_002_205, url: 'draft-api-url', html_url: 'draft-html-url', tag_name: test_version, draft: true)
 
-      allow(client).to receive(:releases).with(test_repo).and_return([published_release, leftover_draft])
+      # The leftover draft comes first, so that a lookup relying on the order the API happens to return the releases in
+      # would pick the wrong one.
+      allow(client).to receive(:releases).with(test_repo).and_return([leftover_draft, published_release])
       allow(client).to receive(:release_assets).with(published_release.url).and_return([])
 
       with_tmp_file(named: 'test-app.zip') do |file_path|


### PR DESCRIPTION
## What does it do?

Addresses a false positive risk in the #763 tests highlighted by Copilot https://github.com/wordpress-mobile/release-toolkit/pull/763#pullrequestreview-4840125118

To verify the false positive, I got Claude to open #765, which reverts the code to the pre-#763 lookup yet has green tests.

The two `#upload_release_assets` specs added there stub `client.releases` with the release they expect the helper to pick already in first position. That makes them pass against a lookup that simply takes the first match — so neither actually pins the deterministic selection they were added for.

Reordering each stub so the wrong candidate comes first turns them into real regression tests. Verified locally: reverting `find_release` to `matches.first` over an unsorted list turns both red, and they go green again with the implementation from #763. The `#publish_release` specs already had adversarial ordering and need no change.

#766 verifies the test fix in this PR. Same revert to pre-#763 lookup, but CI is [red](https://buildkite.com/automattic/release-toolkit/builds/2458/canvas?jid=019fc5bf-4f5b-482f-b8a4-4ed90fb8e8cd&tab=output).

## Checklist before requesting a review

- [x] Run `bundle exec rubocop` to test for code style violations and recommendations.
- [x] Add Unit Tests (aka `specs/*_spec.rb`) if applicable.
- [x] Run `bundle exec rspec` to run the whole test suite and ensure all your tests pass.
- [ ] Make sure you added an entry in [the `CHANGELOG.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/CHANGELOG.md#trunk) to describe your changes under the appropriate existing `###` subsection of the existing `## Trunk` section. — n/a, test-only change; #763 carries the entry.
- [ ] If applicable, add an entry in [the `MIGRATION.md` file](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md) to describe how the changes will affect the migration from the previous major version and what the clients will need to change and consider. — n/a.

---

*Posted by Claude Code (Opus 5) on behalf of @mokagio with approval.*
