### PR TITLE
Release 14.11.2 into trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ _None_
 
 ### Bug Fixes
 
+_None_
+
+### Internal Changes
+
+_None_
+
+## 14.11.2
+
+### Bug Fixes
+
 - `publish_github_release` now publishes the most recently created GitHub Release when several share the same name, instead of whichever one the GitHub API happened to list first. It also warns when it finds more than one match, or when the release it publishes turns out to have been published already. The tag-based release lookup used by `upload_github_release_assets` is deterministic too, preferring the published release that owns the tag, and falling back to the most recently created draft when no published release claims it. [#763]
 
 ### Internal Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fastlane-plugin-wpmreleasetoolkit (14.11.1)
+    fastlane-plugin-wpmreleasetoolkit (14.11.2)
       buildkit (~> 1.5)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
+++ b/lib/fastlane/plugin/wpmreleasetoolkit/version.rb
@@ -3,6 +3,6 @@
 module Fastlane
   module Wpmreleasetoolkit
     NAME = 'fastlane-plugin-wpmreleasetoolkit'
-    VERSION = '14.11.1'
+    VERSION = '14.11.2'
   end
 end


### PR DESCRIPTION
Releasing new version 14.11.2.

# What's Next

PR Author: Be sure to create and publish a GitHub Release pointing to `trunk` once this PR gets merged,
copy/pasting the following text as the GitHub Release's description:
```
### Bug Fixes

- `publish_github_release` now publishes the most recently created GitHub Release when several share the same name, instead of whichever one the GitHub API happened to list first. It also warns when it finds more than one match, or when the release it publishes turns out to have been published already. The tag-based release lookup used by `upload_github_release_assets` is deterministic too, preferring the published release that owns the tag, and falling back to the most recently created draft when no published release claims it. [#763]

### Internal Changes

- Run the `GitHelper` git-lfs specs against a sandboxed `GIT_CONFIG_GLOBAL` so they no longer remove the `[filter "lfs"]` section from the developer's global git config. [#762]


```
