### PR TITLE
[THROWAWAY] Proof: #763 specs pass against the old lookup

### DIFF
--- a/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/helper/github_helper.rb
@@ -262,18 +262,9 @@ module Fastlane
         client.releases(repository).select(&matcher).sort_by { |release| release[:id] }
       end
 
-      # Returns the GitHub Release associated with a given tag, if any, including draft ones.
-      #
-      # @note Unlike a lookup by name, "the most recently created match" is not the right answer here: a git tag can
-      #       only ever back a single *published* release, so if one of the matches is not a draft then it is the
-      #       release owning that tag, and a more recent draft sharing the same `tag_name` is a leftover—typically
-      #       from a re-run of the release finalization—rather than a successor. Only when no published release
-      #       claims the tag yet do we fall back to the most recent draft, which is the case when uploading assets
-      #       to a release that has not been published yet.
-      #
+      # THROWAWAY: reverted to the pre-#763 lookup, which returns whichever match the API happens to list first.
       def find_release(repository:, version:)
-        matches = matching_releases(repository: repository) { |candidate| candidate.tag_name == version }
-        release = matches.reject { |candidate| candidate[:draft] }.last || matches.last
+        release = client.releases(repository).find { |candidate| candidate.tag_name == version }
         return release unless release.nil?
 
         release_for_tag(repository: repository, version: version)


### PR DESCRIPTION
## What does it do?

**Throwaway — do not merge, do not review.** Opened only to make a CI run stand as evidence for a review comment on #763. It will be closed once the checks report.

Stacked on #763, this reverts `find_release` to the pre-#763 lookup — `client.releases(repository).find { … }`, which returns whichever match the GitHub API happens to list first — while leaving `matching_releases` and `publish_release` as #763 has them, so only the claim under discussion is in play.

**Expected result: CI green.** That is the point. The two `#upload_release_assets` specs #763 adds are meant to pin deterministic release selection, but they stub `client.releases` with the release they expect the helper to pick already in first position, so they pass against the very lookup they were written to catch.

The companion PR reverses the stub ordering and goes red against this same implementation.

---

*Posted by Claude Code (Opus 5) on behalf of @mokagio with approval.*
